### PR TITLE
Disable automatic error popup from react devtools  for handeled errors

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -71,7 +71,7 @@
     Code partially borrowed from https://github.com/jeron-diovis/react-app-error-boundary
   -->
   <style id="suppress-cra-overlay-styles">
-    iframe[style*="position: fixed; top: 0px; left: 0px; width: 100%; height: 100%; border: medium none; z-index: 2147483647;"] {
+    iframe[style*="position: fixed; top: 0px; left: 0px; width: 100%; height: 100%; border: none; z-index: 2147483647;"] {
       display: none;
     }
   </style>

--- a/app/scripts/components/common/blocks/figure.js
+++ b/app/scripts/components/common/blocks/figure.js
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import T from 'prop-types';
 import { figureDisplayName, captionDisplayName } from './block-constant';
-import { BlockErrorBoundary } from '.';
 import { Figure } from '$components/common/figure';
 
 const ContentBlockFigure = (props) => {
@@ -22,11 +21,7 @@ ContentBlockFigure.propTypes = {
   children: T.node
 };
 
-const FigureWithError = (props) => (
-  <BlockErrorBoundary {...props} childToRender={ContentBlockFigure} />
-);
-
-const StyledContentBlockFigure = styled(FigureWithError)`
+const StyledContentBlockFigure = styled(ContentBlockFigure)`
   img {
     width: 100%;
   }

--- a/docs/content/MDX_BLOCKS.md
+++ b/docs/content/MDX_BLOCKS.md
@@ -361,7 +361,8 @@ You can replace `attr` option with `<Caption>` component if your image is used i
   <td>
 
   ```jsx
-    <Figure type='full'>
+  <Block type="full>
+    <Figure>
       <Image
         src="http://via.placeholder.com/1200x800?text=figure" 
         alt='description for image'
@@ -373,6 +374,7 @@ You can replace `attr` option with `<Caption>` component if your image is used i
         This is an image. This is <a href="link">a link</a>.
       </Caption> 
     </Figure>
+  </Block>
   ```
   </td>
   <td> 


### PR DESCRIPTION
This is a fix for an overdue bug. (that can help https://github.com/NASA-IMPACT/veda-ui/pull/551)  We want to suppress cra overlay for errors already handled on the component level, and this suppression was not working because the style selector was not correct.  (I realized that this is not the main problem for mdx editor. We would need some sort of logic to clear out errors when an error is fixed. but this one is a good one to fix anyway.)

I sneaked in a little documentation change and other little code changes. Since we enforce users to wrap everything with `<Block>`, Figure doesn't need to be wrapped with error boundary. 