### PR TITLE
Surface errors when build fails

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,7 +104,9 @@ function parcelBuild(cb) {
   const pr = spawn('node', [parcelCli, 'build', ...args, ...parcelTarget], {
     stdio: 'inherit'
   });
-  pr.on('close', () => cb());
+  pr.on('close', (code) => {
+    cb(code ? 'Build failed' : undefined);
+  });
 }
 
 // //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When the parcel build failed, the process was still considered completed resulting in netlify deploying an empty site. This happened in the https://github.com/NASA-IMPACT/veda-config/pull/181 PR.

If an error occurs we surface it, and the build is halted.