### PR TITLE
Include min and max dates of all datasets in brush domain

### DIFF
--- a/app/scripts/components/analysis/results/index.tsx
+++ b/app/scripts/components/analysis/results/index.tsx
@@ -133,17 +133,23 @@ export default function AnalysisResults() {
 
   const availableDomain: [Date, Date] | null = useMemo(() => {
     if (!start || !end) return null;
-    let minDate = +start;
-    let maxDate = +end;
-    requestStatus.forEach((item) => {
-      if (item.data?.timeseries) {
-        const itemDates = item.data.timeseries.map((t) => +new Date(t.date));
-        const itemMin = min(itemDates) ?? Number.POSITIVE_INFINITY;
-        const itemMax = max(itemDates) ?? Number.NEGATIVE_INFINITY;
-        if (itemMin < minDate) minDate = itemMin;
-        if (itemMax > maxDate) maxDate = itemMax;
-      }
-    });
+
+    const { minDate, maxDate } = requestStatus.reduce(
+      (acc, item) => {
+        if (item.data?.timeseries) {
+          const itemDates = item.data.timeseries.map((t) => +new Date(t.date));
+          const itemMin = min(itemDates) ?? Number.POSITIVE_INFINITY;
+          const itemMax = max(itemDates) ?? Number.NEGATIVE_INFINITY;
+
+          return {
+            minDate: itemMin < acc.minDate ? itemMin : acc.minDate,
+            maxDate: itemMax > acc.maxDate ? itemMax : acc.maxDate
+          };
+        }
+        return acc;
+      },
+      { minDate: +start, maxDate: +end }
+    );
 
     const onlySingleValues = requestStatus.every(
       (rs) => rs.data?.timeseries.length === 1


### PR DESCRIPTION
Fix for https://github.com/NASA-IMPACT/veda-ui/issues/430

![Screenshot 2023-01-23 at 11 16 51](https://user-images.githubusercontent.com/1583415/214015247-46b6e9cf-6efe-4200-a246-b3290eaca347.png)
