### PR TITLE
Add country coastlines

### DIFF
--- a/app/scripts/components/common/mapbox/layers/basemap.tsx
+++ b/app/scripts/components/common/mapbox/layers/basemap.tsx
@@ -15,6 +15,17 @@ interface BasemapProps {
   boundariesOption?: boolean;
 }
 
+function mapGroupNameToGroupId(
+  groupNames: string[],
+  mapboxGroups: Record<string, { name: string }>
+) {
+  const groupsAsArray = Object.entries(mapboxGroups);
+
+  return groupNames.map((groupName) => {
+    return groupsAsArray.find(([, group]) => group.name === groupName)?.[0];
+  });
+}
+
 export function Basemap({
   basemapStyleId = 'satellite',
   labelsOption = true,
@@ -53,13 +64,23 @@ export function Basemap({
   useEffect(() => {
     if (!baseStyle) return;
 
+    // Mapbox creates a groupId that can't be changed, so we need to get
+    // this id from the list of groups in the metadata section of the style.
+    const labelsGroupIds = mapGroupNameToGroupId(
+      GROUPS_BY_OPTION.labels,
+      baseStyle.metadata['mapbox:groups']
+    );
+    const boundariesGroupIds = mapGroupNameToGroupId(
+      GROUPS_BY_OPTION.boundaries,
+      baseStyle.metadata['mapbox:groups']
+    );
+
     const layers = baseStyle.layers.map((layer) => {
       const layerGroup = (layer as Layer).metadata?.['mapbox:group'];
 
       if (layerGroup) {
-        const isLabelsLayer = GROUPS_BY_OPTION.labels.includes(layerGroup);
-        const isBoundariesLayer =
-          GROUPS_BY_OPTION.boundaries.includes(layerGroup);
+        const isLabelsLayer = labelsGroupIds.includes(layerGroup);
+        const isBoundariesLayer = boundariesGroupIds.includes(layerGroup);
 
         const visibility =
           (isLabelsLayer && labelsOption) ||

--- a/app/scripts/components/common/mapbox/map-options/basemaps.ts
+++ b/app/scripts/components/common/mapbox/map-options/basemaps.ts
@@ -2,14 +2,15 @@
  * Basemap style requirements (followed by standaard Mapbox Studio styles)
  * - have a layer named "admin-0-boundary-bg". Data will be added below
  *   this layer to ensure country oulines and labels are visible.
- * - for label and boundaries layers to be toggled on and off, they must 
- *   belong to a group specifically named - see GROUPS_BY_OPTION for the 
+ * - for label and boundaries layers to be toggled on and off, they must
+ *   belong to a group specifically named - see GROUPS_BY_OPTION for the
  *   list of accepted group names
  */
 
 export const BASE_STYLE_PATH = 'https://api.mapbox.com/styles/v1/covid-nasa';
 
-export const getStyleUrl = (mapboxId: string) => `${BASE_STYLE_PATH}/${mapboxId}?access_token=${process.env.MAPBOX_TOKEN}`;
+export const getStyleUrl = (mapboxId: string) =>
+  `${BASE_STYLE_PATH}/${mapboxId}?access_token=${process.env.MAPBOX_TOKEN}`;
 
 export const BASEMAP_STYLES = [
   {
@@ -50,7 +51,10 @@ export const GROUPS_BY_OPTION: Record<Option, string[]> = {
     'Road network, road-labels',
     'Transit, transit-labels'
   ],
-  boundaries: ['Administrative boundaries, admin']
+  boundaries: [
+    'Country Borders, country-borders',
+    'Administrative boundaries, admin'
+  ]
 };
 
 export type Basemap = typeof BASEMAP_STYLES;


### PR DESCRIPTION
Mapbox admin boundaries layer does not include the coastlines by default.
I had to add them to every style we use, which involved creating a new group for the coastlines layers (on each style). Because of the lack of group id customization, I had to make some changes to the code to account for this.