### PR TITLE
Notebook connect

### DIFF
--- a/app/scripts/components/common/mapbox/map.tsx
+++ b/app/scripts/components/common/mapbox/map.tsx
@@ -16,6 +16,7 @@ import { aoiCursorStyles, useMbDraw } from './aoi/mb-aoi-draw';
 import ProjectionSelector from './projection-selector';
 import { useMapboxControl } from './use-mapbox-control';
 import { convertProjectionToMapbox } from './projection-selector/utils';
+
 import { round } from '$utils/format';
 
 mapboxgl.accessToken = process.env.MAPBOX_TOKEN ?? '';

--- a/app/scripts/components/common/mdx-content.js
+++ b/app/scripts/components/common/mdx-content.js
@@ -16,6 +16,7 @@ import {
   LazyScrollyTelling,
   LazyMap
 } from '$components/common/blocks/lazy-components';
+import { NotebookConnectCalloutBlock } from '$components/common/notebook-connect';
 
 function MdxContent(props) {
   const pageMdx = useMdxPageLoader(props.loader);
@@ -37,7 +38,8 @@ function MdxContent(props) {
           Map: LazyMap,
           ScrollytellingBlock: LazyScrollyTelling,
           Chart: LazyChart,
-          CompareImage: LazyCompareImage
+          CompareImage: LazyCompareImage,
+          NotebookConnectCallout: NotebookConnectCalloutBlock
         }}
       >
         <pageMdx.MdxContent />

