### PR TITLE
Add support for yearly datatsets

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.js
+++ b/app/scripts/components/datasets/s-explore/index.js
@@ -115,13 +115,17 @@ const HeadingButton = styled.button`
 `;
 
 function getDatePickerView(timeDensity) {
-  // If the data's time density is monthly only allow the user to select a month
-  // by setting the picker to a early view.
-  if (timeDensity === 'month') {
-    return 'year';
-  }
+  const view = {
+    day: 'month',
+    // If the data's time density is yearly only allow the user to select a year
+    // by setting the picker to a decade view.
+    month: 'year',
+    // If the data's time density is monthly only allow the user to select a
+    // month by setting the picker to a early view.
+    year: 'decade'
+  }[timeDensity];
 
-  return 'month';
+  return view || 'month';
 }
 
 function DatasetsExplore() {

--- a/app/scripts/context/layer-data.tsx
+++ b/app/scripts/context/layer-data.tsx
@@ -21,7 +21,7 @@ import { S_SUCCEEDED } from '$utils/status';
 interface STACLayerData {
   timeseries: {
     isPeriodic: boolean;
-    timeDensity: 'day' | 'month' | null;
+    timeDensity: 'day' | 'month' | 'year' | null;
     domain: Array<string>;
   };
 }


### PR DESCRIPTION
Allows the user to pick years through the datepicker for yearly datatsets.
Does not address non periodic cases #52 