### PR TITLE
Improve date slider behavior and performance

### DIFF
--- a/app/scripts/components/common/dateslider/constants.ts
+++ b/app/scripts/components/common/dateslider/constants.ts
@@ -1,7 +1,14 @@
-export type DateSliderData = Array<{ date: Date; hasData: boolean }>;
+export interface DateSliderDataItem {
+  index: number;
+  date: Date;
+  hasData: boolean;
+  breakLength?: number;
+}
 
 export type DateSliderTimeDensity = 'day' | 'month' | 'year';
 
 export const DATA_POINT_WIDTH = 32;
+
+export const RANGE_PADDING = 24;
 
 export const CHART_HEIGHT = 48;

--- a/app/scripts/components/common/dateslider/date-axis.tsx
+++ b/app/scripts/components/common/dateslider/date-axis.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
-import { ScaleTime, select } from 'd3';
+import { ScaleLinear, select } from 'd3';
 import { format } from 'date-fns';
 import { themeVal } from '@devseed-ui/theme-provider';
 import { createSubtitleStyles } from '@devseed-ui/typography';
 
-import { DateSliderData, DateSliderTimeDensity } from './constants';
+import { DateSliderDataItem, DateSliderTimeDensity } from './constants';
 
 const timeFormat = {
   day: 'dd',
@@ -34,8 +34,8 @@ const StyledG = styled.g`
 `;
 
 interface DateAxisProps {
-  data: DateSliderData;
-  x: ScaleTime<number, number, never>;
+  data: DateSliderDataItem[];
+  x: ScaleLinear<number, number, never>;
   zoomXTranslation: number;
   timeDensity: DateSliderTimeDensity;
 }
@@ -49,10 +49,10 @@ export function DateAxis(props: DateAxisProps) {
 
     dateG
       .selectAll('text.date-value')
-      .data(data)
+      .data(data.filter((d) => !d.breakLength))
       .join('text')
       .attr('class', 'date-value')
-      .attr('x', (d) => x(d.date))
+      .attr('x', (d) => x(d.index))
       .attr('y', 16)
       .attr('dy', '1em')
       .attr('text-anchor', 'middle')
@@ -69,8 +69,8 @@ export function DateAxis(props: DateAxisProps) {
 }
 
 interface DateAxisParentProps {
-  data: DateSliderData;
-  x: ScaleTime<number, number, never>;
+  data: DateSliderDataItem[];
+  x: ScaleLinear<number, number, never>;
   zoomXTranslation: number;
   timeDensity: DateSliderTimeDensity;
 }
@@ -85,15 +85,16 @@ export function DateAxisParent(props: DateAxisParentProps) {
     if (timeDensity === 'year') {
       parentG.selectAll('text.date-parent-value').remove();
     } else {
-      const uniqueParent = data.reduce((acc, { date }) => {
-        const exists = acc.find((d) => {
-          return (
-            format(d, parentSearchFormat[timeDensity]) ===
-            format(date, parentSearchFormat[timeDensity])
-          );
-        });
-        return exists ? acc : acc.concat(date);
-      }, [] as Date[]);
+      const uniqueParent = data.reduce<DateSliderDataItem[]>((acc, item) => {
+        const { date } = item;
+        const formatStr = parentSearchFormat[timeDensity];
+
+        const exists = acc.find(
+          (d) => format(d.date, formatStr) === format(date, formatStr)
+        );
+
+        return exists ? acc : acc.concat(item);
+      }, []);
 
       parentG
         .selectAll('text.date-parent-value')
@@ -103,19 +104,19 @@ export function DateAxisParent(props: DateAxisParentProps) {
         .attr('y', 30)
         .attr('dy', '1em')
         .attr('text-anchor', 'middle')
-        .text((d) => format(d, parentTimeFormat[timeDensity]));
+        .text((d) => format(d.date, parentTimeFormat[timeDensity]));
     }
   }, [data, x, timeDensity]);
 
   useEffect(() => {
     select(parentGref.current)
-      .selectAll<SVGTextElement, Date>('text.date-parent-value')
+      .selectAll<SVGTextElement, DateSliderDataItem>('text.date-parent-value')
       .each((d, i, n) => {
         // Expected position of this node.
-        const expectedPosition = x(d);
+        const expectedPosition = x(d.index);
         const expectedAfterTrans = expectedPosition + zoomXTranslation;
 
-        const nextNode = n[i + 1];
+        const nextNode = n[i + 1] as SVGTextElement | undefined;
 
         let maxPos = Infinity;
         // If there's a node after this one, that node will push on this one, so
@@ -124,9 +125,10 @@ export function DateAxisParent(props: DateAxisParentProps) {
           // Width of current node.
           const { width: nextNodeW } = nextNode.getBBox();
           // Position of the next item.
-          const nextItemPos =
-            x(select<SVGTextElement, Date>(nextNode).datum()) +
-            zoomXTranslation;
+          const nextItemData = select<SVGTextElement, DateSliderDataItem>(
+            nextNode
+          ).datum();
+          const nextItemPos = x(nextItemData.index) + zoomXTranslation;
 
           maxPos = nextItemPos - nextNodeW;
         }
@@ -135,7 +137,10 @@ export function DateAxisParent(props: DateAxisParentProps) {
         // because of text anchor middle. Add 4px for spacing.
         const leftPadding = n[i].getBBox().width / 2 + 4;
 
-        const xTrans = Math.min(Math.max(expectedAfterTrans, leftPadding), maxPos);
+        const xTrans = Math.min(
+          Math.max(expectedAfterTrans, leftPadding),
+          maxPos
+        );
         select(n[i]).attr('x', xTrans);
       });
   }, [zoomXTranslation, x]);

--- a/app/scripts/components/common/dateslider/date-axis.tsx
+++ b/app/scripts/components/common/dateslider/date-axis.tsx
@@ -103,7 +103,14 @@ export function DateAxisParent(props: DateAxisParentProps) {
         .attr('class', 'date-parent-value')
         .attr('y', 30)
         .attr('dy', '1em')
-        .attr('text-anchor', 'middle')
+        .attr('text-anchor', d => {
+          const isLastElement = d.index === x.domain()[1];
+          return isLastElement ? 'end' : 'middle';
+        })
+        .attr('dx', d => {
+          const isLastElement = d.index === x.domain()[1];
+          return isLastElement ? '1em' : '';
+        })
         .text((d) => format(d.date, parentTimeFormat[timeDensity]));
     }
   }, [data, x, timeDensity]);

--- a/app/scripts/components/common/dateslider/faders.tsx
+++ b/app/scripts/components/common/dateslider/faders.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { ScaleLinear } from 'd3';
 
-import { DateSliderData } from './constants';
+import { DateSliderDataItem } from './constants';
 import { getZoomTranslateExtent } from './utils';
 
 export const MASK_ID = 'gradient-mask';
 const FADE_ID = 'fade-gradient';
 
 interface FaderDefinitionProps {
-  data: DateSliderData;
+  data: DateSliderDataItem[];
   x: ScaleLinear<number, number, never>;
   zoomXTranslation: number;
   width: number;

--- a/app/scripts/components/common/dateslider/faders.tsx
+++ b/app/scripts/components/common/dateslider/faders.tsx
@@ -1,7 +1,7 @@
-import { ScaleTime } from 'd3';
 import React from 'react';
-import { DateSliderData } from './constants';
+import { ScaleLinear } from 'd3';
 
+import { DateSliderData } from './constants';
 import { getZoomTranslateExtent } from './utils';
 
 export const MASK_ID = 'gradient-mask';
@@ -9,7 +9,7 @@ const FADE_ID = 'fade-gradient';
 
 interface FaderDefinitionProps {
   data: DateSliderData;
-  x: ScaleTime<number, number, never>;
+  x: ScaleLinear<number, number, never>;
   zoomXTranslation: number;
   width: number;
   height: number;

--- a/app/scripts/components/common/dateslider/index.tsx
+++ b/app/scripts/components/common/dateslider/index.tsx
@@ -161,7 +161,7 @@ function useRecenterSlider({ value, width, x, zoomBehavior, svgRef }) {
 
   const recenterFnRef = useRef<() => void>();
   recenterFnRef.current = () => {
-    if (!value) return;
+    if (isNaN(value)) return;
 
     select(svgRef.current)
       .select<SVGRectElement>('.trigger-rect')
@@ -180,7 +180,7 @@ function useRecenterSlider({ value, width, x, zoomBehavior, svgRef }) {
 
   useEffectPrevious(
     (deps, mounted) => {
-      if (!value || !mounted) return;
+      if (isNaN(value) || !mounted) return;
 
       // No animation if reduce motion.
       if (reduceMotion) {

--- a/app/scripts/components/common/dateslider/index.tsx
+++ b/app/scripts/components/common/dateslider/index.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { debounce } from 'lodash';
-import { scaleLinear, select, zoom } from 'd3';
+import { interpolate, scaleLinear, select, zoom } from 'd3';
 import { themeVal } from '@devseed-ui/theme-provider';
 
 import { findDate, getZoomTranslateExtent, useChartDimensions } from './utils';
@@ -58,6 +58,8 @@ export default function DateSliderControl(props: DateSliderControlProps) {
     () =>
       zoom<SVGRectElement, unknown>()
         .translateExtent(getZoomTranslateExtent(data, x))
+        // Remove the zoom interpolation so it doesn't zoom back and forth.
+        .interpolate(interpolate)
         .on('zoom', (event) => {
           setZoomXTranslation(event.transform.x);
         }),
@@ -161,11 +163,11 @@ function useRecenterSlider({ value, width, x, zoomBehavior, svgRef }) {
   recenterFnRef.current = () => {
     if (!value) return;
 
-    const triggerRect = select(svgRef.current)
+    select(svgRef.current)
       .select<SVGRectElement>('.trigger-rect')
       .transition()
-      .duration(500);
-    zoomBehavior.translateTo(triggerRect, x(value), 0);
+      .duration(500)
+      .call(zoomBehavior.translateTo, x(value), 0);
   };
 
   const debouncedRecenter = useMemo(

--- a/app/scripts/components/common/dateslider/index.tsx
+++ b/app/scripts/components/common/dateslider/index.tsx
@@ -80,16 +80,16 @@ export default function DateSliderControl(props: DateSliderControlProps) {
   // horizontal drag window into account.
   const minX = zoomXTranslation * -1;
   const maxX = width - zoomXTranslation;
-  // Using the scale, get the indexes of the data that would be rendered.
-  const indexes = [
+  // Using the scale, get the indices of the data that would be rendered.
+  const indices = [
     Math.max(Math.floor(x.invert(minX)), 0),
     // Add one to account for when there's a single data point.
     Math.ceil(x.invert(maxX)) + 1
   ];
 
   const dataToRender = useMemo(
-    () => data.slice(...indexes),
-    [data, ...indexes]
+    () => data.slice(...indices),
+    [data, ...indices]
   );
 
   // Recenter the slider to the selected date when data changes or when the

--- a/app/scripts/components/common/dateslider/trigger-rect.tsx
+++ b/app/scripts/components/common/dateslider/trigger-rect.tsx
@@ -1,28 +1,28 @@
 import React, { useEffect, useMemo, useRef } from 'react';
-import { ScaleTime, select, ZoomBehavior } from 'd3';
+import { ScaleLinear, select, ZoomBehavior } from 'd3';
 
-import { DateSliderData } from './constants';
+import { DateSliderDataItem } from './constants';
 
-type TriggerRectProps = {
+interface TriggerRectProps {
   onDataOverOut: (result: { hover: boolean; date: Date | null }) => void;
   onDataClick: (result: { date: Date }) => void;
-  data: DateSliderData;
-  x: ScaleTime<number, number, never>;
+  data: DateSliderDataItem[];
+  x: ScaleLinear<number, number, never>;
   zoomXTranslation: number;
   width: number;
   height: number;
   zoomBehavior: ZoomBehavior<SVGRectElement, unknown>;
-};
+}
 
-type Point = {
+interface Point {
   x: number;
   y: number;
-};
+}
 
-type HotZone = Point & {
+interface HotZone extends Point {
   date: Date;
   radius: number;
-};
+}
 
 function dist(p1: Point, p2: Point) {
   return Math.sqrt(Math.pow(p2.x - p1.x, 2) + Math.pow(p2.y - p1.y, 2));
@@ -57,7 +57,7 @@ export default function TriggerRect(props: TriggerRectProps) {
     const dataList = data.filter((d) => d.hasData);
     return dataList.map<HotZone>((d) => ({
       date: d.date,
-      x: x(d.date) + zoomXTranslation,
+      x: x(d.index) + zoomXTranslation,
       y: 12,
       radius: 8
     }));

--- a/app/scripts/components/common/dateslider/trigger-rect.tsx
+++ b/app/scripts/components/common/dateslider/trigger-rect.tsx
@@ -67,7 +67,10 @@ export default function TriggerRect(props: TriggerRectProps) {
     select(elRef.current)
       .call(zoomBehavior)
       .on('dblclick.zoom', null)
-      .on('wheel.zoom', null);
+      .on('wheel.zoom', (event) => {
+        event.preventDefault();
+        zoomBehavior.translateBy(select(event.target), event.wheelDelta, 0);
+      });
   }, [zoomBehavior, x]);
 
   useEffect(() => {

--- a/app/scripts/components/common/dateslider/utils.tsx
+++ b/app/scripts/components/common/dateslider/utils.tsx
@@ -7,7 +7,11 @@ import {
   format
 } from 'date-fns';
 
-import { CHART_HEIGHT, DateSliderTimeDensity } from './constants';
+import {
+  CHART_HEIGHT,
+  DateSliderDataItem,
+  DateSliderTimeDensity
+} from './constants';
 
 const margin = { top: 0, right: 0, bottom: 0, left: 0 };
 
@@ -29,23 +33,45 @@ export function useChartDimensions() {
   };
 }
 
-export function prepareDates(
+const dateFormatByTimeDensity = {
+  day: 'yyyy-MM-dd',
+  month: 'yyyy-MM',
+  year: 'yyyy'
+};
+
+/**
+ * Creates and array of date entries based on the extent of the provided list of
+ * dates, and the time density.
+ * For example, if the time density is month it will return a list of monthly
+ * dates between the min and max of the given list.
+ * For each date in the extent interval we check if there is data for that date.
+ * If there is we set the `hasData` property to true and continue. If there is
+ * no data, we start grouping the dates with no data.
+ * - If the group exceeds the threshold we group them in an entry with 'hasData'
+ *   set to false and 'breakLength' set to the length of the group.
+ * - If it doesn't exceed we keep all dates with 'hasData' set to false.
+ *
+ * The resulting array of objects has an 'index' property added to each object,
+ * starting from 0 which is needed to correctly position the elements after a
+ * .filter operation where we can no longer rely on the array index.
+ *
+ * @param dates List of dates that have data
+ * @param timeDensity Time density of the dates. One of day | month | year
+ * @returns Data for the date slider
+ */
+export function prepareDateSliderData(
   dates: Date[],
-  timeDensityity: DateSliderTimeDensity
+  timeDensity: DateSliderTimeDensity
 ) {
   const domain = extent<Date, Date>(dates, (d) => d) as Date[];
 
-  const dateFormat = {
-    day: 'yyyy-MM-dd',
-    month: 'yyyy-MM',
-    year: 'yyyy'
-  }[timeDensityity];
+  const dateFormat = dateFormatByTimeDensity[timeDensity];
 
   const intervalFn = {
     day: eachDayOfInterval,
     month: eachMonthOfInterval,
     year: eachYearOfInterval
-  }[timeDensityity];
+  }[timeDensity];
 
   const searchStrs = dates.map((d) => format(d, dateFormat));
 
@@ -54,10 +80,38 @@ export function prepareDates(
     end: domain.last
   });
 
-  return allDates.map((d) => ({
-    date: d,
-    hasData: searchStrs.includes(format(d, dateFormat))
-  }));
+  let data: Omit<DateSliderDataItem, 'index'>[] = [];
+  let noDataGroup: Omit<DateSliderDataItem, 'index'>[] = [];
+
+  for (const date of allDates) {
+    const hasData = searchStrs.includes(format(date, dateFormat));
+
+    if (!hasData) {
+      noDataGroup = noDataGroup.concat({ date, hasData });
+    } else {
+      // If we find a date with data and it has been less than 20 entries
+      // without data we keep them all.
+      if (noDataGroup.length < 20) {
+        data = data.concat(noDataGroup, { date, hasData });
+      } else {
+        // Otherwise we add a break group with the first date that doesn't have
+        // data and store how many timesteps don't have data (breakLength)
+        data = data.concat(
+          {
+            date: noDataGroup[0].date,
+            hasData: false,
+            breakLength: noDataGroup.length
+          },
+          { date, hasData }
+        );
+      }
+      noDataGroup = [];
+    }
+  }
+
+  // Add an index property which is needed to correctly position the elements
+  // after a .filter operation where we can no longer rely on the array index.
+  return data.map<DateSliderDataItem>((d, i) => ({ ...d, index: i }));
 }
 
 export function getZoomTranslateExtent(
@@ -66,9 +120,24 @@ export function getZoomTranslateExtent(
 ): [[number, number], [number, number]] {
   // The translation extent should always at least encompass the full chart.
   // This handle problems coming from having only 1 data point.
-  const end = Math.max(xScale(data.last.date), xScale.range()[1]);
+  const end = Math.max(xScale(data.last.index), xScale.range()[1]);
   return [
     [0, 0],
     [end + 16, 0]
   ];
+}
+
+export function findDate(
+  data: DateSliderDataItem[],
+  date: Date | undefined | null,
+  timeDensity: DateSliderTimeDensity
+) {
+  if (!date) return undefined;
+
+  const dateFormat = dateFormatByTimeDensity[timeDensity];
+  const item = data.find(
+    (d) => format(d.date, dateFormat) === format(date, dateFormat)
+  );
+
+  return item;
 }

--- a/app/scripts/components/datasets/s-explore/panel-date-widget.tsx
+++ b/app/scripts/components/datasets/s-explore/panel-date-widget.tsx
@@ -25,7 +25,7 @@ import {
 import { TimeDensity } from '$context/layer-data';
 import { mod } from '$utils/utils';
 import DateSliderControl from '$components/common/dateslider';
-import { prepareDates } from '$components/common/dateslider/utils';
+import { prepareDateSliderData } from '$components/common/dateslider/utils';
 
 function getDatePickerView(timeDensity?: TimeDensity) {
   const view = {
@@ -82,7 +82,7 @@ export function PanelDateWidget(props: PanelDateWidgetProps) {
   const dateSliderDates = useMemo(
     () =>
       availableDates && timeDensity
-        ? prepareDates(availableDates, timeDensity)
+        ? prepareDateSliderData(availableDates, timeDensity)
         : null,
     [availableDates, timeDensity]
   );

--- a/app/scripts/components/sandbox/dateslider/index.js
+++ b/app/scripts/components/sandbox/dateslider/index.js
@@ -12,7 +12,7 @@ import Constrainer from '$styles/constrainer';
 import { mod } from '$utils/utils';
 import { PageMainContent } from '$styles/page';
 import DateSliderControl from '$components/common/dateslider';
-import { prepareDates } from '$components/common/dateslider/utils';
+import { prepareDateSliderData } from '$components/common/dateslider/utils';
 import { utcString2userTzDate } from '$utils/date';
 
 const Wrapper = styled.div`
@@ -40,9 +40,9 @@ const dates = [
   utcString2userTzDate('2022-12-01'),
   utcString2userTzDate('2023-05-01')
 ];
-const readyDatesD = prepareDates(dates, 'day');
-const readyDatesM = prepareDates(dates, 'month');
-const readyDatesY = prepareDates(dates, 'year');
+const readyDatesD = prepareDateSliderData(dates, 'day');
+const readyDatesM = prepareDateSliderData(dates, 'month');
+const readyDatesY = prepareDateSliderData(dates, 'year');
 
 function SandboxTimeseries() {
   const [activeDate, setActiveDate] = useState({
@@ -126,7 +126,7 @@ function SandboxTimeseries() {
               value={readyDatesY[0].date}
               timeDensity='year'
               onChange={() => {
-                /* no-op */
+                // no-op
               }}
             />
           </Box>


### PR DESCRIPTION
Related to #504

The behavior and performance improvement was achieved in essentially 2 ways:
- Only render the elements that are within the viewport extent (with some margin). This results in having little dom nodes, even on datasets with 7000+ timesteps.
- Add data breaks when there are 20 consecutive timesteps with no data.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1090606/231705724-56b224ca-e255-4774-95fc-81ecccfebbca.png">


@karitotp Can you run some tests to ensure this works properly?

cc @faustoperez @ricardoduplos Quick visual check?