### PR TITLE
Ignore abort errors when loading dataset list

### DIFF
--- a/app/scripts/components/analysis/define/use-stac-search.ts
+++ b/app/scripts/components/analysis/define/use-stac-search.ts
@@ -86,7 +86,9 @@ export function useStacSearch({ start, end, aoi }: UseStacSearchProps) {
           )
         );
       } catch (error) {
-        setStacSearchStatus(S_FAILED);
+        if (!controller.signal.aborted) {
+          setStacSearchStatus(S_FAILED);
+        }
       }
     };
 

--- a/app/scripts/utils/date.ts
+++ b/app/scripts/utils/date.ts
@@ -156,7 +156,8 @@ export function dateToInputFormat(date?: Date) {
 }
 
 export function inputFormatToDate(inputFormat: string) {
-  return parse(inputFormat, 'yyyy-MM-dd', new Date());
+  const d = parse(inputFormat, 'yyyy-MM-dd', new Date());
+  return isNaN(d.getTime()) ? null : d;
 }
 
 export type DateRangePreset =


### PR DESCRIPTION
Address first comment from https://github.com/NASA-IMPACT/veda-config/pull/192#issuecomment-1416102928

The error caused by the abort controller was being caught and shown