### PR TITLE
Make one daterange to control charts on analysis page

### DIFF
--- a/app/scripts/components/analysis/results/chart-card.tsx
+++ b/app/scripts/components/analysis/results/chart-card.tsx
@@ -46,7 +46,7 @@ interface ChartCardProps {
   title: React.ReactNode;
   chartData: TimeseriesData;
   activeMetrics: DataMetric[];
-  activeBrushDates: object;
+  activeBrushDates: {start: number; end: number };
   setActiveBrushDates: (dates: { start: number; end: number }) => void;
 }
 

--- a/app/scripts/components/analysis/results/chart-card.tsx
+++ b/app/scripts/components/analysis/results/chart-card.tsx
@@ -41,12 +41,15 @@ import { Tip } from '$components/common/tip';
 import { composeVisuallyDisabled } from '$utils/utils';
 import { exportCsv } from '$components/common/chart/analysis/utils';
 import DropMenuItemButton from '$styles/drop-menu-item-button';
-
+export interface ActiveDates {
+  start: number; 
+  end: number;
+}
 interface ChartCardProps {
   title: React.ReactNode;
   chartData: TimeseriesData;
   activeMetrics: DataMetric[];
-  activeBrushDates: {start: number; end: number };
+  activeBrushDates: ActiveDates;
   setActiveBrushDates: (dates: { start: number; end: number }) => void;
 }
 

