### PR TITLE
Add fallback for when there is no featured dataset/discovery

### DIFF
--- a/app/scripts/components/home/index.js
+++ b/app/scripts/components/home/index.js
@@ -113,9 +113,10 @@ function Home() {
 
   // TO DO: Ideally, these featured contents should be in carousel.
   // but for now, we are showing only one item.
+  // When there are no featured dataset, stub with the latest one (alphabetic order since dataset doesn't have pubDate)
   const mainDatasets = featuredDatasets.length
     ? featuredDatasets
-    : [thematic.data.datasets.sort()[0]];
+    : [[...thematic.data.datasets].sort()[0]];
 
   const featuredDiscoveries = thematic.data.discoveries.filter((d) => {
     return d.featuredOn?.find((thematicId) => thematicId === thematic.data.id);
@@ -125,7 +126,7 @@ function Home() {
   const mainDiscoveries = featuredDiscoveries.length
     ? featuredDiscoveries
     : [
-        thematic.data.discoveries.sort(
+        [...thematic.data.discoveries].sort(
           (a, b) => new Date(b.pubDate) - new Date(a.pubDate)
         )[0]
       ];


### PR DESCRIPTION
When there is no featured discovery: (the heading will say 'latest discovery' instead of 'featured discoveries' 

<img width="1147" alt="Screen Shot 2022-05-23 at 3 39 08 PM" src="https://user-images.githubusercontent.com/4583806/169898390-69eaad01-85da-46bd-ba66-0ea715e914db.png">

What will be good alt heading for the dataset though? 🤔 
