### PR TITLE
Use frontmatter to get local image

### DIFF
--- a/app/scripts/components/common/images/index.js
+++ b/app/scripts/components/common/images/index.js
@@ -9,6 +9,7 @@ import {
 } from '$components/common/figure';
 
 import { captionDisplayName } from '$components/common/blocks/block-constant';
+import { useThematicAreaDiscovery } from '$utils/thematics';
 
 export const Caption = function ({ children, attrAuthor, attrUrl }) {
   return (
@@ -29,12 +30,30 @@ Caption.propTypes = {
 
 const Image = function (props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { align, attr, attrAuthor, attrUrl, ...propsWithoutAttrs } = props;
+
+  const { align, attr, attrAuthor, attrUrl, embedded, ...propsWithoutAttrs } =
+    props;
   const imageAlign = align ? align : 'center';
+
+  function getImage() {
+    if (embedded) {
+      const discovery = useThematicAreaDiscovery();
+      const { embeddedLocal } = discovery.data;
+      return (
+        <img
+          loading='lazy'
+          src={embeddedLocal[embedded].src}
+          alt={embeddedLocal[embedded].alt}
+          {...propsWithoutAttrs}
+        />
+      );
+    } else return <img loading='lazy' {...propsWithoutAttrs} />;
+  }
+
   return attr || attrAuthor ? (
     // if it is an inline image with a caption
     <Figure className={`align-${imageAlign}`}>
-      <img loading='lazy' {...propsWithoutAttrs} />
+      {getImage()}
       <Caption attrAuthor={attrAuthor} attrUrl={props.attrUrl}>
         {attr}
       </Caption>

--- a/app/scripts/components/discoveries/single/index.js
+++ b/app/scripts/components/discoveries/single/index.js
@@ -26,7 +26,6 @@ function DiscoveriesSingle() {
   const thematic = useThematicArea();
   const discovery = useThematicAreaDiscovery();
   const pageMdx = useMdxPageLoader(discovery?.content);
-
   if (!thematic || !discovery) throw resourceNotFound();
 
   const { media } = discovery.data;

--- a/app/scripts/utils/thematics.js
+++ b/app/scripts/utils/thematics.js
@@ -44,7 +44,6 @@ export function useThematicAreaDiscovery() {
   const { discoveryId } = useParams();
 
   const discovery = discoveries[discoveryId];
-
   // Stop if the discovery doesn't exist or if it doesn't belong to this
   // thematic area.
   if (!discovery || !discovery.data.thematics.includes(thematic.data.id)) {
@@ -65,7 +64,6 @@ export function useThematicAreaDataset() {
   const { datasetId } = useParams();
 
   const dataset = datasets[datasetId];
-
   // Stop if the datasets doesn't exist or if it doesn't belong to this
   // thematic area.
   if (!dataset || !dataset.data.thematics.includes(thematic.data.id)) {

--- a/mock/discoveries/history.discoveries.mdx
+++ b/mock/discoveries/history.discoveries.mdx
@@ -47,7 +47,7 @@ scelerisque.
 ### Cras viverra urna felis
 
 <Image 
-src="https://picsum.photos/id/107/5760/3840" 
+src={new URL('./img-placeholder-5.jpg', import.meta.url).href}
 align="right" 
 alt="Tux, the Linux mascot" 
 attr="tux" 

--- a/mock/discoveries/history.discoveries.mdx
+++ b/mock/discoveries/history.discoveries.mdx
@@ -9,6 +9,10 @@ media:
   author:
     name: Unsplash
     url: https://unsplash.com/
+embeddedLocal:
+  image1:
+    src: ::file ./img-placeholder-5.jpg
+    alt: placeholder
 pubDate: 2022-02-09
 thematics:
   - agriculture
@@ -17,13 +21,13 @@ thematics:
 
 <Block>
   <Prose>
+  
 ## CB Prose Alpha
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut vitae ornare lectus, ac accumsan erat. Cras eget eleifend ligula. Curabitur ac nisi tempor, molestie lorem vitae, consectetur turpis. Etiam hendrerit et sapien ac interdum.
 
 <Image 
-  src="http://via.placeholder.com/256x128?text=align-left" 
-  alt="Media example" 
+  embedded="image1"
   align="left" 
   attr="tux" 
   attrAuthor="penguin"


### PR DESCRIPTION
tldr:
I can think of two not-that-great options to let editors use local images. 

1. ask users to put local assets in `static` folder
2. predefine local assets in front matter

---

At first, I thought all the images and static assets can go to `public/static` folder 
(like how Chart component is handling local data 

```
<Chart
  dataPath='/public/example.csv' // <- data is in /static/public folder
  dateFormat="%m/%d/%Y" 
  idKey='County' 
  xKey='Test Date' 
  yKey='New Positives' 
  highlightStart = '12/10/2021'
  highlightEnd = '01/20/2022'
  highlightLabel = 'Omicron'
/>
```
)

but then I realized this makes users to put images or static assets to put in two separate places which is not ideal. but I am not sure how we can pass parcel-generated image path in async-loaded mdx contents 🤔 . (what @danielfdsilva  explained about parcel's image asset generation system helped me figure out the problem fast.) so this is what I came up with, defining local assets in frontmatter and using `embedded` props to indicate that it is a local asset to component. I feel like it is not an intuitive way of using local assets, but can't think of any other ways.. wonder any of you have a better idea? @ricardoduplos @danielfdsilva ?

This pr is just a proof of concept, but opening for discussion. 