### PR TITLE
User defined dataset bounds

### DIFF
--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -419,7 +419,7 @@ function MapboxMapComponent(
                 id={`base-${baseLayerResolvedData.id}`}
                 stacCol={baseLayerResolvedData.stacCol}
                 mapInstance={mapRef.current}
-                urlPosition={initialPosition}
+                isPositionSet={!!initialPosition}
                 date={date}
                 sourceParams={baseLayerResolvedData.sourceParams}
                 zoomExtent={baseLayerResolvedData.zoomExtent}

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -422,6 +422,7 @@ function MapboxMapComponent(
                 date={date}
                 sourceParams={baseLayerResolvedData.sourceParams}
                 zoomExtent={baseLayerResolvedData.zoomExtent}
+                bounds={baseLayerResolvedData.bounds}
                 onStatusChange={onBaseLayerStatusChange}
               />
             )}
@@ -471,6 +472,7 @@ function MapboxMapComponent(
                   date={compareToDate ?? undefined}
                   sourceParams={compareLayerResolvedData.sourceParams}
                   zoomExtent={compareLayerResolvedData.zoomExtent}
+                  bounds={compareLayerResolvedData.bounds}
                   onStatusChange={onCompareLayerStatusChange}
                 />
               )}

--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -419,6 +419,7 @@ function MapboxMapComponent(
                 id={`base-${baseLayerResolvedData.id}`}
                 stacCol={baseLayerResolvedData.stacCol}
                 mapInstance={mapRef.current}
+                urlPosition={initialPosition}
                 date={date}
                 sourceParams={baseLayerResolvedData.sourceParams}
                 zoomExtent={baseLayerResolvedData.zoomExtent}

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -46,6 +46,7 @@ export interface MapLayerRasterTimeseriesProps {
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden?: boolean;
   idSuffix?: string;
+  isPositionSet?: boolean;
 }
 
 export interface StacFeature {
@@ -76,7 +77,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     onStatusChange,
     isHidden,
     idSuffix = '',
-    urlPosition
+    isPositionSet
   } = props;
 
   const theme = useTheme();
@@ -472,7 +473,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     () => (stacCollection.length ? getMergedBBox(stacCollection) : undefined),
     [stacCollection]
   );
-  useFitBbox(mapInstance, urlPosition, bounds, layerBounds);
+  useFitBbox(mapInstance, !!isPositionSet, bounds, layerBounds);
 
   return null;
 }

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -16,6 +16,7 @@ import { featureCollection, point } from '@turf/helpers';
 import { useMapStyle } from './styles';
 import {
   checkFitBoundsFromLayer,
+  FIT_BOUNDS_PADDING,
   getFilterPayload,
   getMergedBBox,
   requestQuickCache,
@@ -34,8 +35,6 @@ import {
 // Whether or not to print the request logs.
 const LOG = true;
 
-const FIT_BOUNDS_PADDING = 32;
-
 export interface MapLayerRasterTimeseriesProps {
   id: string;
   stacCol: string;
@@ -43,6 +42,7 @@ export interface MapLayerRasterTimeseriesProps {
   mapInstance: MapboxMap;
   sourceParams?: Record<string, any>;
   zoomExtent?: number[];
+  bounds?: number[];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden?: boolean;
   idSuffix?: string;
@@ -72,6 +72,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     mapInstance,
     sourceParams,
     zoomExtent,
+    bounds,
     onStatusChange,
     isHidden,
     idSuffix = ''
@@ -470,10 +471,18 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     if (!stacCollection.length) return;
     const layerBounds = getMergedBBox(stacCollection);
 
-    if (checkFitBoundsFromLayer(layerBounds, mapInstance)) {
-      mapInstance.fitBounds(layerBounds, { padding: FIT_BOUNDS_PADDING });
+    // Prefer layer defined bounds to STAC collection bounds.
+    const usableBounds = (bounds?.length === 4 ? bounds : layerBounds) as [
+      number,
+      number,
+      number,
+      number
+    ];
+
+    if (checkFitBoundsFromLayer(usableBounds, mapInstance)) {
+      mapInstance.fitBounds(usableBounds, { padding: FIT_BOUNDS_PADDING });
     }
-  }, [mapInstance, stacCol, stacCollection]);
+  }, [mapInstance, stacCol, bounds, stacCollection]);
 
   return null;
 }

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -75,7 +75,8 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     bounds,
     onStatusChange,
     isHidden,
-    idSuffix = ''
+    idSuffix = '',
+    urlPosition
   } = props;
 
   const theme = useTheme();
@@ -471,7 +472,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
     () => (stacCollection.length ? getMergedBBox(stacCollection) : undefined),
     [stacCollection]
   );
