### PR TITLE
Do not fit boundaries if there is a user defined zoom and center (Block Map) 

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -164,7 +164,7 @@ function MapBlock(props: MapBlockProps) {
         isComparing={!!selectedCompareDatetime}
         compareDate={selectedCompareDatetime}
         compareLabel={compareLabel}
-        initialPosition={{ lng: center?.[0], lat: center?.[1], zoom }}
+        initialPosition={{ lng: center?.[0], lat: center?.[1], zoom, userDefined: !!(center && zoom) }}
         cooperativeGestures
         projection={projection}
         onProjectionChange={allowProjectionChange ? setProjection : undefined}

--- a/app/scripts/components/common/blocks/index.tsx
+++ b/app/scripts/components/common/blocks/index.tsx
@@ -251,7 +251,6 @@ function BlockComponent(props: BlockComponentProps) {
     (acc, curr) => acc + curr,
     ''
   );
-
   if (![defaultBlockName, wideBlockName, fullBlockName].includes(typeName)) {
     throw new HintedError(`${blockTypeErrorMessage} '${typeName}'`, [
       `Supported block types: 'wide', 'full'`

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -302,6 +302,7 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
             stacCol={compareLayerResolvedData.stacCol}
             mapInstance={mapCompareRef.current}
             date={compareToDate}
+            userDefinedInitialPosition={initialPosition?.userDefined}
             sourceParams={compareLayerResolvedData.sourceParams}
             zoomExtent={compareLayerResolvedData.zoomExtent}
             onStatusChange={onCompareLayerStatusChange}
@@ -479,6 +480,10 @@ interface MapPosition {
   zoom: number;
 }
 
+interface BlockMapPosition extends MapPosition {
+  userDefined: boolean;
+}
+
 export interface MapboxMapProps {
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   as?: any;
@@ -491,7 +496,7 @@ export interface MapboxMapProps {
   compareLabel?: string;
   isComparing?: boolean;
   cooperativeGestures?: boolean;
-  initialPosition?: Partial<MapPosition>;
+  initialPosition?: Partial<BlockMapPosition>;
   onPositionChange?: (
     result: MapPosition & {
       userInitiated: boolean;

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -31,6 +31,7 @@ interface MapLayerRasterTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
+  userDefinedInitialPosition: boolean;
 }
 
 export interface StacFeature {
@@ -58,7 +59,8 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     sourceParams,
     zoomExtent,
     onStatusChange,
-    isHidden
+    isHidden,
+    userDefinedInitialPosition
   } = props;
 
   const theme = useTheme();
@@ -402,13 +404,13 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
   // FitBounds when needed
   //
   useEffect(() => {
-    if (!stacCollection.length) return;
+    if (!stacCollection.length || userDefinedInitialPosition) return;
     const layerBounds = getMergedBBox(stacCollection);
 
     if (checkFitBoundsFromLayer(layerBounds, mapInstance)) {
       mapInstance.fitBounds(layerBounds, { padding: FIT_BOUNDS_PADDING });
     }
-  }, [mapInstance, stacCol, stacCollection]);
+  }, [mapInstance, stacCol, stacCollection, userDefinedInitialPosition]);
 
   //
   // Visibility control for the layer and the markers.


### PR DESCRIPTION
I noticed that 'BlockMap's center, zoom props are not working as expected occasionally. I wonder if it is the race condition between the position passed as mapoptions vs. automatic boundary detection? This PR disables automatic zoom to the dataset when there is a position passed by a user. 