--- a/app/scripts/components/common/notebook-connect.tsx
+++ b/app/scripts/components/common/notebook-connect.tsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
+import { multiply, themeVal } from '@devseed-ui/theme-provider';
+import { Button, ButtonProps } from '@devseed-ui/button';
+import { CollecticonCode } from '@devseed-ui/collecticons';
+import { Modal } from '@devseed-ui/modal';
+import { DatasetData, datasets, VedaDatum } from 'veda/thematics';
+
+import { HintedError } from '$utils/hinted-error';
+import { variableGlsp } from '$styles/variable-utils';
+
+interface NotebookConnectButtonProps {
+  compact?: boolean;
+  variation?: ButtonProps['variation'];
+  size?: ButtonProps['size'];
+  dataset?: VedaDatum<DatasetData>;
+  className?: string;
+}
+
+function NotebookConnectButtonSelf(props: NotebookConnectButtonProps) {
+  const {
+    className,
+    compact = true,
+    variation = 'primary-fill',
+    size = 'medium',
+    dataset
+  } = props;
+
+  const [revealed, setRevealed] = useState(false);
+  const close = useCallback(() => setRevealed(false), []);
+
+  const datasetUsages = dataset?.data.usage;
+
+  if (!datasetUsages) {
+    return null;
+  }
+
+  const layerIdsSet = dataset.data.layers.reduce(
+    (acc, layer) => acc.add(layer.stacCol),
+    new Set<string>()
+  );
+
+  return (
+    <>
+      <Button
+        className={className}
+        type='button'
+        variation={variation}
+        fitting={compact ? 'skinny' : 'regular'}
+        onClick={() => setRevealed(true)}
+        size={size}
+      >
+        <CollecticonCode meaningful={compact} title='Open code usage options' />
+        {compact ? '' : 'Use code'}
+      </Button>
+      <Modal
+        id='modal'
+        size='medium'
+        title='Code usage'
+        revealed={revealed}
+        onCloseClick={close}
+        onOverlayClick={close}
+        closeButton
+        content={
+          <>
+            <p>Check out how to use this dataset:</p>
+            <ul>
+              {datasetUsages.map((datasetUsage) => (
+                <li key={datasetUsage.url}>
+                  {datasetUsage.label}:{' '}
+                  <a href={datasetUsage.url}>{datasetUsage.title}</a>
+                </li>
+              ))}
+            </ul>
+            <p>
+              For reference, the following STAC collection ID&apos;s are
+              associated with this dataset:
+            </p>
+            <ul>
+              {Array.from(layerIdsSet).map((id) => (
+                <li key={id}>
+                  <code>{id}</code>
+                </li>
+              ))}
+            </ul>
+          </>
+        }
+      />
+    </>
+  );
+}
+
+export const NotebookConnectButton = styled(NotebookConnectButtonSelf)`
+  /* Convert to styled-component: https://styled-components.com/docs/advanced#caveat */
+`;
+
+interface NotebookConnectCalloutProps {
+  children: React.ReactNode;
+  datasetId: string;
+  className?: string;
+}
+
+function NotebookConnectCalloutSelf(props: NotebookConnectCalloutProps) {
+  const { children, datasetId, className } = props;
+
+  if (!datasetId) {
+    throw new HintedError('Malformed Map Block', [
+      'Missing property: datasetId'
+    ]);
+  }
+
+  const dataset = datasets[datasetId];
+
+  if (!dataset) {
+    throw new HintedError('Malformed Map Block', [
+      `Dataset not found: ${datasetId}`
+    ]);
+  }
+
+  if (!dataset.data.usage?.length) {
+    throw new HintedError('Malformed Map Block', [
+      `Dataset does not have 'usage' defined: ${datasetId}`
+    ]);
+  }
+
+  return (
+    <div className={className}>
+      <div>{children}</div>
+      <NotebookConnectButton
+        // compact={false}
+        variation='base-outline'
+        dataset={dataset}
+      />
+    </div>
+  );
+}
+
+export const NotebookConnectCalloutBlock = styled(NotebookConnectCalloutSelf)`
+  /* Convert to styled-component: https://styled-components.com/docs/advanced#caveat */
+  display: flex;
+  flex-flow: row nowrap;
+  border-radius: ${multiply(themeVal('shape.rounded'), 2)};
+  background: ${themeVal('color.base-50')};
+  padding: ${variableGlsp()};
+  gap: ${variableGlsp()};
+  box-shadow: inset 0 -1px 0 0 ${themeVal('color.base-50a')};
+
+  ${NotebookConnectButton} {
+    margin-left: auto;
+  }
+`;

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -53,6 +53,7 @@ import {
 import { variableGlsp } from '$styles/variable-utils';
 import { S_SUCCEEDED } from '$utils/status';
 import { projectionDefault } from '$components/common/mapbox/projection-selector/utils';
+import { NotebookConnectButton } from '$components/common/notebook-connect';
 
 const Explorer = styled.div`
   position: relative;
@@ -74,6 +75,13 @@ const Carto = styled.div`
     .mapboxgl-ctrl-top-left {
       margin-top: calc(2rem + ${variableGlsp(0.5)});
     }
+  }
+
+  ${NotebookConnectButton} {
+    position: absolute;
+    z-index: 1;
+    right: ${variableGlsp()};
+    top: ${variableGlsp()};
   }
 `;
 
@@ -553,6 +561,7 @@ function DatasetsExplore() {
             </PanelInner>
           </Panel>
           <Carto>
+            <NotebookConnectButton dataset={dataset} />
             <MapboxMap
               ref={mapboxRef}
               withGeocoder

--- a/app/scripts/components/datasets/s-overview/index.js
+++ b/app/scripts/components/datasets/s-overview/index.js
@@ -1,6 +1,7 @@
 import React, { lazy } from 'react';
-import { Button } from '@devseed-ui/button';
 import { Link } from 'react-router-dom';
+import { Button } from '@devseed-ui/button';
+import { CollecticonCompass } from '@devseed-ui/collecticons';
 
 import { resourceNotFound } from '$components/uhoh';
 import { LayoutProps } from '$components/common/layout-root';
@@ -8,6 +9,7 @@ import { PageActions, PageLead, PageMainContent } from '$styles/page';
 import { DatasetsLocalMenu } from '$components/common/page-local-nav';
 import PageHero from '$components/common/page-hero';
 import RelatedContent from '$components/common/related-content';
+import { NotebookConnectButton } from '$components/common/notebook-connect';
 
 import { useThematicArea, useThematicAreaDataset } from '$utils/thematics';
 import { datasetExplorePath, thematicDatasetsPath } from '$utils/routes';
@@ -51,8 +53,15 @@ function DatasetsOverview() {
                   size='large'
                   variation='achromic-outline'
                 >
-                  Explore the data
+                  <CollecticonCompass />
+                  Explore data
                 </Button>
+                <NotebookConnectButton
+                  dataset={dataset}
+                  size='large'
+                  compact={false}
+                  variation='achromic-outline'
+                />
               </PageActions>
             </>
           )}

--- a/app/scripts/components/sandbox/mdx-page/page.mdx
+++ b/app/scripts/components/sandbox/mdx-page/page.mdx
@@ -7,17 +7,14 @@
 <Block type='wide'>
   <Figure>
     <Map
-      datasetId='sandbox'
+      datasetId='no2'
       layerId='no2-monthly'
       dateTime='2018-03-01'
       isComparing={true}
       compareLabel='Overriding label'
       projectionId='globe'
     />
-    <Caption
-      attrAuthor='somebody'
-      attrUrl='https://developmentseed.org'
-    >
+    <Caption attrAuthor='somebody' attrUrl='https://developmentseed.org'>
       Comparing dates set via the configuration function
     </Caption>
   </Figure>
@@ -34,25 +31,25 @@
       allowProjectionChange
       isComparing={true}
     />
-    <Caption>
-      Comparing dates set manually
-    </Caption>
+    <Caption>Comparing dates set manually</Caption>
   </Figure>
 </Block>
 
 <Block type='full'>
   <Figure>
-    <Map datasetId='sandbox' layerId='nightlights-hd-monthly' dateTime='2020-03-01' isComparing={false} />
-    <Caption>
-      This map has a caption **below** it!
-    </Caption>
+    <Map
+      datasetId='nighttime-lights'
+      layerId='nightlights-hd-monthly'
+      dateTime='2020-03-01'
+      isComparing={false}
+    />
+    <Caption>This map has a caption **below** it!</Caption>
   </Figure>
 </Block>
 
-
 <Block type='full'>
   <Figure>
-    <CompareImage 
+    <CompareImage
       leftImageSrc='http://via.placeholder.com/256x128?text=left-left'
       leftImageAlt='example left image for compare-image component'
       leftImageLabel='left'
@@ -60,24 +57,37 @@
       rightImageAlt='example right image for compare-image component'
       rightImageLabel='right'
     />
-    <Caption attrAuthor='Development Seed' attrUrl='https://developmentseed.org'>
+    <Caption
+      attrAuthor='Development Seed'
+      attrUrl='https://developmentseed.org'
+    >
       This component is to compare two images.
     </Caption>
   </Figure>
   <Prose>
-    ## Compare two images
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-    labore et dolore magna aliqua. A diam sollicitudin tempor id eu nisl nunc mi ipsum. Lectus 
-    arcu bibendum at varius vel pharetra vel turpis. Lorem sed risus ultricies tristique nulla.
-    Sed faucibus turpis in eu mi bibendum neque egestas congue. Mi proin sed libero enim sed. 
-    Odio aenean sed adipiscing diam donec adipiscing tristique risus. Nunc sed velit dignissim 
-    sodales ut eu sem. Duis ultricies lacus sed turpis tincidunt. Urna et pharetra pharetra
-    massa. Malesuada proin libero nunc consequat interdum varius sit. Velit ut tortor pretium
-    viverra. Et tortor consequat id porta. Gravida rutrum quisque non tellus orci ac auctor
-    augue mauris. Ut faucibus pulvinar elementum integer. Id donec ultrices tincidunt arcunon.
+    ## Compare two images Lorem ipsum dolor sit amet, consectetur adipiscing
+
+    elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. A
+    diam sollicitudin tempor id eu nisl nunc mi ipsum. Lectus arcu bibendum at
+    varius vel pharetra vel turpis. Lorem sed risus ultricies tristique nulla.
+    Sed faucibus turpis in eu mi bibendum neque egestas congue. Mi proin sed
+    libero enim sed. Odio aenean sed adipiscing diam donec adipiscing tristique
+    risus. Nunc sed velit dignissim sodales ut eu sem. Duis ultricies lacus sed
+    turpis tincidunt.
+
+    <NotebookConnectCallout datasetId='no2'>
+      Lorem sed risus ultricies tristique nulla. Sed faucibus turpis in eu mi
+      bibendum neque egestas congue. Mi proin sed libero enim sed. Odio aenean
+      sed adipiscing diam donec adipiscing tristique risus.
+    </NotebookConnectCallout>
+
+    Urna et pharetra pharetra massa. Malesuada proin libero
+    nunc consequat interdum varius sit. Velit ut tortor pretium viverra. Et
+    tortor consequat id porta. Gravida rutrum quisque non tellus orci ac auctor
+    augue mauris. Ut faucibus pulvinar elementum integer.
+
   </Prose>
 </Block>
-
 
 <Block>
   <Figure>

--- a/app/scripts/styles/page.js
+++ b/app/scripts/styles/page.js
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Overline } from '@devseed-ui/typography';
 
 import { VarHeading, VarLead } from './variable-components';
-import { variableBaseType } from './variable-utils';
+import { variableBaseType, variableGlsp } from './variable-utils';
 
 export const PageMainContent = styled.main`
   flex-grow: 1;
