### PR TITLE
Address QA review of stage/v0.6.0

### DIFF
--- a/app/scripts/components/analysis/results/use-analysis-params.ts
+++ b/app/scripts/components/analysis/results/use-analysis-params.ts
@@ -107,9 +107,8 @@ export function useAnalysisParams(): {
         throw new ValidationError(sentences);
       }
 
-      // lon,lat|lon,lat||lon,lat|lon,lat
-      // || separates polygons
-      // | separates points
+      // polyline-encoding;polyline-encoding
+      // ; separates polygons
       const { geojson, errors: gjvErrors } = polygonUrlDecode(aoi);
 
       if (gjvErrors.length) {

--- a/app/scripts/components/common/nav-wrapper.js
+++ b/app/scripts/components/common/nav-wrapper.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import T from 'prop-types';
 import styled, { css } from 'styled-components';
+import { themeVal } from '@devseed-ui/theme-provider';
 
 import PageHeader from './page-header';
 import { useSlidingStickyHeaderProps } from './layout-root';
@@ -15,7 +16,7 @@ const NavWrapper = styled.div`
   position: sticky;
   top: 0;
   width: 100%;
-  z-index: 900;
+  z-index: ${themeVal('zIndices.sticky')};
 
   transition: top ${HEADER_TRANSITION_DURATION}ms ease-out;
   ${({ shouldSlideHeader, headerHeight }) =>

--- a/app/scripts/components/common/tip.ts
+++ b/app/scripts/components/common/tip.ts
@@ -11,7 +11,7 @@ export const Tip = Typpy;
 export const reactTippyStyles = () => css`
   body {
     [data-tippy-root] {
-      z-index: 800 !important;
+      z-index: ${themeVal('zIndices.tooltip')} !important;
     }
 
     .tippy-box {

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -2,45 +2,59 @@ import { createUITheme, media, themeVal } from '@devseed-ui/theme-provider';
 import { createGlobalStyle } from 'styled-components';
 import { reactTippyStyles } from '$components/common/tip';
 
-export default function themeOverrides() {
-  return createUITheme({
-    color: {
-      base: '#2c3e50',
-      primary: '#2276ac',
-      infographicA: '#fcab10',
-      infographicB: '#f4442e',
-      infographicC: '#b62b6e',
-      infographicD: '#2ca58d',
-      infographicE: '#2276ac'
-    },
-    type: {
-      base: {
-        leadSize: '1.25rem',
-        extrabold: '800',
-        // Increments to the type.base.size for each media breakpoint.
-        sizeIncrement: {
-          small: '0rem',
-          medium: '0rem',
-          large: '0.25rem',
-          xlarge: '0.25rem'
-        }
-      },
-      heading: {
-        settings: '"wdth" 100, "wght" 700'
+export const VEDA_OVERRIDE_THEME = {
+  zIndices: {
+    hide: -1,
+    docked: 10,
+    sticky: 900,
+    dropdown: 1000,
+    overlay: 1300,
+    modal: 1400,
+    popover: 1500,
+    skipLink: 1600,
+    toast: 1700,
+    tooltip: 1800
+  },
+  color: {
+    base: '#2c3e50',
+    primary: '#2276ac',
+    infographicA: '#fcab10',
+    infographicB: '#f4442e',
+    infographicC: '#b62b6e',
+    infographicD: '#2ca58d',
+    infographicE: '#2276ac'
+  },
+  type: {
+    base: {
+      leadSize: '1.25rem',
+      extrabold: '800',
+      // Increments to the type.base.size for each media breakpoint.
+      sizeIncrement: {
+        small: '0rem',
+        medium: '0rem',
+        large: '0.25rem',
+        xlarge: '0.25rem'
       }
     },
-    layout: {
-      min: '384px',
-      max: '1440px',
-      glspMultiplier: {
-        xsmall: 1,
-        small: 1,
-        medium: 1.5,
-        large: 2,
-        xlarge: 2
-      }
+    heading: {
+      settings: '"wdth" 100, "wght" 700'
     }
-  });
+  },
+  layout: {
+    min: '384px',
+    max: '1440px',
+    glspMultiplier: {
+      xsmall: 1,
+      small: 1,
+      medium: 1.5,
+      large: 2,
+      xlarge: 2
+    }
+  }
+};
+
+export default function themeOverrides() {
+  return createUITheme(VEDA_OVERRIDE_THEME);
 }
 
 /**
@@ -51,7 +65,7 @@ export const GlobalStyles = createGlobalStyle`
   ${reactTippyStyles()}
 
   .tether-element.tether-element {
-    z-index: 700;
+    z-index: ${themeVal('zIndices.dropdown')};
   }
 
   :root {

--- a/app/scripts/utils/polygon-url.ts
+++ b/app/scripts/utils/polygon-url.ts
@@ -6,15 +6,15 @@ import { decode, encode } from 'google-polyline';
  * Decodes a multi polygon string converting it into a FeatureCollection of
  * Polygons.
  *
- * Format: polyline-encoding||polyline-encoding
+ * Format: polyline-encoding;polyline-encoding
  *
- * || separates polygons
+ * ; separates polygons
  *
  */
 export function polygonUrlDecode(polygonStr: string) {
   const geojson = {
     type: 'FeatureCollection',
-    features: polygonStr.split('||').map((polygon) => {
+    features: polygonStr.split(';').map((polygon) => {
       const coords = decode(polygon);
       return {
         type: 'Feature',
@@ -37,9 +37,9 @@ export function polygonUrlDecode(polygonStr: string) {
  * Converts a FeatureCollection of Polygons into a url string.
  * Removes the last point of the polygon as it is the same as the first.
  *
- * Format: polyline-encoding||polyline-encoding
+ * Format: polyline-encoding;polyline-encoding
  *
- * || separates polygons
+ * ; separates polygons
  *
  */
 export function polygonUrlEncode(
@@ -52,5 +52,5 @@ export function polygonUrlEncode(
         .slice(0, -1);
       return encode(points);
     })
-    .join('||');
+    .join(';');
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,16 @@
+import { VEDA_OVERRIDE_THEME } from "$styles/theme";
+
+// Convert object keys to string paths.
+type PropertyStringPath<T, Prefix = ''> = {
+  [K in keyof T]: T[K] extends number | string
+    ? `${string & Prefix}${string & K}`
+    : PropertyStringPath<T[K], `${string & Prefix}${string & K}.`>;
+}[keyof T];
+
+declare module '@devseed-ui/theme-provider' {
+  type ThemeValPathExtend =
+    | ThemeValPath
+    | PropertyStringPath<typeof VEDA_OVERRIDE_THEME>;
+
+  function themeVal(path: ThemeValPathExtend): ThemeValReturn;
+}


### PR DESCRIPTION
# Problems covered by this PR
Report: https://www.dropbox.com/scl/fi/kjroygitvhc8f2kh2nhuw/Veda-Dashboard-QA-Stage-deploy-v0.6.0.paper?dl=0&rlkey=ls3fz1idxvq03hlzewfnblnnz

## Broken polygons in analysis page
We were using the double pipe `||` as a way to separate polygons in the url, however a polyline has naturally occurring double pipes, so when the polyline of a complex polgon had them, it was being broken into multiple polygons.
Replaced the separator with a semicolon `;` which is not present in the polyline.

## Overlay z-index
Updated the z-index of the dropdown and created a list of z-indices in the theme to simplify usage. Also converted the theme file to typescript which required updating the typings of `themeVal`