### PR TITLE
Put two legends when compare layer is not the same with the base layer

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -34,7 +34,7 @@ import { S_FAILED, S_SUCCEEDED } from '$utils/status';
 
 import { SimpleMap } from '$components/common/mapbox/map';
 import Hug from '$styles/hug';
-import LayerLegendContainer from '$components/common/mapbox/layer-legend';
+import LayerLegendContainer, { LayerLegend } from '$components/common/mapbox/layer-legend';
 import MapMessage from '$components/common/mapbox/map-message';
 import { MapLoading } from '$components/common/loading-skeleton';
 import { HintedError } from '$utils/hinted-error';
@@ -402,14 +402,14 @@ function Scrollytelling(props) {
               }}
               classNames='reveal'
             >
-            <LayerLegendContainer
-              layers={[{
-                id:`base-${activeChapterLayer.layer.id}`,
-                description: activeChapterLayer.layer.description, 
-                title: activeChapterLayer.layer.name, 
-                ...activeChapterLayer.layer.legend}
-              ]}
-            />
+            <LayerLegendContainer key={activeChapterLayer.layer.name}>
+              <LayerLegend       
+                  id={`base-${activeChapterLayer.layer.id}`}
+                  description={activeChapterLayer.layer.description}
+                  title={activeChapterLayer.layer.name}
+                  {...activeChapterLayer.layer.legend}
+              />
+            </LayerLegendContainer>
             </CSSTransition>
           </SwitchTransition>
         )}

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -34,7 +34,8 @@ import { S_FAILED, S_SUCCEEDED } from '$utils/status';
 
 import { SimpleMap } from '$components/common/mapbox/map';
 import Hug from '$styles/hug';
-import LayerLegendContainer, {
+import {
+  LayerLegendContainer,
   LayerLegend
 } from '$components/common/mapbox/layer-legend';
 import MapMessage from '$components/common/mapbox/map-message';

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -67,6 +67,9 @@ const TheMap = styled.div<{ topOffset: number }>`
     top: ${topOffset}px;
     height: calc(100vh - ${topOffset}px);
   `}
+  .mapboxgl-canvas {
+    height: 100%;
+  }
 `;
 
 const TheChapters = styled(Hug)`
@@ -465,7 +468,11 @@ function Scrollytelling(props) {
             className='root'
             mapRef={mapRef}
             containerRef={mapContainer}
-            onLoad={() => setMapLoaded(true)}
+            onLoad={() => {
+              setMapLoaded(true);
+              // Fit the map to the container once  loaded.
+              mapRef.current?.resize();
+            }}
             mapOptions={mapOptions}
           />
         </Styles>

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -34,7 +34,7 @@ import { S_FAILED, S_SUCCEEDED } from '$utils/status';
 
 import { SimpleMap } from '$components/common/mapbox/map';
 import Hug from '$styles/hug';
-import LayerLegend from '$components/common/mapbox/layer-legend';
+import LayerLegendContainer from '$components/common/mapbox/layer-legend';
 import MapMessage from '$components/common/mapbox/map-message';
 import { MapLoading } from '$components/common/loading-skeleton';
 import { HintedError } from '$utils/hinted-error';
@@ -402,12 +402,14 @@ function Scrollytelling(props) {
               }}
               classNames='reveal'
             >
-              <LayerLegend
-                id={`base-${activeChapterLayer.layer.id}`}
-                description={activeChapterLayer.layer.description}
-                title={activeChapterLayer.layer.name}
-                {...activeChapterLayer.layer.legend}
-              />
+            <LayerLegendContainer
+              layers={[{
+                id:`base-${activeChapterLayer.layer.id}`,
+                description: activeChapterLayer.layer.description, 
+                title: activeChapterLayer.layer.name, 
+                ...activeChapterLayer.layer.legend}
+              ]}
+            />
             </CSSTransition>
           </SwitchTransition>
         )}

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -28,7 +28,7 @@ import { AoiChangeListenerOverload, AoiState } from '../aoi/types';
 import { getLayerComponent, resolveConfigFunctions } from './layers/utils';
 import { SimpleMap } from './map';
 import MapMessage from './map-message';
-import LayerLegendContainer from './layer-legend';
+import LayerLegendContainer, {LayerLegend} from './layer-legend';
 import { useBasemap } from './map-options/use-basemap';
 import { DEFAULT_MAP_STYLE_URL } from './map-options/basemaps';
 import { Styles } from './layers/styles';
