### PR TITLE
Show mosaic register fail on map

### DIFF
--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -12,8 +12,15 @@ import 'mapbox-gl/dist/mapbox-gl.css';
 import CompareMbGL from 'mapbox-gl-compare';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
 import * as dateFns from 'date-fns';
+import { CollecticonCircleXmark } from '@devseed-ui/collecticons';
 
-import { ActionStatus, S_FAILED, S_IDLE, S_LOADING, S_SUCCEEDED } from '$utils/status';
+import {
+  ActionStatus,
+  S_FAILED,
+  S_IDLE,
+  S_LOADING,
+  S_SUCCEEDED
+} from '$utils/status';
 import { getLayerComponent, resolveConfigFunctions } from './layers/utils';
 import { useDatasetAsyncLayer } from '$context/layer-data';
 import { MapLoading } from '$components/common/loading-skeleton';
@@ -77,8 +84,11 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
   const [isMapCompareLoaded, setMapCompareLoaded] = useState(false);
 
   // This baseLayerStatus is for BaseLayerComponent
-  // ex. RasterTimeSeries uses this variable to track the status of registering mosaic
-  const [baseLayerStatus, setBaseLayerStatus] = useState<ActionStatus>(S_IDLE);
+  // ex. RasterTimeSeries uses this variable to track the status of
+  // registering mosaic.
+  const [baseLayerStatus, setBaseLayerStatus] =
+    useState<ActionStatus>(S_IDLE);
+
   const onBaseLayerStatusChange = useCallback(
     ({status}) => setBaseLayerStatus(status),
     []
@@ -231,20 +241,28 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
         <MapLoading position='right' />
       )}
 
-        <MapMessage
-          id='mosaic-base-fail-message'
-          active={baseLayerStatus === S_FAILED}
-        >
-          Failed to register layer {baseLayer?.data.id}
-        </MapMessage>
-      
-        <MapMessage
-          id='mosaic-compare-fail-message'
-          active={compareLayerStatus === S_FAILED}
-        >
-          Failed to register layer {compareLayer?.data.id}
-        </MapMessage>
-      
+      {/*
+        Normally we only need 1 error which is centered. If we're comparing we
+        need to render an error for each layer, but instead of centering them,
+        we show them on top of their respective map.
+      */}
+      <MapMessage
+        id='mosaic-base-fail-message'
+        active={baseLayerStatus === S_FAILED}
+        position={shouldRenderCompare ? 'left' : 'center'}
+        isInvalid
+      >
+        <CollecticonCircleXmark /> Failed to load layer {baseLayer?.data?.id}
+      </MapMessage>
+      <MapMessage
+        id='mosaic-compare-fail-message'
+        active={compareLayerStatus === S_FAILED}
+        position='right'
+        isInvalid
+      >
+        <CollecticonCircleXmark /> Failed to load compare layer{' '}
+        {compareLayer?.data?.id}
+      </MapMessage>
 
       {/*
         Map overlay element
@@ -254,7 +272,13 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
       */}
       <MapMessage
         id='compare-message'
-        active={!!(shouldRenderCompare && compareLayerResolvedData && !(compareLayerStatus === S_FAILED))}
+        active={
+          !!(
+            shouldRenderCompare &&
+            compareLayerResolvedData &&
+            compareLayerStatus !== S_FAILED
+          )
+        }
       >
         {computedCompareLabel}
       </MapMessage>

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -53,13 +53,13 @@ async function requestQuickCache(
 ) {
   const key = `${url}${JSON.stringify(payload)}`;
 
-    // No cache found, make request.
-   if (!quickCache.has(key)) {
-      const response = await axios.post(url, payload, {
-        signal: controller.signal
-      });
-      quickCache.set(key, response.data);
-    }
+  // No cache found, make request.
+  if (!quickCache.has(key)) {
+    const response = await axios.post(url, payload, {
+      signal: controller.signal
+    });
+    quickCache.set(key, response.data);
+  }
   return quickCache.get(key);
 }
 
@@ -182,7 +182,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         changeStatus?.({ status: S_LOADING, context: 'zoom-markers' });
 
         const payload = {
-          "filter-lang": "cql2-json",
+          'filter-lang': 'cql2-json',
           filter: getFilterPayload(userTzDate2utcString(date), layerId),
           limit: 500,
           fields: {
@@ -290,7 +290,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       changeStatus?.({ status: S_LOADING, context: 'layer' });
       try {
         const payload = {
-          "filter-lang": "cql2-json",
+          'filter-lang': 'cql2-json',
           filter: getFilterPayload(userTzDate2utcString(date), layerId)
         };
 

--- a/app/scripts/components/common/mapbox/map-message.tsx
+++ b/app/scripts/components/common/mapbox/map-message.tsx
@@ -10,11 +10,11 @@ const fadeDuration = 240;
 interface MessageProps {
   show: boolean;
   isInvalid?: boolean;
+  position?: 'left' | 'right' | 'center';
 }
 
 const Message = styled.div<MessageProps>`
   position: absolute;
-  left: 50%;
   z-index: 8;
   transform: translate(-50%, 0);
   padding: ${glsp(0.5, 0.75)};
@@ -26,6 +26,12 @@ const Message = styled.div<MessageProps>`
   display: flex;
   align-items: center;
   gap: ${glsp(0.5)};
+
+  ${({ position }) => {
+    if (position === 'left') return 'left: 25%;';
+    if (position === 'right') return 'left: 75%;';
+    return 'left: 50%;';
+  }}
 
   ${({ isInvalid }) =>
     isInvalid
@@ -47,20 +53,19 @@ const Message = styled.div<MessageProps>`
         `
       : css`
           visibility: hidden;
-          top: -${variableGlsp()};
+          top: ${variableGlsp(-1)};
           opacity: 0;
         `}
 `;
 
-interface MapMessageProps {
+interface MapMessageProps extends Pick<MessageProps, 'isInvalid' | 'position'> {
   id: string;
   active: boolean;
   children: React.ReactNode;
-  isInvalid?: boolean;
 }
 
 export default function MapMessage(props: MapMessageProps) {
-  const { id, children, active, isInvalid } = props;
+  const { id, children, active, isInvalid, position } = props;
 
   return (
     <TransitionGroup component={null}>
@@ -71,6 +76,7 @@ export default function MapMessage(props: MapMessageProps) {
               <Message
                 show={state === 'entered' || state === 'entering'}
                 isInvalid={isInvalid}
+                position={position}
               >
                 {children}
               </Message>


### PR DESCRIPTION
Close #54
- add 'context' attribute to BaseLayerStatus, CompareLayerStatus so it
  can be used to detect where the layer's status is from