### PR TITLE
[Proof of concept] Dataset search

### DIFF
--- a/app/scripts/components/common/card.tsx
+++ b/app/scripts/components/common/card.tsx
@@ -214,12 +214,12 @@ const CardFigure = styled(Figure)`
 `;
 
 interface CardComponentProps {
-  title: string;
+  title: React.ReactNode;
   linkLabel: string;
   linkTo: string;
   className?: string;
   cardType?: CardType;
-  description?: string;
+  description?: React.ReactNode;
   date?: Date;
   overline?: React.ReactNode;
   imgSrc?: string;

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -14,6 +14,8 @@ import SandboxDateslider from './dateslider';
 import SandboxChart from './mdx-chart';
 import SandboxAnalysisChart from './analysis-chart';
 import SandboxRequest from './request';
+import SandboxSearch from './search';
+
 import { resourceNotFound } from '$components/uhoh';
 import { Card, CardList } from '$components/common/card';
 import { Fold, FoldHeader, FoldTitle } from '$components/common/fold';
@@ -86,6 +88,11 @@ const pages = [
     id: 'request',
     name: 'Requests',
     component: SandboxRequest
+  },
+  {
+    id: 'search',
+    name: 'Search',
+    component: SandboxSearch
   }
 ];
 

--- a/app/scripts/components/sandbox/search/index.tsx
+++ b/app/scripts/components/sandbox/search/index.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Form, FormInput } from '@devseed-ui/form';
+import { glsp } from '@devseed-ui/theme-provider';
+import { datasets } from 'veda/thematics';
+
+import TextHighlight from './text-highlight';
+
+import { Fold } from '$components/common/fold';
+import { Card, CardList } from '$components/common/card';
+
+const Wrapper = styled.div`
+  position: relative;
+  grid-column: 1 / -1;
+  display: flex;
+  flex-flow: column;
+  gap: ${glsp(2)};
+`;
+
+function findDatasets(val) {
+  if (val?.length < 3) return null;
+
+  return Object.values(datasets)
+    .filter(
+      (d) =>
+        d && (d.data.name.includes(val) || d.data.description.includes(val))
+    )
+    .map((d) => d!.data);
+}
+
+function SandboxSearch() {
+  const [searchVal, setSearchVal] = useState('');
+
+  const foundDatasets = findDatasets(searchVal);
+
+  return (
+    <Fold>
+      <Wrapper>
+        <Form>
+          <label htmlFor='dataset-search-input'>Search Datasets</label>
+          <FormInput
+            id='dataset-search-input'
+            type='text'
+            onChange={(e) => setSearchVal(e.target.value)}
+            value={searchVal}
+            placeholder='Start typing...'
+          />
+        </Form>
+        {foundDatasets &&
+          (foundDatasets.length ? (
+            <CardList>
+              {foundDatasets.map((d) => (
+                <li key={d.id}>
+                  <Card
+                    cardType='cover'
+                    linkLabel='View more'
+                    linkTo={d.id}
+                    title={
+                      <TextHighlight value={searchVal}>{d.name}</TextHighlight>
+                    }
+                    parentName='Dataset'
+                    description={
+                      <TextHighlight value={searchVal}>
+                        {d.description}
+                      </TextHighlight>
+                    }
+                    imgSrc={d.media?.src}
+                    imgAlt={d.media?.alt}
+                  />
+                </li>
+              ))}
+            </CardList>
+          ) : (
+            <p>No datasets match the search criteria</p>
+          ))}
+      </Wrapper>
+    </Fold>
+  );
+}
+
+export default SandboxSearch;

--- a/app/scripts/components/sandbox/search/index.tsx
+++ b/app/scripts/components/sandbox/search/index.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Form, FormInput } from '@devseed-ui/form';
+import { uniq } from 'lodash';
+import {
+  Form,
+  FormCheckable,
+  FormCheckableGroup,
+  FormInput
+} from '@devseed-ui/form';
 import { glsp } from '@devseed-ui/theme-provider';
 import { datasets } from 'veda/thematics';
 
@@ -17,21 +23,58 @@ const Wrapper = styled.div`
   gap: ${glsp(2)};
 `;
 