@@ -365,20 +365,22 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
         Layer legend for the active layer.
       */}
       {baseLayerResolvedData?.legend && (
-        <LayerLegendContainer
-          layers={[{
-            id: `base-${baseLayerResolvedData.id}`,
-            title: baseLayerResolvedData.name,
-            description: baseLayerResolvedData.description,
-            ...baseLayerResolvedData.legend },
-            ...compareLayerResolvedData?.legend?[{
-              id:`compare-${compareLayerResolvedData.id}`,
-              title:compareLayerResolvedData.name,
-              description:compareLayerResolvedData.description,
-              ...compareLayerResolvedData.legend
-            }]: []
-          ]}
-        />)}
+        <LayerLegendContainer>
+          <LayerLegend
+            id={`base-${baseLayerResolvedData.id}`}
+            title={baseLayerResolvedData.name}
+            description={baseLayerResolvedData.description}
+            {...baseLayerResolvedData.legend}
+          /> 
+          {compareLayerResolvedData?.legend &&
+                    <LayerLegend
+                    id={`compare-${compareLayerResolvedData.id}`}
+                    title={compareLayerResolvedData.name}
+                    description={compareLayerResolvedData.description}
+                    {...compareLayerResolvedData.legend}
+                    />}
+        </LayerLegendContainer>
+          )}
       
 
 

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -28,7 +28,7 @@ import { AoiChangeListenerOverload, AoiState } from '../aoi/types';
 import { getLayerComponent, resolveConfigFunctions } from './layers/utils';
 import { SimpleMap } from './map';
 import MapMessage from './map-message';
-import LayerLegend from './layer-legend';
+import LayerLegend, {LegendContainer} from './layer-legend';
 import { useBasemap } from './map-options/use-basemap';
 import { DEFAULT_MAP_STYLE_URL } from './map-options/basemaps';
 import { Styles } from './layers/styles';
@@ -365,13 +365,25 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
         Layer legend for the active layer.
       */}
       {baseLayerResolvedData?.legend && (
-        <LayerLegend
-          id={`base-${baseLayerResolvedData.id}`}
-          title={baseLayerResolvedData.name}
-          description={baseLayerResolvedData.description}
-          {...baseLayerResolvedData.legend}
-        />
+        <LegendContainer>
+          <LayerLegend
+            id={`base-${baseLayerResolvedData.id}`}
+            title={baseLayerResolvedData.name}
+            description={baseLayerResolvedData.description}
+            {...baseLayerResolvedData.legend}
+          />      
+          
+          {compareLayerResolvedData?.legend && (compareLayerResolvedData.id !== baseLayerResolvedData.id) && (
+            <LayerLegend
+              id={`compare-${compareLayerResolvedData.id}`}
+              title={compareLayerResolvedData.name}
+              description={compareLayerResolvedData.description}
+              {...compareLayerResolvedData.legend}
+            />
+          )}
+        </LegendContainer>
       )}
