### PR TITLE
Add suffix props for RasterTimeseries component 

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -358,42 +358,6 @@ function Scrollytelling(props) {
   return (
     <ScrollyMapWrapper>
       <TheMap topOffset={topOffset}>
-        <Styles>
-          <Basemap />
-          {isMapLoaded &&
-            resolvedLayers.map((resolvedLayer) => {
-              if (!resolvedLayer) return null;
-
-              const { runtimeData, Component: LayerCmp, layer } = resolvedLayer;
-
-              if (!LayerCmp) return null;
-
-              // Each layer type is added to the map through a component. This
-              // component has all the logic needed to add/update/remove the
-              // layer. Which component to use will depend on the characteristics
-              // of the layer and dataset.
-              // The function getLayerComponent() should be used to get the
-              // correct component.
-              return (
-                <LayerCmp
-                  key={runtimeData.id}
-                  id={runtimeData.id}
-                  mapInstance={mapRef.current}
-                  stacCol={layer.stacCol}
-                  date={runtimeData.datetime}
-                  sourceParams={layer.sourceParams}
-                  zoomExtent={layer.zoomExtent}
-                  onStatusChange={onLayerLoadSuccess}
-                  isHidden={
-                    !activeChapterLayerId ||
-                    activeChapterLayerId !== runtimeData.id ||
-                    activeChapter.showBaseMap
-                  }
-                />
-              );
-            })}
-        </Styles>
-
         {areLayersLoading && <MapLoading />}
 
         {/*
@@ -451,10 +415,13 @@ function Scrollytelling(props) {
         <Styles>
           <Basemap />
           {isMapLoaded &&
-            resolvedLayers.map((resolvedLayer) => {
+            resolvedLayers.map((resolvedLayer, lIdx) => {
               if (!resolvedLayer) return null;
 
               const { runtimeData, Component: LayerCmp, layer } = resolvedLayer;
+              const isHidden = (!activeChapterLayerId ||
+              activeChapterLayerId !== runtimeData.id ||
+              activeChapter.showBaseMap);
 
               if (!LayerCmp) return null;
 
@@ -474,11 +441,8 @@ function Scrollytelling(props) {
                   sourceParams={layer.sourceParams}
                   zoomExtent={layer.zoomExtent}
                   onStatusChange={onLayerLoadSuccess}
-                  isHidden={
-                    !activeChapterLayerId ||
-                    activeChapterLayerId !== runtimeData.id ||
-                    activeChapter.showBaseMap
-                  }
+                  suffix={'scrolly-'+ lIdx}
+                  isHidden={isHidden}
                 />
               );
             })}

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -179,7 +179,7 @@ function useMapLayersFromChapters(chList: ScrollyChapter[]) {
   const resolvedLayers = useMemo(
     () =>
       asyncLayers.map(({ baseLayer }, index) => {
-        if (baseLayer?.status !== S_SUCCEEDED || !baseLayer.data) return null;
+        if (baseLayer.status !== S_SUCCEEDED || !baseLayer.data) return null;
 
         if (resolvedLayersCache.current[index]) {
           return resolvedLayersCache.current[index];
@@ -217,7 +217,7 @@ function useMapLayersFromChapters(chList: ScrollyChapter[]) {
   );
 
   const resolvedStatus = useMemo(
-    () => asyncLayers.map(({ baseLayer }) => baseLayer?.status),
+    () => asyncLayers.map(({ baseLayer }) => baseLayer.status),
     [asyncLayers]
   );
 
@@ -383,8 +383,8 @@ function Scrollytelling(props) {
         >
           {activeChapterLayer?.runtimeData.datetime
             ? formatSingleDate(
-                activeChapterLayer?.runtimeData.datetime,
-                activeChapterLayer?.layer.timeseries.timeDensity
+                activeChapterLayer.runtimeData.datetime,
+                activeChapterLayer.layer.timeseries.timeDensity
               )
             : null}
         </MapMessage>
@@ -441,7 +441,7 @@ function Scrollytelling(props) {
                   sourceParams={layer.sourceParams}
                   zoomExtent={layer.zoomExtent}
                   onStatusChange={onLayerLoadSuccess}
-                  suffix={'scrolly-'+ lIdx}
+                  idSuffix={'scrolly-'+ lIdx}
                   isHidden={isHidden}
                 />
               );

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -45,7 +45,7 @@ interface MapLayerRasterTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
-  suffix?: string
+  idSuffix?: string
 }
 
 export interface StacFeature {
@@ -74,13 +74,14 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     zoomExtent,
     onStatusChange,
     isHidden,
-    suffix = ''
+    idSuffix = ''
   } = props;
 
   const theme = useTheme();
   const { updateStyle } = useMapStyle();
 
   const minZoom = zoomExtent?.[0] ?? 0;
+  const generatorId = 'raster-timeseries' + idSuffix;
 
   // Status tracking.
   // A raster timeseries layer has a base layer and may have markers.
@@ -406,7 +407,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       }
 
       updateStyle({
-        generatorId: 'raster-timeseries' + suffix,
+        generatorId,
         sources,
         layers
       });
@@ -420,7 +421,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       points,
       haveSourceParamsChanged,
       isHidden,
-      suffix
+      generatorId
     ]
   );
 
@@ -430,12 +431,12 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
   useEffect(() => {
     return () => {
       updateStyle({
-        generatorId: 'raster-timeseries' + suffix,
+        generatorId,
         sources: {},
         layers: []
       });
     };
-  }, [updateStyle, suffix]);
+  }, [updateStyle, generatorId]);
 
   //
   // Listen to mouse events on the markers layer

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -435,7 +435,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         layers: []
       });
     };
-  }, [updateStyle]);
+  }, [updateStyle, suffix]);
 
   //
   // Listen to mouse events on the markers layer

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -430,7 +430,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
   useEffect(() => {
     return () => {
       updateStyle({
-        generatorId: 'raster-timeseries',
+        generatorId: 'raster-timeseries' + suffix,
         sources: {},
         layers: []
       });

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -45,6 +45,7 @@ interface MapLayerRasterTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
+  suffix?: string
 }
 
 export interface StacFeature {
@@ -72,7 +73,8 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     sourceParams,
     zoomExtent,
     onStatusChange,
-    isHidden
+    isHidden,
+    suffix = ''
   } = props;
 
   const theme = useTheme();
@@ -404,7 +406,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       }
 
       updateStyle({
-        generatorId: 'raster-timeseries',
+        generatorId: 'raster-timeseries' + suffix,
         sources,
         layers
       });
@@ -417,7 +419,8 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       minZoom,
       points,
       haveSourceParamsChanged,
-      isHidden
+      isHidden,
+      suffix
     ]
   );
 

--- a/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
@@ -28,6 +28,7 @@ interface MapLayerVectorTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
+  idSuffix?: string;
 }
 
 export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
@@ -39,7 +40,8 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
     sourceParams,
     zoomExtent,
     onStatusChange,
-    isHidden
+    isHidden,
+    idSuffix = ''
   } = props;
 
   const theme = useTheme();
@@ -47,6 +49,8 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
   const [featuresApiEndpoint, setFeaturesApiEndpoint] = useState('');
 
   const [minZoom, maxZoom] = zoomExtent ?? [0, 20];
+
+  const generatorId = 'vector-timeseries' + idSuffix;
 
   //
   // Get the tiles url
@@ -204,7 +208,7 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
     ].filter(Boolean) as AnyLayer[];
 
     updateStyle({
-      generatorId: 'vector-timeseries',
+      generatorId,
       sources,
       layers
     });
@@ -219,7 +223,8 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
     minZoom,
     maxZoom,
     isHidden,
-    haveSourceParamsChanged
+    haveSourceParamsChanged,
+    generatorId
   ]);
 
   //
@@ -228,12 +233,12 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
   useEffect(() => {
     return () => {
       updateStyle({
-        generatorId: 'vector-timeseries',
+        generatorId,
         sources: {},
         layers: []
       });
     };
-  }, [updateStyle]);
+  }, [updateStyle, generatorId]);
 
   //
   // Listen to mouse events on the markers layer


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/veda-ui/issues/542

This PR is a quick fix to add suffixes to rastetimeseris component for Scrollymap component. We would need a way of generating unique IDs if we are moving forward in the direction of displaying multiple layers simultaneously in the future. I feel like that is an overengineering at this moment so here is a quick fix. 