### PR TITLE
Put y axis domain as auto

### DIFF
--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -228,7 +228,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
                 position='bottom'
               />
             </XAxis>
-            <YAxis axisLine={false} tickFormatter={(t) => getNumForChart(t)}>
+            <YAxis axisLine={false} domain={['auto', 'auto']} tickFormatter={(t) => getNumForChart(t)}>
               <Label
                 className='label-y'
                 value={yAxisLabel}


### PR DESCRIPTION
Rechart's default behavior for y-axis is setting [0, 'auto'], which is not very helpful. Explicitly declare to use auto (from rechart doc: any element of the domain is set to be 'auto', comprehensible scale ticks will be calculated, and the final domain of axis is generated by the ticks). 