### PR TITLE
Align legend unit

### DIFF
--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -168,9 +168,9 @@ const LegendList = styled.dl`
       ${visuallyHidden()}
     }
 
-    i {
-      margin: 0 auto;
-      opacity: 0;
+    .unit {
+      width: 100%;
+      text-align: center;
     }
   }
 `;
@@ -341,8 +341,8 @@ function LayerGradientGraphic(props: LayerLegendGradient) {
         </Tip>
       </dt>
       <dd>
-        <span>{printLegendVal(min)} {unit?.label}</span>
-        <i> – </i>
+        <span>{printLegendVal(min)}</span>
+        {unit?.label && <span className='unit'>{unit.label}</span>}
         <span>{printLegendVal(max)}</span>
       </dd>
     </LegendList>


### PR DESCRIPTION
Fix #599
Aligns legend units to the center.
<img width="301" alt="image" src="https://github.com/NASA-IMPACT/veda-ui/assets/1090606/e82cde79-2108-43ca-b0ee-eae48b9367ad">