--- a/app/scripts/components/analysis/results/chart-card.tsx
+++ b/app/scripts/components/analysis/results/chart-card.tsx
@@ -75,7 +75,9 @@ export default function ChartCard(props: ChartCardProps) {
   const [brushIndex, setBrushIndex] = useState({ startIndex: 0, endIndex: 0 });
   const noDownloadReason = getNoDownloadReason(chartData);
 
-  const ascendingData = useMemo(() => {
+  // The indexes expect the data to be ascending, so we have to reverse the
+  // data.
+  const dataInAscOrder = useMemo(() => {
     if (!chartData.data?.timeseries.length) {
       return;
     }
@@ -85,13 +87,12 @@ export default function ChartCard(props: ChartCardProps) {
   const onExportClick = useCallback(
     (e: MouseEvent, type: 'image' | 'text') => {
       e.preventDefault();
-      if (!ascendingData) {
+      if (!dataInAscOrder) {
         return;
       }
       const { startIndex, endIndex } = brushIndex;
-      // The indexes expect the data to be ascending, so we have to reverse the
-      // data.
-      const data = ascendingData;//reverse(chartData.data.timeseries);
+
+      const data = dataInAscOrder;//reverse(chartData.data.timeseries);
       const dFormat = 'yyyy-MM-dd';
       const startDate = format(new Date(data[startIndex].date), dFormat);
       const endDate = format(new Date(data[endIndex].date), dFormat);
@@ -110,7 +111,7 @@ export default function ChartCard(props: ChartCardProps) {
         );
       }
     },
-    [id, ascendingData, brushIndex, activeMetrics]
+    [id, dataInAscOrder, brushIndex, activeMetrics]
   );
 
   const theme = useTheme();
@@ -200,7 +201,7 @@ export default function ChartCard(props: ChartCardProps) {
               <ChartCardNoMetric />
             ) : (
               <Chart
-                id={id+title}
+                id={id}
                 activeStartDate={activeBrushDates.start}
                 activeEndDate={activeBrushDates.end}
                 ref={chartRef}
@@ -214,14 +215,13 @@ export default function ChartCard(props: ChartCardProps) {
                 altDesc={`Amount of ${name} over time`}
                 xAxisLabel='Time'
                 yAxisLabel='Amount'
-                mainBrushIndex={brushIndex}
                 onBrushChange={(newIndex) => {
                   setBrushIndex(newIndex);
-                  if(!ascendingData) return;
-                  setActiveBrushDates(
-                    {start: new Date(ascendingData[newIndex.startIndex].date).getTime(),
-                    end: new Date(ascendingData[newIndex.endIndex].date).getTime()}
-                  );
+                  if(!dataInAscOrder) return;
+                  setActiveBrushDates({
+                      start: new Date(dataInAscOrder[newIndex.startIndex].date).getTime(),
+                      end: new Date(dataInAscOrder[newIndex.endIndex].date).getTime()
+                    });
                 }}
               />
             )

--- a/app/scripts/components/analysis/results/chart-card.tsx
+++ b/app/scripts/components/analysis/results/chart-card.tsx
@@ -84,6 +84,14 @@ export default function ChartCard(props: ChartCardProps) {
     return reverse(chartData.data.timeseries);
   },[chartData.data]);
   
+  const onBrushChange = useCallback((newIndex) => {
+    if(!dataInAscOrder) return;
+    setActiveBrushDates({
+        start: new Date(dataInAscOrder[newIndex.startIndex].date).getTime(),
+        end: new Date(dataInAscOrder[newIndex.endIndex].date).getTime()
+      });
+  },[dataInAscOrder,setActiveBrushDates]);
+
   const onExportClick = useCallback(
     (e: MouseEvent, type: 'image' | 'text') => {
       e.preventDefault();
@@ -215,14 +223,8 @@ export default function ChartCard(props: ChartCardProps) {
                 altDesc={`Amount of ${name} over time`}
                 xAxisLabel='Time'
                 yAxisLabel='Amount'
-                onBrushChange={(newIndex) => {
-                  setBrushIndex(newIndex);
-                  if(!dataInAscOrder) return;
-                  setActiveBrushDates({
-                      start: new Date(dataInAscOrder[newIndex.startIndex].date).getTime(),
-                      end: new Date(dataInAscOrder[newIndex.endIndex].date).getTime()
-                    });
-                }}
+                setLocalBrushIndex={setBrushIndex}
+                onBrushChange={onBrushChange}
               />
             )
           ) : (

--- a/app/scripts/components/analysis/results/index.tsx
+++ b/app/scripts/components/analysis/results/index.tsx
@@ -66,6 +66,7 @@ export default function AnalysisResults() {
   const { start, end, datasetsLayers, aoi, errors } = params;
 
   const [activeMetrics, setActiveMetrics] = useState<DataMetric[]>(dataMetrics);
+  const [activeBrushDates, setActiveBrushDates] = useState<object>({start: 0, end: 0});
 
   useEffect(() => {
     if (!start || !end || !datasetsLayers || !aoi) return;
@@ -175,6 +176,8 @@ export default function AnalysisResults() {
                   <ChartCard
                     title={l.name}
                     chartData={l}
+                    activeBrushDates={activeBrushDates}
+                    setActiveBrushDates={setActiveBrushDates}
                     activeMetrics={activeMetrics}
                   />
                 </li>

--- a/app/scripts/components/analysis/results/index.tsx
+++ b/app/scripts/components/analysis/results/index.tsx
@@ -15,7 +15,7 @@ import {
   requestStacDatasetsTimeseries,
   TimeseriesData
 } from './timeseries-data';
-import ChartCard from './chart-card';
+import ChartCard, { ActiveDates } from './chart-card';
 import AnalysisHeadActions, {
   DataMetric,
   dataMetrics
@@ -66,7 +66,7 @@ export default function AnalysisResults() {
   const { start, end, datasetsLayers, aoi, errors } = params;
 
   const [activeMetrics, setActiveMetrics] = useState<DataMetric[]>(dataMetrics);
-  const [activeBrushDates, setActiveBrushDates] = useState<object>({start: 0, end: 0});
+  const [activeBrushDates, setActiveBrushDates] = useState<ActiveDates>({start: 0, end: 0});
 
   useEffect(() => {
     if (!start || !end || !datasetsLayers || !aoi) return;

--- a/app/scripts/components/common/chart/block.tsx
+++ b/app/scripts/components/common/chart/block.tsx
@@ -11,7 +11,7 @@ interface BlockChartProp extends CommonLineChartProps {
   yKey: string;
 }
 
-const subIdKey = 'subIdeKey';
+const subIdKey = 'subIdKey';
 
 export default function BlockChart(props: BlockChartProp) {
   const { dataPath, idKey, xKey, yKey, dateFormat } = props;
@@ -69,6 +69,7 @@ export default function BlockChart(props: BlockChartProp) {
   return (
     <Chart
       {...props}
+      id={newDataPath + yKey}
       chartData={chartData}
       uniqueKeys={uniqueKeys}
       renderLegend={true}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useMemo, useEffect, useCallback } from 'react';
 import styled from 'styled-components';
 import {
   LineChart,
@@ -121,12 +121,20 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
 
     const { isMediumUp } = useMediaQuery();
 
+    const indexRef = useRef();
+
     const handleBrushChange = useCallback((newIndex) => {
-      const { startIndex, endIndex } = newIndex;
+      //const { startIndex, endIndex } = newIndex;
+      indexRef.current = newIndex;
+    }, []);
+
+    const onMouseRelease = useCallback(()=> {
+      if(!indexRef.current) return;
+      const { startIndex, endIndex } = indexRef.current;
       setBrushStartIndex(startIndex);
       setBrushEndIndex(endIndex);
-      onBrushChange?.(newIndex);
-    }, [onBrushChange]);
+      onBrushChange?.({startIndex, endIndex});
+    },[onBrushChange]);
 
     useEffect(() => {
       // Fire brush callback on mount to have the correct starting values.
@@ -189,6 +197,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
           <LineChartWithFont
             // enforcing rerendering when brushindex change
             key={`${brushStartIndex}${brushEndIndex}${id}-line`}
+            onMouseUp={onMouseRelease}
             ref={ref as any}
             data={chartData}
             margin={chartMargin}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -121,15 +121,13 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
 
     const { isMediumUp } = useMediaQuery();
 
-    const indexRef = useRef();
+    const indexRef = useRef({startIndex: 0, endIndex: 0});
 
     const handleBrushChange = useCallback((newIndex) => {
-      //const { startIndex, endIndex } = newIndex;
       indexRef.current = newIndex;
     }, []);
 
     const onMouseRelease = useCallback(()=> {
-      if(!indexRef.current) return;
       const { startIndex, endIndex } = indexRef.current;
       setBrushStartIndex(startIndex);
       setBrushEndIndex(endIndex);
@@ -197,22 +195,25 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
           <LineChartWithFont
             // enforcing rerendering when brushindex change
             key={`${brushStartIndex}${brushEndIndex}${id}-line`}
+            // update brush index only when mouse gets released
             onMouseUp={onMouseRelease}
+            onMouseLeave={onMouseRelease}
             ref={ref as any}
             data={chartData}
             margin={chartMargin}
             syncId={syncId}
-            syncMethod={(tick, data) => {
-              const index = syncMethodFunction({
-                data,
-                chartData,
-                xKey,
-                dateFormat,
-                startDate: activeStartDate,
-                endDate: activeEndDate,
-              });
-              return index;
-            }}
+            syncMethod='value'
+            // syncMethod={(tick, data) => {
+            //   const index = syncMethodFunction({
+            //     data,
+            //     chartData,
+            //     xKey,
+            //     dateFormat,
+            //     startDate: activeStartDate,
+            //     endDate: activeEndDate,
+            //   });
+            //   return index;
+            // }}
           >
             <AltTitle title={altTitle} desc={altDesc} />
             <CartesianGrid stroke='#efefef' vertical={false} />

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -273,6 +273,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                 <Line
                   type='linear'
                   isAnimationActive={false}
+                  dot={{ r:2, strokeWidth: 1}}
                   activeDot={false}
                   key={`${k.value}-line`}
                   dataKey={k.label}
@@ -316,6 +317,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                       <Line
                         type='linear'
                         isAnimationActive={false}
+                        dot={{ r:1, strokeWidth: 1}}
                         activeDot={false}
                         key={`${k.value}-line-brush`}
                         dataKey={k.label}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -88,6 +88,9 @@ function CustomCursor(props) {
 export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
   function RLineChart(props, ref) {
     const {
+      id,
+      activeStartDate,
+      activeEndDate,
       chartData,
       uniqueKeys,
       xKey,
@@ -169,8 +172,8 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                 chartData,
                 xKey,
                 dateFormat,
-                startDate: chartData[brushStartIndex][xKey],
-                endDate: chartData[brushStartIndex][xKey],
+                startDate: activeStartDate,
+                endDate: activeEndDate,
               });
               return index;
             }}
@@ -262,6 +265,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
             )}
             {renderBrush && (
               <Brush
+                key={`${activeStartDate}${activeEndDate}${id}brush`}
                 data={chartData}
                 dataKey={xKey}
                 height={brushHeight}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -66,6 +66,7 @@ export interface CommonLineChartProps {
   highlightEnd?: string;
   highlightLabel?: string;
   uniqueKeys: UniqueKeyUnit[];
+  setLocalBrushIndex?: (idx: { startIndex: number; endIndex: number }) => void;
   onBrushChange?: (idx: { startIndex: number; endIndex: number }) => void;
 }
 
@@ -110,6 +111,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
       highlightLabel,
       xAxisLabel,
       yAxisLabel,
+      setLocalBrushIndex,
       onBrushChange
     } = props;
 
@@ -128,9 +130,14 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
 
     useEffect(() => {
       // Fire brush callback on mount to have the correct starting values.
-      onBrushChange?.({ startIndex: 0, endIndex: chartData.length - 1 });
+      setLocalBrushIndex?.({ startIndex: 0, endIndex: chartData.length - 1 });
     }, []);
 
+    useEffect(() => {
+      setLocalBrushIndex?.({ startIndex: brushStartIndex, endIndex: brushEndIndex });
+    },[brushStartIndex, brushEndIndex, setLocalBrushIndex]);
+
+    // Set brush range again when active date changes
     useEffect(() => {
       const newStartIndex = chartData.findIndex(e => e[xKey] === activeStartDate);
       const newEndIndex = chartData.findIndex(e => {

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -273,7 +273,6 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                 <Line
                   type='linear'
                   isAnimationActive={false}
-                  dot={false}
                   activeDot={false}
                   key={`${k.value}-line`}
                   dataKey={k.label}
@@ -317,7 +316,6 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                       <Line
                         type='linear'
                         isAnimationActive={false}
-                        dot={false}
                         activeDot={false}
                         key={`${k.value}-line-brush`}
                         dataKey={k.label}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -49,6 +49,9 @@ const ChartWrapper = styled.div`
 `;
 
 export interface CommonLineChartProps {
+  id: string;
+  activeStartDate: number;
+  activeEndDate: number;
   xKey: string;
   altTitle: string;
   altDesc: string;
@@ -129,6 +132,20 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
     }, []);
 
     useEffect(() => {
+      const newStartIndex = chartData.findIndex(e => e[xKey] === activeStartDate);
+      const newEndIndex = chartData.findIndex(e => {
+        return e[xKey] === activeEndDate;
+      });
+
+      if (newStartIndex > -1 && newStartIndex !== brushStartIndex) {
+        setBrushStartIndex(newStartIndex);
+      } 
+      if (newEndIndex > -1 && newEndIndex !== brushEndIndex) {
+        setBrushEndIndex(newEndIndex);
+      }
+    }, [activeStartDate, activeEndDate, chartData, brushStartIndex, brushEndIndex, xKey]);
+
+    useEffect(() => {
       if (!isMediumUp) {
         setChartMargin({
           ...defaultMargin,
@@ -154,7 +171,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
 
     return (
       <ChartWrapper>
-        <ResponsiveContainer
+        <ResponsiveContainer 
           aspect={chartAspectRatio}
           debounce={500}
           height='auto'
@@ -162,6 +179,8 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
           maxHeight={chartMaxHeight}
         >
           <LineChartWithFont
+            // enforcing rerendering when brushindex change
+            key={`${brushStartIndex}${brushEndIndex}${id}-line`}
             ref={ref as any}
             data={chartData}
             margin={chartMargin}
@@ -265,10 +284,10 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
             )}
             {renderBrush && (
               <Brush
-                key={`${activeStartDate}${activeEndDate}${id}brush`}
                 data={chartData}
                 dataKey={xKey}
                 height={brushHeight}
+                travellerWidth={15}
                 tickFormatter={(t) => timeFormatter(t, dateFormat)}
                 onChange={handleBrushChange}
                 startIndex={brushStartIndex}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -131,6 +131,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
     useEffect(() => {
       // Fire brush callback on mount to have the correct starting values.
       setLocalBrushIndex?.({ startIndex: 0, endIndex: chartData.length - 1 });
+      onBrushChange?.({ startIndex: 0, endIndex: chartData.length - 1 });
     }, []);
 
     useEffect(() => {

--- a/app/scripts/components/common/chart/utils.ts
+++ b/app/scripts/components/common/chart/utils.ts
@@ -197,7 +197,7 @@ export function syncMethodFunction({
 }) {
   const { activeLabel, activePayload } = data;
   const dateFormatFromData = activePayload[0].payload.dateFormat;
-
+  
   let matchingIndex: number | null = -1;
   // Make sure that matching point is in current (zoomed) chart 
   const filteredChartData = chartData.filter(e=> e[xKey] <= endDate && e[xKey] >= startDate);
@@ -211,7 +211,7 @@ export function syncMethodFunction({
   });
 
   if (matchingIndex < 0) {
-    matchingIndex = chartData.findIndex(e => {
+    matchingIndex = filteredChartData.findIndex(e => {
       return isSameFormattedDate({
         date1: e[xKey],
         date2: activeLabel,


### PR DESCRIPTION
👉  [Preview to analysis result page with charts](https://deploy-preview-343--veda-ui.netlify.app/air-quality/analysis/results?start=2020-04-29T00%3A00%3A00.000Z&end=2022-11-12T00%3A00%3A00.000Z&datasetsLayers=no2-monthly%7Cno2-monthly-diff&aoi=paxfRyk%7DmFitqkBfab%5Bpfus%40zorm%40f%60op%40prl%40)

- close https://github.com/NASA-IMPACT/delta-ui/issues/324 https://github.com/NASA-IMPACT/delta-ui/issues/326
- set up `activeBrushDates` on analysis result page level to control all the charts on the analysis page.
- I realized that recharts need to be forced to rerender when we sync charts manually. (using `key)`, passing props needed for key (`id`). 

- But this pr introduces **the other problem** that because the whole component is being rendered (or its state is being updated), brushing becomes jagged. like you change one date, then you lose control over the mouse action which I think is really annoying. You can compare sandbox brush on the main branch now from this pr when force rerendering is not in place: https://veda-ui.netlify.app/sandbox/analysis-chart - I will talk about this in detail at front-end standup
: **Update** - I worked around this problem by updating the brush index only when mouse gets released 🤔 Now the charts don't get synced up in real-time but the other chart 'catches up' when mouse is up.

- I replaced 'syncMethod' with 'value' for now, the chart will get synced only when there is the exact same value on x-axis. I did this because I am a bit fuzzy about how brush should work on different time densities + advanced syncing doesn't seem to be in demand based on the feedback we have collected so far. 🤔 we can revisit this in the future.

Misc
- Bigger handle
- dots for data points along the lines (This was brought up in the feedback session.) 

