### PR TITLE
Set linechart attribute useUTC as false

### DIFF
--- a/app/scripts/components/common/blocks/chart/line.js
+++ b/app/scripts/components/common/blocks/chart/line.js
@@ -70,7 +70,8 @@ const LineChart = ({
         margin={chartMargin}
         xScale={{
           type: 'time',
-          format: dateFormat
+          format: dateFormat,
+          useUTC: false
         }}
         colors={getColors(data.length)}
         xFormat={`time:${dateFormat}`}


### PR DESCRIPTION
Thank you @danielfdsilva to look into this problem! 
(@aboydnw : This will fix the data getting shifted by one month problem. I know you manually edited data to show the right chart, this change would need to be reverted)