+      
 
       {/*
         Maps container
@@ -442,7 +454,6 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
               boundariesOption={boundariesOption}
             />
             {isMapCompareLoaded &&
-              isComparing &&
               compareLayerResolvedData &&
               CompareLayerComponent && (
                 <CompareLayerComponent

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -28,7 +28,7 @@ import { AoiChangeListenerOverload, AoiState } from '../aoi/types';
 import { getLayerComponent, resolveConfigFunctions } from './layers/utils';
 import { SimpleMap } from './map';
 import MapMessage from './map-message';
-import LayerLegendContainer, {LayerLegend} from './layer-legend';
+import { LayerLegendContainer, LayerLegend } from './layer-legend';
 import { useBasemap } from './map-options/use-basemap';
 import { DEFAULT_MAP_STYLE_URL } from './map-options/basemaps';
 import { Styles } from './layers/styles';
@@ -373,6 +373,7 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
             {...baseLayerResolvedData.legend}
           /> 
           {compareLayerResolvedData?.legend &&
+          isComparing &&
           (baseLayerResolvedData.id !== compareLayerResolvedData.id) && 
                     <LayerLegend
                     id={`compare-${compareLayerResolvedData.id}`}

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -373,7 +373,8 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
             {...baseLayerResolvedData.legend}
           />      
           
-          {compareLayerResolvedData?.legend && (compareLayerResolvedData.id !== baseLayerResolvedData.id) && (
+          {compareLayerResolvedData?.legend &&
+            (compareLayerResolvedData.id !== baseLayerResolvedData.id) && (
             <LayerLegend
               id={`compare-${compareLayerResolvedData.id}`}
               title={compareLayerResolvedData.name}

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -28,7 +28,7 @@ import { AoiChangeListenerOverload, AoiState } from '../aoi/types';
 import { getLayerComponent, resolveConfigFunctions } from './layers/utils';
 import { SimpleMap } from './map';
 import MapMessage from './map-message';
-import LayerLegend, {LegendContainer} from './layer-legend';
+import LayerLegendContainer from './layer-legend';
 import { useBasemap } from './map-options/use-basemap';
 import { DEFAULT_MAP_STYLE_URL } from './map-options/basemaps';
 import { Styles } from './layers/styles';
@@ -365,26 +365,23 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
         Layer legend for the active layer.
       */}
       {baseLayerResolvedData?.legend && (
-        <LegendContainer>
-          <LayerLegend
-            id={`base-${baseLayerResolvedData.id}`}
-            title={baseLayerResolvedData.name}
-            description={baseLayerResolvedData.description}
-            {...baseLayerResolvedData.legend}
-          />      
-          
-          {compareLayerResolvedData?.legend &&
-            (compareLayerResolvedData.id !== baseLayerResolvedData.id) && (
-            <LayerLegend
-              id={`compare-${compareLayerResolvedData.id}`}
-              title={compareLayerResolvedData.name}
-              description={compareLayerResolvedData.description}
-              {...compareLayerResolvedData.legend}
-            />
-          )}
-        </LegendContainer>
-      )}
+        <LayerLegendContainer
+          layers={[{
+            id: `base-${baseLayerResolvedData.id}`,
+            title: baseLayerResolvedData.name,
+            description: baseLayerResolvedData.description,
+            ...baseLayerResolvedData.legend },
+            ...compareLayerResolvedData?.legend?[{
+              id:`compare-${compareLayerResolvedData.id}`,
+              title:compareLayerResolvedData.name,
+              description:compareLayerResolvedData.description,
+              ...compareLayerResolvedData.legend
+            }]: []
+          ]}
+        />)}
       
