### PR TITLE
Fix analysis and use configured "assets" value

### DIFF
--- a/app/scripts/components/analysis/define/use-stac-search.ts
+++ b/app/scripts/components/analysis/define/use-stac-search.ts
@@ -39,8 +39,8 @@ export function useStacSearch({ start, end, aoi }: UseStacSearchProps) {
       try {
         const url = `${process.env.API_STAC_ENDPOINT}/search`;
 
-        const allAvailableDatasetsLayersIds = allAvailableDatasetsLayers.map(
-          (layer) => layer.id
+        const allAvailableDatasetsLayersSTACIds = allAvailableDatasetsLayers.map(
+          (layer) => layer.stacCol
         );
         const payload = {
           'filter-lang': 'cql2-json',
@@ -48,7 +48,7 @@ export function useStacSearch({ start, end, aoi }: UseStacSearchProps) {
             start,
             end,
             aoi,
-            allAvailableDatasetsLayersIds
+            allAvailableDatasetsLayersSTACIds
           ),
           limit: 100,
           fields: {
@@ -73,7 +73,7 @@ export function useStacSearch({ start, end, aoi }: UseStacSearchProps) {
         );
         setSelectableDatasetLayers(
           allAvailableDatasetsLayers.filter((l) =>
-            itemsParentCollections.includes(l.id)
+            itemsParentCollections.includes(l.stacCol)
           )
         );
       } catch (error) {

--- a/app/scripts/components/analysis/results/timeseries-data.ts
+++ b/app/scripts/components/analysis/results/timeseries-data.ts
@@ -135,20 +135,21 @@ export function requestStacDatasetsTimeseries({
 }
 
 interface DatasetAssetsRequestParams {
-  id: string;
+  stacCol: string;
+  assets: string;
   dateStart: Date;
   dateEnd: Date;
   aoi: FeatureCollection<Polygon>;
 }
 
 async function getDatasetAssets(
-  { dateStart, dateEnd, id, aoi }: DatasetAssetsRequestParams,
+  { dateStart, dateEnd, stacCol, assets, aoi }: DatasetAssetsRequestParams,
   opts: AxiosRequestConfig,
   concurrencyManager: ConcurrencyManagerInstance
 ) {
   const data = await concurrencyManager.queue(async () => {
     const collectionReqRes = await axios.get(
-      `${process.env.API_STAC_ENDPOINT}/collections/${id}`
+      `${process.env.API_STAC_ENDPOINT}/collections/${stacCol}`
     );
 
     const searchReqRes = await axios.post(
@@ -158,13 +159,13 @@ async function getDatasetAssets(
         limit: 10000,
         fields: {
           include: [
-            'assets.cog_default.href',
+            `assets.${assets}.href`,
             'properties.start_datetime',
             'properties.datetime'
           ],
           exclude: ['collection', 'links']
         },
-        filter: getFilterPayload(dateStart, dateEnd, aoi, [id])
+        filter: getFilterPayload(dateStart, dateEnd, aoi, [stacCol])
       },
       opts
     );
@@ -175,7 +176,7 @@ async function getDatasetAssets(
       domain: collectionReqRes.data.summaries.datetime,
       assets: searchReqRes.data.features.map((o) => ({
         date: o.properties.start_datetime || o.properties.datetime,
-        url: o.assets.cog_default.href
+        url: o.assets[assets].href
       }))
     };
   });
@@ -235,7 +236,8 @@ async function requestTimeseries({
       ({ signal }) =>
         getDatasetAssets(
           {
-            id,
+            stacCol: layer.stacCol,
+            assets: layer.sourceParams?.assets || 'cog_default',
             aoi,
             dateStart: start,
             dateEnd: end


### PR DESCRIPTION
(from #570 ) The analysis was not working properly. It was requesting datasets from stac using the `layerId` instead of `stacCol`. We haven't noticed it before because most of the datasets have the same value (coincidentally). This PR also addresses this bug while making the `assets` value configurable for the analysis.

@slesaad Great catch! I also noticed that the `/statistics` response returns data under a `b1` key, and we're expecting a `1` key (This is so in VEDA). Is this possible to standardize?

<img width="503" alt="image" src="https://github.com/NASA-IMPACT/veda-ui/assets/1090606/ab40b52d-7cfb-4c71-bf5a-c53ed9c9ee62">