### PR TITLE
Keep date visible on scrollytelling maps

### DIFF
--- a/app/scripts/components/analysis/page-hero-analysis.tsx
+++ b/app/scripts/components/analysis/page-hero-analysis.tsx
@@ -18,8 +18,7 @@ import Constrainer from '$styles/constrainer';
 
 import { variableGlsp } from '$styles/variable-utils';
 import { useMediaQuery } from '$utils/use-media-query';
-
-export const HERO_TRANSITION_DURATION = 320;
+import { HEADER_TRANSITION_DURATION } from '$utils/use-sliding-sticky-header';
 
 const PageHeroBlockAlpha = styled.div`
   display: flex;
@@ -74,9 +73,9 @@ const PageHeroSelf = styled.div<PageHeroSelfProps>`
   background: ${themeVal('color.primary')};
   color: ${themeVal('color.surface')};
   min-height: 14rem;
-  animation: ${reveal} ${HERO_TRANSITION_DURATION}ms ease 0s 1;
-  transition: top ${HERO_TRANSITION_DURATION}ms ease-out,
-    min-height ${HERO_TRANSITION_DURATION}ms ease-out;
+  animation: ${reveal} ${HEADER_TRANSITION_DURATION}ms ease 0s 1;
+  transition: top ${HEADER_TRANSITION_DURATION}ms ease-out,
+    min-height ${HEADER_TRANSITION_DURATION}ms ease-out;
 
   ${({ isHidden }) => isHidden && visuallyHidden()}
 