+
+
 
       {/*
         Maps container

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -373,6 +373,7 @@ function MapboxMapComponent(props: MapboxMapProps, ref) {
             {...baseLayerResolvedData.legend}
           /> 
           {compareLayerResolvedData?.legend &&
+          (baseLayerResolvedData.id !== compareLayerResolvedData.id) && 
                     <LayerLegend
                     id={`compare-${compareLayerResolvedData.id}`}
                     title={compareLayerResolvedData.name}

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -51,20 +51,16 @@ export const LegendContainer = styled.div`
   right: ${variableGlsp()};
   display: flex;
   flex-flow: column nowrap;
+  box-shadow: ${themeVal('boxShadow.elevationB')};
+  border-radius: ${themeVal('shape.rounded')};
+  background-color: ${themeVal('color.surface')};
 `;
 
 const LayerLegendSelf = styled.div`
   display: flex;
   flex-flow: column nowrap;
-  border-radius: ${themeVal('shape.rounded')};
-  box-shadow: ${themeVal('boxShadow.elevationB')};
-  background-color: ${themeVal('color.surface')};
   width: 16rem;
-
-  &:not(:last-child) {
-    margin-bottom: ${variableGlsp(0.25)};
-  }
-
+  border-bottom: 1px solid ${themeVal('color.base-100')}; 
   &.reveal-enter {
     opacity: 0;
     bottom: 4rem;
@@ -87,7 +83,7 @@ const LayerLegendSelf = styled.div`
   }
 
   ${WidgetItemHeader} {
-    padding: ${variableGlsp(0.5, 0.75)};
+    padding: ${variableGlsp(0.25, 0.75)};
   }
 `;
 
@@ -173,7 +169,7 @@ function LayerLegend(
   const { id, type, title, description } = props;
 
   return (
-    <AccordionManager>
+
       <AccordionFold
         id={id}
         forwardedAs={LayerLegendSelf}
@@ -228,11 +224,22 @@ function LayerLegend(
           </LegendBody>
         )}
       />
-    </AccordionManager>
   );
 }
 
-export default LayerLegend;
+
+function LayerLegendContainer({ layers }) {
+  return (
+    <LegendContainer>
+      <AccordionManager>
+        {layers.map(e=> <LayerLegend key={e.id} {...e} />)}
+      </AccordionManager>
+    </LegendContainer>
+  );
+}
+
+export default LayerLegendContainer;
+
 
 function LayerCategoricalGraphic(props: LayerLegendCategorical) {
   const { stops } = props;

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -22,7 +22,6 @@ import {
   WidgetItemHGroup
 } from '$styles/panel';
 
-
 interface LayerLegendCommonProps{
   id: string;
   title: string;
@@ -32,6 +31,10 @@ interface LayerLegendCommonProps{
 interface LegendSwatchProps{
   hasHelp?: boolean;
   stops: string | string[];
+}
+
+interface LayerLegendContainerProps {
+  layers: (LayerLegendCommonProps & (LayerLegendGradient | LayerLegendCategorical))[];
 }
 
 const makeGradient = (stops: string[]) => {
@@ -84,6 +87,12 @@ const LayerLegendSelf = styled.div`
 
   ${WidgetItemHeader} {
     padding: ${variableGlsp(0.25, 0.75)};
+  }
+
+  &:only-child {
+    ${WidgetItemHeader} {
+      padding: ${variableGlsp(0.5, 0.75)};
+    }
   }
 `;
 
@@ -228,11 +237,11 @@ function LayerLegend(
 }
 
 
-function LayerLegendContainer({ layers }) {
+function LayerLegendContainer(props: LayerLegendContainerProps) {
   return (
     <LegendContainer>
       <AccordionManager>
-        {layers.map(e=> <LayerLegend key={e.id} {...e} />)}
+        {props.layers.map(e=> <LayerLegend key={e.id} {...e} />)}
       </AccordionManager>
     </LegendContainer>
   );

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { ReactNode, Fragment } from 'react';
 import styled from 'styled-components';
 import { LayerLegendCategorical, LayerLegendGradient } from 'veda';
 import { AccordionFold, AccordionManager } from '@devseed-ui/accordion';
@@ -34,7 +34,7 @@ interface LegendSwatchProps{
 }
 
 interface LayerLegendContainerProps {
-  layers: (LayerLegendCommonProps & (LayerLegendGradient | LayerLegendCategorical))[];
+  children: ReactNode | ReactNode[];
 }
 
 const makeGradient = (stops: string[]) => {
@@ -172,13 +172,12 @@ const LegendBody = styled(WidgetItemBodyInner)`
   }
 `;
 
-function LayerLegend(
+export function LayerLegend(
   props: LayerLegendCommonProps & (LayerLegendGradient | LayerLegendCategorical)
 ) {
   const { id, type, title, description } = props;
 
   return (
-
       <AccordionFold
         id={id}
         forwardedAs={LayerLegendSelf}
@@ -241,7 +240,8 @@ function LayerLegendContainer(props: LayerLegendContainerProps) {
   return (
     <LegendContainer>
       <AccordionManager>
-        {props.layers.map(e=> <LayerLegend key={e.id} {...e} />)}
+        {props.children}
+        {/* {props.layers.map(e=> <LayerLegend key={e.id} {...e} />)} */}
       </AccordionManager>
     </LegendContainer>
   );

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -23,16 +23,16 @@ import {
 } from '$styles/panel';
 
 
-type LayerLegendCommonProps = {
+interface LayerLegendCommonProps{
   id: string;
   title: string;
   description: string;
-};
+}
 