-function findDatasets(val) {
-  if (val?.length < 3) return null;
-
-  return Object.values(datasets)
-    .filter(
-      (d) =>
-        d && (d.data.name.includes(val) || d.data.description.includes(val))
+const colormapOptions = uniq(
+  Object.values(datasets)
+    .flatMap((d) =>
+      d?.data.layers.flatMap((l) => l.sourceParams?.colormap_name)
     )
-    .map((d) => d!.data);
+    .filter(Boolean)
+);
+
+function toggleArrayVal(array, val) {
+  return array.includes(val)
+    ? array.filter((v) => v !== val)
+    : array.concat(val);
+}
+
+function findDatasets({ search, hasCompare, colormaps }) {
+  let filtered = Object.values(datasets).map((d) => d!.data);
+
+  // Does the free text search appear in specific fields?
+  if (search?.length >= 3) {
+    filtered = filtered.filter(
+      (d) =>
+        d.name.includes(search) ||
+        d.description.includes(search) ||
+        d.layers.some((l) => l.stacCol.includes(search))
+    );
+  }
+
+  if (hasCompare) {
+    // Does any layer have a compare?
+    filtered = filtered.filter((d) => d.layers.some((l) => !!l.compare));
+  }
+
+  if (colormaps.length) {
+    // Does any layer have a matching colormap?
+    filtered = filtered.filter((d) =>
+      d.layers.some((l) => colormaps.includes(l.sourceParams?.colormap_name))
+    );
+  }
+
+  return filtered;
 }
 
 function SandboxSearch() {
   const [searchVal, setSearchVal] = useState('');
+  const [hasCompare, setHasCompare] = useState(false);
+  const [colormaps, setColormaps] = useState<string[]>([]);
 
-  const foundDatasets = findDatasets(searchVal);
+  const foundDatasets = findDatasets({
+    search: searchVal,
+    hasCompare,
+    colormaps
+  });
 
   return (
     <Fold>
@@ -46,33 +89,71 @@ function SandboxSearch() {
             placeholder='Start typing...'
           />
         </Form>
-        {foundDatasets &&
-          (foundDatasets.length ? (
-            <CardList>
-              {foundDatasets.map((d) => (
-                <li key={d.id}>
-                  <Card
-                    cardType='cover'
-                    linkLabel='View more'
-                    linkTo={d.id}
-                    title={
-                      <TextHighlight value={searchVal}>{d.name}</TextHighlight>
-                    }
-                    parentName='Dataset'
-                    description={
-                      <TextHighlight value={searchVal}>
-                        {d.description}
-                      </TextHighlight>
-                    }
-                    imgSrc={d.media?.src}
-                    imgAlt={d.media?.alt}
-                  />
-                </li>
-              ))}
-            </CardList>
-          ) : (
-            <p>No datasets match the search criteria</p>
-          ))}
+        <div>
+          <FormCheckable
+            type='checkbox'
+            name='has-compare'
+            id='has-compare'
+            value='has-compare'
+            checked={hasCompare}
+            onChange={() => setHasCompare((v) => !v)}
+          >
+            Has compare layer
+          </FormCheckable>
+        </div>
+        <div>
+          <label>Colormap</label>
+          <FormCheckableGroup>
+            {colormapOptions.map((t) => (
+              <FormCheckable
+                key={t}
+                type='checkbox'
+                name={t}
+                id={t}
+                value={t}
+                checked={colormaps.includes(t)}
+                onChange={() => setColormaps(toggleArrayVal(colormaps, t))}
+              >
+                {t}
+              </FormCheckable>
+            ))}
+          </FormCheckableGroup>
+        </div>
+        <h2>Results</h2>
+        {foundDatasets.length ? (
+          <CardList>
+            {foundDatasets.map((d) => (
+              <li key={d.id}>
+                <Card
+                  cardType='cover'
+                  linkLabel='View more'
+                  linkTo={d.id}
+                  title={
+                    <TextHighlight
+                      value={searchVal}
+                      disabled={searchVal.length < 3}
+                    >
+                      {d.name}
+                    </TextHighlight>
+                  }
+                  parentName='Dataset'
+                  description={
+                    <TextHighlight
+                      value={searchVal}
+                      disabled={searchVal.length < 3}
+                    >
+                      {d.description}
+                    </TextHighlight>
+                  }
+                  imgSrc={d.media?.src}
+                  imgAlt={d.media?.alt}
+                />
+              </li>
+            ))}
+          </CardList>
+        ) : (
+          <p>No datasets match the search criteria</p>
+        )}
       </Wrapper>
     </Fold>
   );

--- a/app/scripts/components/sandbox/search/text-highlight.tsx
+++ b/app/scripts/components/sandbox/search/text-highlight.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import styled from 'styled-components';
+import { themeVal } from '@devseed-ui/theme-provider';
+
+const SearchHighlight = styled.mark`
+  font-style: italic;
+  background-color: ${themeVal('color.warning')};
+`;
+
+interface TextHighlightProps {
+  children: string;
+  value?: string;
+  highlightEl?: React.ComponentType | keyof JSX.IntrinsicElements;
+  disabled?: boolean;
+}
+
+export default function TextHighlight(props: TextHighlightProps) {
+  const { children, value, highlightEl, disabled } = props;
+
+  if (!value || disabled) return <>{children}</>;
+  const El = highlightEl ?? SearchHighlight;
+
+  // Highlight is done index based because it has to take case insensitive
+  // searches into account.
+  const regex = new RegExp(value, 'ig');
+  /* eslint-disable-next-line prefer-const */
+  let highlighted: React.ReactNode[] = [];
+  let workingIdx = 0;
+  let m;
+  /* eslint-disable-next-line no-cond-assign */
+  while ((m = regex.exec(children)) !== null) {
+    // Prevent infinite loops with zero-width matches.
+    if (m.index === regex.lastIndex) regex.lastIndex++;
+
+    // Store string since last match.
+    highlighted = highlighted.concat(children.substring(workingIdx, m.index));
+    // Highlight word.
+    highlighted = highlighted.concat(
+      <El key={m.index}>
+        {children.substring(m.index, m.index + value.length)}
+      </El>
+    );
+    // Move index forward.
+    workingIdx = m.index + value.length;
+  }
+  // Add last piece. From working index to the end.
+  highlighted = highlighted.concat(children.substring(workingIdx));
+
+  return <>{highlighted}</>;
+}


### PR DESCRIPTION
Contributes to #465.
View sandbox page at https://deploy-preview-475--veda-ui.netlify.app/sandbox/search

Search datasets by checking the name and the dataset description.
Currently the `veda/thematics` module exports a list of all datasets with their properties so it is very easy to perform a search on these properties. The dataset long form content is not loaded and therefore not searchable. It will not be possible to search this content efficiently without using a 3rd party search service (see [ADR](https://github.com/NASA-IMPACT/veda-ui/blob/main/docs/adr/001-dashboard-v1-catalog-explore.md)).

The list exported by `veda/thematics` is used to render the datasets throughout the app. As the number of datasets increases this list may become too heavy. Some sort of pagination will need to be implemented and that will impact the search. I'm not sure what the threshold for this is, but we need to conduct some tests.

cc @michaelgsuttles @nerik @hanbyul-here 