@@ -35,5 +35,7 @@ export const PageLead = styled(VarLead)`
 `;
 
 export const PageActions = styled.div`
-  /* styled-component */
+  display: flex;
+  flex-direction: row nowrap;
+  gap: ${variableGlsp(0.5)};
 `;


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-architecture/issues/174
This sets up the baseline for the notebook connect widget for veda.

Currently the notebook connect presents itself as a button in the dataset overview and explore pages:

| | |
|--|--|
|<img width="1276" alt="image" src="https://user-images.githubusercontent.com/1090606/215559681-14312372-c757-4bdc-84f8-908f5327060f.png">|<img width="1277" alt="image" src="https://user-images.githubusercontent.com/1090606/215560014-71d1fa25-4d3a-4675-b05e-6235084d7744.png">|

Clicking the button will open a modal with the content that is currently on the usage page for each dataset.

<img width="823" alt="image" src="https://user-images.githubusercontent.com/1090606/215560372-2701fb39-e86a-471a-8f9d-a8cfbc10b11b.png">

> ⚠️ If the dataset has no `usage` defined on the MDX file, the button will not be available.

There is also an option to add a callout to a long form text page (like discoveries). Here the user will have to specify some text for the callout and the dataset for which to load the usage. Example:  
  

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1090606/215560790-4a6a438f-e740-4c5a-980f-a6cdab4d4437.png">

The code to generate this being:
```jsx
<NotebookConnectCallout datasetId='no2'>
  Lorem sed risus ultricies tristique nulla. Sed faucibus turpis in eu mi
  bibendum neque egestas congue. Mi proin sed libero enim sed. Odio aenean
  sed adipiscing diam donec adipiscing tristique risus.
</NotebookConnectCallout>
```

What are your thoughts @j08lue @abarciauskas-bgse @michaelgsuttles?

----

## Content updates

Feel free to suggest a name change for the button and modal title.  
The modal content is currently dynamically generated from the [`usage` property](https://github.com/NASA-IMPACT/veda-config/blob/develop/docs/CONTENT.md#datasets). We can change the common hardcoded portion if needed.

----

## Next steps

This is what we propose for a first release. Next up is having the button on top of charts and small maps in the long form pages. This requires some more complex technical changes, but wanted to have something to start with.