-type LegendSwatchProps = {
+interface LegendSwatchProps{
   hasHelp?: boolean;
   stops: string | string[];
-};
+}
 
 const makeGradient = (stops: string[]) => {
   if (stops.length === 1) return stops[0];
@@ -44,17 +44,26 @@ const makeGradient = (stops: string[]) => {
 const printLegendVal = (val: string | number) =>
   typeof val === 'number' ? formatThousands(val, { shorten: true }) : val;
 
-const LayerLegendSelf = styled.div`
+export const LegendContainer = styled.div`
   position: absolute;
   z-index: 8;
   bottom: ${variableGlsp()};
   right: ${variableGlsp()};
   display: flex;
   flex-flow: column nowrap;
+`;
+
+const LayerLegendSelf = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
   border-radius: ${themeVal('shape.rounded')};
   box-shadow: ${themeVal('boxShadow.elevationB')};
   background-color: ${themeVal('color.surface')};
   width: 16rem;
+
+  &:not(:last-child) {
+    margin-bottom: ${variableGlsp(0.25)};
+  }
 
   &.reveal-enter {
     opacity: 0;

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -94,6 +94,7 @@ const LayerLegendSelf = styled.div`
     ${WidgetItemHeader} {
       padding: ${variableGlsp(0.5, 0.75)};
     }
+    border-bottom: 0;
   }
 `;
 
@@ -167,7 +168,6 @@ const LegendBody = styled(WidgetItemBodyInner)`
   .scroll-inner {
     padding: ${variableGlsp(0.5, 0.75)};
   }
-
   .shadow-bottom {
     border-radius: ${themeVal('shape.rounded')};
   }
@@ -221,7 +221,7 @@ export function LayerLegend(
             scrollbarsProps={{
               autoHeight: true,
               autoHeightMin: 32,
-              autoHeightMax: 240
+              autoHeightMax: 120
             }}
           >
             <div className='scroll-inner'>

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -22,13 +22,13 @@ import {
   WidgetItemHGroup
 } from '$styles/panel';
 
-interface LayerLegendCommonProps{
+interface LayerLegendCommonProps {
   id: string;
   title: string;
   description: string;
 }
 
-interface LegendSwatchProps{
+interface LegendSwatchProps {
   hasHelp?: boolean;
   stops: string | string[];
 }
@@ -57,13 +57,7 @@ export const LegendContainer = styled.div`
   box-shadow: ${themeVal('boxShadow.elevationB')};
   border-radius: ${themeVal('shape.rounded')};
   background-color: ${themeVal('color.surface')};
-`;
 
-const LayerLegendSelf = styled.div`
-  display: flex;
-  flex-flow: column nowrap;
-  width: 16rem;
-  border-bottom: 1px solid ${themeVal('color.base-100')}; 
   &.reveal-enter {
     opacity: 0;
     bottom: 4rem;
@@ -84,6 +78,13 @@ const LayerLegendSelf = styled.div`
   &.reveal-exit-active {
     transition: bottom 240ms ease-in-out, opacity 240ms ease-in-out;
   }
+`;
+
+const LayerLegendSelf = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  width: 16rem;
+  border-bottom: 1px solid ${themeVal('color.base-100')};
 
   ${WidgetItemHeader} {
     padding: ${variableGlsp(0.25, 0.75)};
@@ -178,63 +179,60 @@ export function LayerLegend(
   const { id, type, title, description } = props;
 
   return (
-      <AccordionFold
-        id={id}
-        forwardedAs={LayerLegendSelf}
-        renderHeader={({ isExpanded, toggleExpanded }) => (
-          <WidgetItemHeader>
-            <WidgetItemHGroup>
-              <WidgetItemHeadline>
-                <LayerLegendTitle>{title}</LayerLegendTitle>
-                {/* <Subtitle as='p'>Subtitle</Subtitle> */}
-              </WidgetItemHeadline>
-              <Toolbar size='small'>
-                <ToolbarIconButton
-                  variation='base-text'
-                  active={isExpanded}
-                  onClick={toggleExpanded}
-                >
-                  <CollecticonCircleInformation
-                    title='Information about layer'
-                    meaningful
-                  />
-                </ToolbarIconButton>
-              </Toolbar>
-            </WidgetItemHGroup>
-            {type === 'categorical' && (
-              <LayerCategoricalGraphic type='categorical' stops={props.stops} />
-            )}
-            {type === 'gradient' && (
-              <LayerGradientGraphic
-                type='gradient'
-                stops={props.stops}
-                min={props.min}
-                max={props.max}
-              />
-            )}
-          </WidgetItemHeader>
-        )}
-        renderBody={() => (
-          <LegendBody>
-            <ShadowScrollbar
-              scrollbarsProps={{
-                autoHeight: true,
-                autoHeightMin: 32,
-                autoHeightMax: 240
-              }}
-            >
-              <div className='scroll-inner'>
-                {description || (
-                  <p>No info available for this layer.</p>
-                )}
-              </div>
-            </ShadowScrollbar>
-          </LegendBody>
-        )}
-      />
+    <AccordionFold
+      id={id}
+      forwardedAs={LayerLegendSelf}
+      renderHeader={({ isExpanded, toggleExpanded }) => (
+        <WidgetItemHeader>
+          <WidgetItemHGroup>
+            <WidgetItemHeadline>
+              <LayerLegendTitle>{title}</LayerLegendTitle>
+              {/* <Subtitle as='p'>Subtitle</Subtitle> */}
+            </WidgetItemHeadline>
+            <Toolbar size='small'>
+              <ToolbarIconButton
+                variation='base-text'
+                active={isExpanded}
+                onClick={toggleExpanded}
+              >
+                <CollecticonCircleInformation
+                  title='Information about layer'
+                  meaningful
+                />
+              </ToolbarIconButton>
+            </Toolbar>
+          </WidgetItemHGroup>
+          {type === 'categorical' && (
+            <LayerCategoricalGraphic type='categorical' stops={props.stops} />
+          )}
+          {type === 'gradient' && (
+            <LayerGradientGraphic
+              type='gradient'
+              stops={props.stops}
+              min={props.min}
+              max={props.max}
+            />
+          )}
+        </WidgetItemHeader>
+      )}
+      renderBody={() => (
+        <LegendBody>
+          <ShadowScrollbar
+            scrollbarsProps={{
+              autoHeight: true,
+              autoHeightMin: 32,
+              autoHeightMax: 240
+            }}
+          >
+            <div className='scroll-inner'>
+              {description || <p>No info available for this layer.</p>}
+            </div>
+          </ShadowScrollbar>
+        </LegendBody>
+      )}
+    />
   );
 }
-
 
 function LayerLegendContainer(props: LayerLegendContainerProps) {
   return (
@@ -248,7 +246,6 @@ function LayerLegendContainer(props: LayerLegendContainerProps) {
 }
 
 export default LayerLegendContainer;
-
 
 function LayerCategoricalGraphic(props: LayerLegendCategorical) {
   const { stops } = props;

--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -87,12 +87,12 @@ const LayerLegendSelf = styled.div`
   border-bottom: 1px solid ${themeVal('color.base-100')};
 
   ${WidgetItemHeader} {
-    padding: ${variableGlsp(0.25, 0.75)};
+    padding: ${variableGlsp(0.25, 0.5)};
   }
 
   &:only-child {
     ${WidgetItemHeader} {
-      padding: ${variableGlsp(0.5, 0.75)};
+      padding: ${variableGlsp(0.5)};
     }
     border-bottom: 0;
   }
@@ -234,18 +234,15 @@ export function LayerLegend(
   );
 }
 
-function LayerLegendContainer(props: LayerLegendContainerProps) {
+export function LayerLegendContainer(props: LayerLegendContainerProps) {
   return (
     <LegendContainer>
       <AccordionManager>
         {props.children}
-        {/* {props.layers.map(e=> <LayerLegend key={e.id} {...e} />)} */}
       </AccordionManager>
     </LegendContainer>
   );
 }
-
-export default LayerLegendContainer;
 
 function LayerCategoricalGraphic(props: LayerLegendCategorical) {
   const { stops } = props;

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -45,11 +45,7 @@ interface MapLayerRasterTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
-<<<<<<< HEAD
-  idSuffix?: string
-=======
-  suffix?: string
->>>>>>> ddca7f1 (Wrap layers with a container)
+  idSuffix?: string;
 }
 
 export interface StacFeature {
@@ -78,11 +74,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     zoomExtent,
     onStatusChange,
     isHidden,
-<<<<<<< HEAD
     idSuffix = ''
-=======
-    suffix = ''
->>>>>>> ddca7f1 (Wrap layers with a container)
   } = props;
 
   const theme = useTheme();
@@ -415,7 +407,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       }
 
       updateStyle({
-        generatorId: 'raster-timeseries' + suffix,
+        generatorId,
         sources,
         layers
       });
@@ -429,11 +421,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       points,
       haveSourceParamsChanged,
       isHidden,
-<<<<<<< HEAD
       generatorId
-=======
-      suffix
->>>>>>> ddca7f1 (Wrap layers with a container)
     ]
   );
 

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -45,7 +45,11 @@ interface MapLayerRasterTimeseriesProps {
   zoomExtent?: [number, number];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden: boolean;
+<<<<<<< HEAD
   idSuffix?: string
+=======
+  suffix?: string
+>>>>>>> ddca7f1 (Wrap layers with a container)
 }
 
 export interface StacFeature {
@@ -74,7 +78,11 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     zoomExtent,
     onStatusChange,
     isHidden,
+<<<<<<< HEAD
     idSuffix = ''
+=======
+    suffix = ''
+>>>>>>> ddca7f1 (Wrap layers with a container)
   } = props;
 
   const theme = useTheme();
@@ -407,7 +415,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       }
 
       updateStyle({
-        generatorId,
+        generatorId: 'raster-timeseries' + suffix,
         sources,
         layers
       });