-  useFitBbox(mapInstance, bounds, layerBounds);
+  useFitBbox(mapInstance, urlPosition, bounds, layerBounds);
 
   return null;
 }

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -15,11 +15,11 @@ import { featureCollection, point } from '@turf/helpers';
 
 import { useMapStyle } from './styles';
 import {
-  checkFitBoundsFromLayer,
   FIT_BOUNDS_PADDING,
   getFilterPayload,
   getMergedBBox,
   requestQuickCache,
+  useFitBbox,
   useLayerInteraction
 } from './utils';
 import { useCustomMarker } from './custom-marker';
@@ -467,22 +467,11 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
   //
   // FitBounds when needed
   //
-  useEffect(() => {
-    if (!stacCollection.length) return;
-    const layerBounds = getMergedBBox(stacCollection);
-
-    // Prefer layer defined bounds to STAC collection bounds.
-    const usableBounds = (bounds?.length === 4 ? bounds : layerBounds) as [
-      number,
-      number,
-      number,
-      number
-    ];
-
-    if (checkFitBoundsFromLayer(usableBounds, mapInstance)) {
-      mapInstance.fitBounds(usableBounds, { padding: FIT_BOUNDS_PADDING });
-    }
-  }, [mapInstance, stacCol, bounds, stacCollection]);
+  const layerBounds = useMemo(
+    () => (stacCollection.length ? getMergedBBox(stacCollection) : undefined),
+    [stacCollection]
+  );
+  useFitBbox(mapInstance, bounds, layerBounds);
 
   return null;
 }

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -370,6 +370,8 @@ export function getMergedBBox(features: StacFeature[]) {
   ) as [number, number, number, number];
 }
 
+export const FIT_BOUNDS_PADDING = 32;
+
 export function checkFitBoundsFromLayer(
   layerBounds?: [number, number, number, number],
   mapInstance?: MapboxMap

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -133,7 +133,7 @@ export const getCompareLayerData = (
       type: otherLayer.type,
       name: otherLayer.name,
       description: otherLayer.description,
-      legend: otherLayer.legend, 
+      legend: otherLayer.legend,
       stacCol: otherLayer.stacCol,
       zoomExtent: zoomExtent ?? otherLayer.zoomExtent,
       sourceParams: defaultsDeep({}, sourceParams, otherLayer.sourceParams),
@@ -432,7 +432,6 @@ export function useLayerInteraction({
   }, [layerId, mapInstance, onClick]);
 }
 
-
 type OptionalBbox = number[] | undefined | null;
 
 /**
@@ -445,10 +444,13 @@ type OptionalBbox = number[] | undefined | null;
  */
 export function useFitBbox(
   mapInstance: MapboxMap,
+  urlPosition: any,
   initialBbox: OptionalBbox,
   stacBbox: OptionalBbox
 ) {
   useEffect(() => {
+    if (urlPosition) return;
+
     // Prefer layer defined bounds to STAC collection bounds.
     const bounds = (initialBbox ?? stacBbox) as
       | [number, number, number, number]
@@ -457,5 +459,5 @@ export function useFitBbox(
     if (bounds?.length && checkFitBoundsFromLayer(bounds, mapInstance)) {
       mapInstance.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
     }
-  }, [mapInstance, initialBbox, stacBbox]);
+  }, [mapInstance, urlPosition, initialBbox, stacBbox]);
 }

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -435,21 +435,23 @@ export function useLayerInteraction({
 type OptionalBbox = number[] | undefined | null;
 
 /**
- * Centers on the given bounds if the current position is not within the bounds.
- * Gives preference to the layer defined bounds over the STAC collection bounds.
+ * Centers on the given bounds if the current position is not within the bounds,
+ * and there's no user defined position (via user initiated map movement). Gives
+ * preference to the layer defined bounds over the STAC collection bounds.
  *
  * @param mapInstance Mapbox instance
+ * @param isUserPositionSet Whether the user has set a position
  * @param initialBbox Bounding box from the layer
  * @param stacBbox Bounds from the STAC collection
  */
 export function useFitBbox(
   mapInstance: MapboxMap,
-  urlPosition: any,
+  isUserPositionSet: boolean,
   initialBbox: OptionalBbox,
   stacBbox: OptionalBbox
 ) {
   useEffect(() => {
-    if (urlPosition) return;
+    if (isUserPositionSet) return;
 
     // Prefer layer defined bounds to STAC collection bounds.
     const bounds = (initialBbox ?? stacBbox) as
@@ -459,5 +461,5 @@ export function useFitBbox(
     if (bounds?.length && checkFitBoundsFromLayer(bounds, mapInstance)) {
       mapInstance.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
     }
-  }, [mapInstance, urlPosition, initialBbox, stacBbox]);
+  }, [mapInstance, isUserPositionSet, initialBbox, stacBbox]);
 }

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -431,3 +431,31 @@ export function useLayerInteraction({
     };
   }, [layerId, mapInstance, onClick]);
 }
