### PR TITLE
Disconnect sync between charts

### DIFF
--- a/app/scripts/components/common/chart/analysis/index.tsx
+++ b/app/scripts/components/common/chart/analysis/index.tsx
@@ -22,7 +22,7 @@ export interface AnalysisChartRef {
   saveAsImage: (name?: string) => Promise<void>;
 }
 
-const syncId = 'analysis';
+const syncId = null;
 
 export default React.forwardRef<AnalysisChartRef, AnalysisChartProps>(
   function AnalysisChart(props, ref) {


### PR DESCRIPTION
This PR disconnects sync behavior between charts. This should be just a temporary solution until the new brush is ready. Feel free to close if not needed. 