@@ -421,7 +429,11 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
       points,
       haveSourceParamsChanged,
       isHidden,
+<<<<<<< HEAD
       generatorId
+=======
+      suffix
+>>>>>>> ddca7f1 (Wrap layers with a container)
     ]
   );
 

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -114,9 +114,9 @@ export const getCompareLayerData = (
     return {
       id: otherLayer.id,
       type: otherLayer.type,
-      name: otherLayer?.name,
-      description: otherLayer?.description,
-      legend: otherLayer?.legend, 
+      name: otherLayer.name,
+      description: otherLayer.description,
+      legend: otherLayer.legend, 
       stacCol: otherLayer.stacCol,
       zoomExtent: zoomExtent ?? otherLayer.zoomExtent,
       sourceParams: defaultsDeep({}, sourceParams, otherLayer.sourceParams),

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -69,7 +69,7 @@ export const getCompareLayerData = (
       id: stacCol,
       stacCol,
       type: type || layerData.type,
-      zoomExtent: zoomExtent || layerData.zoomExtent,
+      zoomExtent: zoomExtent ?? layerData.zoomExtent,
       sourceParams: defaultsDeep({}, sourceParams, layerData.sourceParams),
       ...passThroughProps
     };

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -92,11 +92,13 @@ export const getCompareLayerData = (
 
     const datasetData = datasets[datasetId]?.data;
     if (!datasetData) {
+      // eslint-disable-next-line fp/no-mutating-methods
       errorHints.push(`Dataset [${datasetId}] not found (compare.datasetId)`);
     }
 
-    const otherLayer = datasetData?.layers?.find((l) => l.id === layerId);
+    const otherLayer = datasetData?.layers.find((l) => l.id === layerId);
     if (!otherLayer) {
+      // eslint-disable-next-line fp/no-mutating-methods
       errorHints.push(
         `Layer [${layerId}] not found in dataset [${datasetId}] (compare.layerId)`
       );
@@ -112,8 +114,11 @@ export const getCompareLayerData = (
     return {
       id: otherLayer.id,
       type: otherLayer.type,
+      name: otherLayer?.name,
+      description: otherLayer?.description,
+      legend: otherLayer?.legend, 
       stacCol: otherLayer.stacCol,
-      zoomExtent: zoomExtent || otherLayer.zoomExtent,
+      zoomExtent: zoomExtent ?? otherLayer.zoomExtent,
       sourceParams: defaultsDeep({}, sourceParams, otherLayer.sourceParams),
       ...passThroughProps
     };
@@ -133,7 +138,7 @@ type Res<T> = T extends Fn
     ? DatasetDatumReturnType
     : never
   : T extends any[]
-  ? Array<Res<T[number]>>
+  ? Res<T[number]>[]
   : T extends object
   ? ObjResMap<T>
   : T;
@@ -143,10 +148,10 @@ export function resolveConfigFunctions<T>(
   bag: DatasetDatumFnResolverBag
 ): Res<T>;
 /* eslint-disable-next-line no-redeclare */
-export function resolveConfigFunctions<T extends Array<any>>(
+export function resolveConfigFunctions<T extends any[]>(
   datum: T,
   bag: DatasetDatumFnResolverBag
-): Array<Res<T[number]>>;
+): Res<T[number]>[];
 /* eslint-disable-next-line no-redeclare */
 export function resolveConfigFunctions(
   datum: any,

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -41,12 +41,41 @@ layers:
         - 0
         - 1.5e16
     compare:
-      datasetId: no2
-      layerId: no2-monthly
+      datasetId: nighttime-lights
+      layerId: nightlights-hd-monthly
       mapLabel: |
         ::js ({ dateFns, datetime, compareDatetime }) => {
           return `${dateFns.format(datetime, 'LLL yyyy')} VS ${dateFns.format(compareDatetime, 'LLL yyyy')}`;
         }
+    legend:
+      unit: 
+        label: Molecules cm3
+      type: gradient
+      min: "Less"
+      max: "More"
+      stops:
+        - "#99c5e0"
+        - "#f9eaa9"
+        - "#f7765d"
+        - "#c13b72"
+        - "#461070"
+        - "#050308"
+  - id: no2-monthly-2
+    stacCol: no2-monthly
+    name: No2
+    type: raster
+    description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+      resampling_method: bilinear
+      bidx: 1
+      color_formula: gamma r 1.05
+      colormap_name: coolwarm
+      rescale:
+        - 0
+        - 1.5e16
     legend:
       unit: 
         label: Molecules cm3

--- a/mock/discoveries/air-quality-and-covid-19.discoveries.mdx
+++ b/mock/discoveries/air-quality-and-covid-19.discoveries.mdx
@@ -261,11 +261,10 @@ thematics:
   <Figure>
     <Map
       datasetId='no2'
-      layerId='no2-monthly'
+      layerId='no2-monthly-2'
       center={[120.11, 34.95]}
       zoom={4.5}
       dateTime='2020-02-01'
-      compareDateTime='2022-02-01'
     />
     <Caption 
       attrAuthor='NASA' 

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -72,20 +72,6 @@ declare module 'veda' {
     stacCol: string;
     type: DatasetLayerType;
   }
-
-  interface DatasetLayerCompareNoLegend extends DatasetLayerCompareBase {
-    legend?: never;
-    name?: never;
-    description?: never;
-  }
-      
-  interface DatasetLayerCompareWLegend extends DatasetLayerCompareBase {
-    legend: LayerLegendCategorical | LayerLegendGradient | undefined;
-    name: string;
-    description: string;
-  }
-
-
   export interface DatasetLayerCompareNormalized
     extends DatasetLayerCommonCompareProps {
     id: string;

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -66,8 +66,11 @@ declare module 'veda' {
   export interface DatasetLayerCompareNormalized
     extends DatasetLayerCommonCompareProps {
     id: string;
+    name?: string;
+    description?: string;
     stacCol: string;
     type: DatasetLayerType;
+    legend?: LayerLegendCategorical | LayerLegendGradient;
   }
 
   // TODO: Complete once known

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -66,8 +66,8 @@ declare module 'veda' {
   export interface DatasetLayerCompareNormalized
     extends DatasetLayerCommonCompareProps {
     id: string;
-    name?: string;
-    description?: string;
+    name: string;
+    description: string;
     stacCol: string;
     type: DatasetLayerType;
     legend?: LayerLegendCategorical | LayerLegendGradient;

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -39,6 +39,9 @@ declare module 'veda' {
     extends DatasetLayerCommonCompareProps {
     stacCol: string;
     type: DatasetLayerType;
+    name: string;
+    description: string;
+    legend?: LayerLegendCategorical | LayerLegendGradient;
   }
 
   export interface DatasetLayerCompareInternal
@@ -82,7 +85,18 @@ declare module 'veda' {
     description: string;
   }
 
-  export type DatasetLayerCompareNormalized = DatasetLayerCompareNoLegend | DatasetLayerCompareWLegend
+
+  export interface DatasetLayerCompareNormalized
+    extends DatasetLayerCommonCompareProps {
+    id: string;
+    name: string;
+    description: string;
+    stacCol: string;
+    type: DatasetLayerType;
+    legend?: LayerLegendCategorical | LayerLegendGradient;
+  }
+
+  // export type DatasetLayerCompareNormalized = DatasetLayerCompareNoLegend | DatasetLayerCompareWLegend
 
   // TODO: Complete once known
   export interface DatasetDatumFnResolverBag {

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -63,15 +63,26 @@ declare module 'veda' {
   // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The
   // difference with a "base" dataset layer is not having a name and
   // description.
-  export interface DatasetLayerCompareNormalized
+  export interface DatasetLayerCompareBase
     extends DatasetLayerCommonCompareProps {
     id: string;
-    name: string;
-    description: string;
     stacCol: string;
     type: DatasetLayerType;
-    legend?: LayerLegendCategorical | LayerLegendGradient;
   }
+
+  interface DatasetLayerCompareNoLegend extends DatasetLayerCompareBase {
+    legend?: never;
+    name?: never;
+    description?: never;
+  }
+      
+  interface DatasetLayerCompareWLegend extends DatasetLayerCompareBase {
+    legend: LayerLegendCategorical | LayerLegendGradient | undefined;
+    name: string;
+    description: string;
+  }
+
+  export type DatasetLayerCompareNormalized = DatasetLayerCompareNoLegend | DatasetLayerCompareWLegend
 
   // TODO: Complete once known
   export interface DatasetDatumFnResolverBag {


### PR DESCRIPTION
related to #468 

Sometimes authors need to put two layers with different colormaps to compare. (ex. https://www.earthdata.nasa.gov/dashboard/discoveries/urban-heating the map at the top could be an interactive compare map.) This PR addresses the need. 

Currently, there is one discovery that uses different layers to compare from a config repo: /discoveries/tws-trends 

This PR stacks two legends. I am happy to iterate if there is a better way to handle multiple legends.
![Screen Shot 2023-06-01 at 3 40 22 PM](https://github.com/NASA-IMPACT/veda-ui/assets/4583806/0b1432d4-c42f-46c2-aeff-dadaa85c33de)