+
+
+type OptionalBbox = number[] | undefined | null;
+
+/**
+ * Centers on the given bounds if the current position is not within the bounds.
+ * Gives preference to the layer defined bounds over the STAC collection bounds.
+ *
+ * @param mapInstance Mapbox instance
+ * @param initialBbox Bounding box from the layer
+ * @param stacBbox Bounds from the STAC collection
+ */
+export function useFitBbox(
+  mapInstance: MapboxMap,
+  initialBbox: OptionalBbox,
+  stacBbox: OptionalBbox
+) {
+  useEffect(() => {
+    // Prefer layer defined bounds to STAC collection bounds.
+    const bounds = (initialBbox ?? stacBbox) as
+      | [number, number, number, number]
+      | undefined;
+
+    if (bounds?.length && checkFitBoundsFromLayer(bounds, mapInstance)) {
+      mapInstance.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
+    }
+  }, [mapInstance, initialBbox, stacBbox]);
+}

--- a/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
@@ -12,11 +12,7 @@ import { Feature } from 'geojson';
 import { endOfDay, startOfDay } from 'date-fns';
 import centroid from '@turf/centroid';
 
-import {
-  requestQuickCache,
-  useFitBbox,
-  useLayerInteraction
-} from './utils';
+import { requestQuickCache, useFitBbox, useLayerInteraction } from './utils';
 import { useMapStyle } from './styles';
 import { useCustomMarker } from './custom-marker';
 
@@ -47,7 +43,8 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
     bounds,
     onStatusChange,
     isHidden,
-    idSuffix = ''
+    idSuffix = '',
+    urlPosition
   } = props;
 
   const theme = useTheme();
@@ -288,7 +285,7 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
   //
   // FitBounds when needed
   //
-  useFitBbox(mapInstance, bounds, featuresBbox);
+  useFitBbox(mapInstance, urlPosition, bounds, featuresBbox);
 
   return null;
 }

--- a/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/vector-timeseries.tsx
@@ -30,6 +30,7 @@ export interface MapLayerVectorTimeseriesProps {
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isHidden?: boolean;
   idSuffix?: string;
+  isPositionSet?: boolean;
 }
 
 export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
@@ -44,7 +45,7 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
     onStatusChange,
     isHidden,
     idSuffix = '',
-    urlPosition
+    isPositionSet
   } = props;
 
   const theme = useTheme();