@@ -94,12 +93,12 @@ const PageHeroSelf = styled.div<PageHeroSelfProps>`
     `}
 
   ${PageHeroMedia} {
-    transition: opacity ${HERO_TRANSITION_DURATION}ms ease-out;
+    transition: opacity ${HEADER_TRANSITION_DURATION}ms ease-out;
     opacity: ${({ isStuck }) => Number(!isStuck)};
   }
 
   ${PageLead} {
-    transition: font-size ${HERO_TRANSITION_DURATION}ms ease-out;
+    transition: font-size ${HEADER_TRANSITION_DURATION}ms ease-out;
     ${({ isStuck }) =>
       isStuck &&
       css`
@@ -109,7 +108,7 @@ const PageHeroSelf = styled.div<PageHeroSelfProps>`
   }
 
   ${PageHeroBlockAlpha} {
-    transition: gap ${HERO_TRANSITION_DURATION}ms ease-out;
+    transition: gap ${HEADER_TRANSITION_DURATION}ms ease-out;
     ${({ isStuck }) =>
       isStuck &&
       css`
@@ -128,7 +127,7 @@ const PageHeroSelf = styled.div<PageHeroSelfProps>`
 
 const PageHeroInner = styled(Constrainer)`
   align-items: end;
-  transition: padding ${HERO_TRANSITION_DURATION}ms ease-out;
+  transition: padding ${HEADER_TRANSITION_DURATION}ms ease-out;
 
   ${({ isStuck }) =>
     isStuck

--- a/app/scripts/components/analysis/page-hero-media.tsx
+++ b/app/scripts/components/analysis/page-hero-media.tsx
@@ -7,9 +7,9 @@ import { shade } from 'polished';
 import { rgba, themeVal } from '@devseed-ui/theme-provider';
 import { reveal } from '@devseed-ui/animation';
 
-import { HERO_TRANSITION_DURATION } from './page-hero-analysis';
 import { SimpleMap } from '$components/common/mapbox/map';
 import { useEffectPrevious } from '$utils/use-effect-previous';
+import { HEADER_TRANSITION_DURATION } from '$utils/use-sliding-sticky-header';
 
 const WORLD_POLYGON = [
   [180, 90],
@@ -58,7 +58,7 @@ function PageHeroMedia(props: PageHeroMediaProps) {
       if (!shouldMount && wasStuck && !isHeaderStuck) {
         const tid = setTimeout(
           () => setShouldMount(true),
-          HERO_TRANSITION_DURATION
+          HEADER_TRANSITION_DURATION
         );
 
         return () => {

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -37,7 +37,7 @@ import { HintedError } from '$utils/hinted-error';
 import { formatSingleDate } from '$components/common/mapbox/utils';
 import { convertProjectionToMapbox } from '$components/common/mapbox/projection-selector/utils';
 import { useSlidingStickyHeaderProps } from '$components/common/layout-root';
-import { HERO_TRANSITION_DURATION } from '$components/analysis/page-hero-analysis';
+import { HEADER_TRANSITION_DURATION } from '$utils/use-sliding-sticky-header';
 
 type ResolvedLayer = {
   layer: Exclude<AsyncDatasetLayer['baseLayer']['data'], null>;
@@ -52,8 +52,8 @@ const ScrollyMapWrapper = styled.div``;
 const TheMap = styled.div<{ topOffset: number }>`
   height: ${scrollyMapHeight};
   position: sticky;
-  transition: top ${HERO_TRANSITION_DURATION}ms ease-out,
-    height ${HERO_TRANSITION_DURATION}ms ease-out;
+  transition: top ${HEADER_TRANSITION_DURATION}ms ease-out,
+    height ${HEADER_TRANSITION_DURATION}ms ease-out;
 
   ${({ topOffset }) => css`
     top: ${topOffset}px;

--- a/app/scripts/components/common/nav-wrapper.js
+++ b/app/scripts/components/common/nav-wrapper.js
@@ -6,7 +6,10 @@ import PageHeader from './page-header';
 import { useSlidingStickyHeaderProps } from './layout-root';
 import PageLocalNav from '$components/common/page-local-nav';
 
-import { HEADER_WRAPPER_ID } from '$utils/use-sliding-sticky-header';
+import {
+  HEADER_WRAPPER_ID,
+  HEADER_TRANSITION_DURATION
+} from '$utils/use-sliding-sticky-header';
 
 const NavWrapper = styled.div`
   position: sticky;
@@ -14,7 +17,7 @@ const NavWrapper = styled.div`
   width: 100%;
   z-index: 900;
 
-  transition: top 0.32s ease-out;
+  transition: top ${HEADER_TRANSITION_DURATION}ms ease-out;
   ${({ shouldSlideHeader, headerHeight }) =>
     // Hide the header by translating the nav by the header's height. The
     // translate is in the NavWrapper and not the header because in this way the

--- a/app/scripts/utils/use-sliding-sticky-header.ts
+++ b/app/scripts/utils/use-sliding-sticky-header.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 export const HEADER_ID = 'page-header';
 export const HEADER_WRAPPER_ID = 'header-wrapper';
+export const HEADER_TRANSITION_DURATION = 320;
 
 export function useSlidingStickyHeader() {
   const [isHidden, setHidden] = useState(false);
@@ -44,13 +45,19 @@ export function useSlidingStickyHeader() {
     observer.observe(navWrapperElement);
 
     function tick(currY) {
-      const wrapperEl = document.querySelector(
+      const wrapperEl = document.querySelector<HTMLElement>(
         `#${HEADER_WRAPPER_ID}`
-      ) as HTMLElement;
-      setWrapperHeight(wrapperEl?.offsetHeight || 0);
+      );
+
+      if (!wrapperEl)
+        throw new Error(
+          `Header element with ID ${HEADER_WRAPPER_ID} not found.`
+        );
+
+      setWrapperHeight(wrapperEl.offsetHeight);
 
       const el = document.querySelector<HTMLElement>(`#${HEADER_ID}`);
-      const headerHeightQueried = el?.offsetHeight || 0;
+      const headerHeightQueried = el?.offsetHeight ?? 0;
       setHeaderHeight(headerHeightQueried);
 
       // When the document is scrolled quickly to the bottom of the page, the


### PR DESCRIPTION
Ensures that the date remains visible by changing the scrollytelling block offset when the header is visible #376