### PR TITLE
Fix dataset name overflow

### DIFF
--- a/app/scripts/components/datasets/s-explore/dataset-layer-single.js
+++ b/app/scripts/components/datasets/s-explore/dataset-layer-single.js
@@ -11,8 +11,6 @@ import {
   ElementInteractive,
   Wrapper as ElementInteractiveWrapper
 } from '$components/common/element-interactive';
-import { VarProse } from '$styles/variable-components';
-import { variableGlsp } from '$styles/variable-utils';
 import {
   WidgetItemBodyInner,
   WidgetItemHeader,

--- a/app/scripts/styles/panel.tsx
+++ b/app/scripts/styles/panel.tsx
@@ -141,6 +141,7 @@ export const WidgetItemHeader = styled.header`
   flex-flow: column nowrap;
   padding: ${variableGlsp(0.5, 1)};
   gap: ${glsp(0.5)};
+  min-width: 0;
 `;
 
 export const WidgetItemHeadline = styled.div`


### PR DESCRIPTION
#129

Result:
<img width="383" alt="image" src="https://user-images.githubusercontent.com/1090606/174632049-7e3188ef-c23e-40a0-8be1-9ab8e3c4aae1.png">


cc @ricardoduplos  This was fixed by setting `min-width: 0;` on the `WidgetItemHeader`. Please check if this is the appropriate solution or you were looking for something different.