@@ -285,7 +286,7 @@ export function MapLayerVectorTimeseries(props: MapLayerVectorTimeseriesProps) {
   //
   // FitBounds when needed
   //
-  useFitBbox(mapInstance, urlPosition, bounds, featuresBbox);
+  useFitBbox(mapInstance, !!isPositionSet, bounds, featuresBbox);
 
   return null;
 }

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -570,6 +570,8 @@ function DatasetsExplore() {
               isComparing={isComparing}
               initialPosition={mapPosition ?? undefined}
               onPositionChange={(v) => {
+                // Only store the map position if the change was initiated by
+                // the user.
                 if (v.userInitiated) {
                   setMapPosition(v);
                 }

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -569,7 +569,11 @@ function DatasetsExplore() {
               compareDate={selectedCompareDatetime ?? undefined}
               isComparing={isComparing}
               initialPosition={mapPosition ?? undefined}
-              onPositionChange={setMapPosition}
+              onPositionChange={(v) => {
+                if (v.userInitiated) {
+                  setMapPosition(v);
+                }
+              }}
               projection={mapProjection ?? projectionDefault}
               onProjectionChange={setMapProjection}
             />

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -215,6 +215,7 @@ function DatasetsExplore() {
   useEffect(() => {
     setPanelRevealed(!isMediumDown);
   }, [isMediumDown]);
+
   // When the panel changes resize the map after a the animation finishes.
   useEffect(() => {
     const id = setTimeout(

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -72,7 +72,7 @@ These values may vary greatly depending on the layer being added but some may be
 `[int, int, int, int] | fn(bag)`  
 Initial bounds for the map. This is useful for datasets that are not global, and for which the STAC bounds are not appropriate.
 
-This property should be an array with 4 numbers, representing the minimum and maximum longitude and latitude values, in that order.
+This property should be an array with 4 numbers, representing the minimum and maximum longitude and latitude values, in the following order: [minLongitude, minLatitude, maxLongitude, maxLatitude].
 Example (world bounds)
 ```yml
 bounds: [-180, -90, 180, 90] 

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -70,7 +70,7 @@ These values may vary greatly depending on the layer being added but some may be
 
 **bounds**  
 `[int, int, int, int] | fn(bag)`  
-Initial bounds for the map. This is useful for datasets that are not global, and for which the STAC bounds are not appropriate.
+Initial bounds for the map. This is useful for adjusting the initial view on datasets for which the STAC bounds are not appropriate.
 
 This property should be an array with 4 numbers, representing the minimum and maximum longitude and latitude values, in the following order: [minLongitude, minLatitude, maxLongitude, maxLatitude].
 Example (world bounds)

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -16,6 +16,7 @@ initialDatetime: 'oldest' | 'newest' | Date(YYYY-MM-DD) = 'newest'
 description: string
 projection: Projection
 zoomExtent: [int, int] | null | fn(bag)
+bounds: [int, int, int, int] | null | fn(bag)
 sourceParams:
   [key]: value | fn(bag)
 compare: Compare
@@ -66,6 +67,20 @@ These values may vary greatly depending on the layer being added but some may be
 - **colormap_name**  
   `string`  
   The colormap to use for the layer. One of https://cogeotiff.github.io/rio-tiler/colormap/#default-rio-tilers-colormaps
+
+**bounds**  
+`[int, int, int, int] | fn(bag)`  
+Initial bounds for the map. This is useful for datasets that are not global, and for which the STAC bounds are not appropriate.
+
+This property should be an array with 4 numbers, representing the minimum and maximum longitude and latitude values, in that order.
+Example (world bounds)
+```yml
+bounds: [-180, -90, 180, 90] 
+```
+
+Note on bounds and dataset layer switching:  
+The exploration map will always prioritize the position set in the url. This is so that the user can share a link to a specific location. However, upon load the map will check if the position set in the url is within or overlapping the bounds of the dataset layer. If it is not, the map will switch to the dataset layer bounds avoiding showing an empty map when the user shares a link to a location that is not within the dataset layer bounds.
+If there are no bounds set in the dataset configuration, the bbox from the STAC catalog will be used if available, otherwise it will default to the world bounds.
 
 ### Projection
 

--- a/mock/datasets/fire.data.mdx
+++ b/mock/datasets/fire.data.mdx
@@ -23,17 +23,9 @@ taxonomy:
     values:
       - COx
 layers:
-  - id: eis_fire_fireline
-    stacCol: eis_fire_fireline
-    name: Fire
-    type: vector
-    description: eis_fire_fireline
-    zoomExtent:
-      - 5
-      - 20
   - id: eis_fire_perimeter
     stacCol: eis_fire_perimeter
-    name: Fire Perimeter
+    name: Fire
     type: vector
     description: eis_fire_perimeter
     zoomExtent:

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -37,8 +37,9 @@ taxonomy:
 layers:
   - id: no2-monthly
     stacCol: no2-monthly
-    name: No2
+    name: No2 PT
     type: raster
+    bounds: [-10, 36, -5, 42]
     description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     zoomExtent:
       - 0
@@ -73,7 +74,8 @@ layers:
         - "#050308"
   - id: no2-monthly-2
     stacCol: no2-monthly
-    name: No2
+    name: No2 US
+    bounds: [-124, 29, -65, 49]
     type: raster
     description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     zoomExtent:

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -26,6 +26,7 @@ declare module 'veda' {
 
   interface DatasetLayerCommonProps {
     zoomExtent?: number[];
+    bounds?: number[];
     sourceParams?: Record<string, any>;
   }
 


### PR DESCRIPTION
This PR adds support for dataset layers to define initial bounds for the map. This is useful for datasets that are not global, and for which the STAC bounds are not appropriate.

Bounds are defined using a `bounds` property on the dataset layer. This property should be an array with 4 numbers, representing the minimum and maximum longitude and latitude values, in that order.
Example (world bounds)
```yml
bounds: [-180, -90, 180, 90] 
```

Note on bounds and dataset layer switching:  
The exploration map will always prioritize the position set in the url. This is so that the user can share a link to a specific location. However, upon load the map will check if the position set in the url is within or overlapping the bounds of the dataset layer. If it is not, the map will switch to the dataset layer bounds. This is to avoid showing an empty map when the user shares a link to a location that is not within the dataset layer bounds.
If there are no bounds set in the dataset configuration, the bbox from the STAC catalog will be used if available, otherwise it will default to the world bounds.