### PR TITLE
Support datasets without layers

### DIFF
--- a/app/scripts/components/analysis/define/index.tsx
+++ b/app/scripts/components/analysis/define/index.tsx
@@ -114,7 +114,7 @@ export const allAvailableDatasetsLayers: DatasetLayer[] = Object.values(
 )
   .map((dataset) => (dataset as VedaDatum<DatasetData>).data.layers)
   .flat()
-  .filter((d) => d.type !== 'vector');
+  .filter((d) =>  !!d && (d.type !== 'vector'));
 
 export default function Analysis() {
   const { params, setAnalysisParam } = useAnalysisParams();

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -54,7 +54,7 @@ function DatasetsOverview() {
           description={dataset.data.description}
           renderBetaBlock={() => (
               <PageActions>
-                { dataset.data.layers && 
+                { !!dataset.data.layers && 
                   <Button
                     forwardedAs={Link}
                     to={getDatasetExplorePath(dataset.data)}

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -54,7 +54,7 @@ function DatasetsOverview() {
           description={dataset.data.description}
           renderBetaBlock={() => (
               <PageActions>
-                { !!dataset.data.layers && 
+                {!!dataset.data.layers && (
                   <Button
                     forwardedAs={Link}
                     to={getDatasetExplorePath(dataset.data)}
@@ -64,7 +64,7 @@ function DatasetsOverview() {
                     <CollecticonCompass />
                     Explore data
                   </Button>
-                }
+                )}
                 <NotebookConnectButton
                   dataset={dataset.data}
                   size='large'

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -54,15 +54,17 @@ function DatasetsOverview() {
           description={dataset.data.description}
           renderBetaBlock={() => (
               <PageActions>
-                <Button
-                  forwardedAs={Link}
-                  to={getDatasetExplorePath(dataset.data)}
-                  size='large'
-                  variation='achromic-outline'
-                >
-                  <CollecticonCompass />
-                  Explore data
-                </Button>
+                { dataset.data.layers && 
+                  <Button
+                    forwardedAs={Link}
+                    to={getDatasetExplorePath(dataset.data)}
+                    size='large'
+                    variation='achromic-outline'
+                  >
+                    <CollecticonCompass />
+                    Explore data
+                  </Button>
+                }
                 <NotebookConnectButton
                   dataset={dataset.data}
                   size='large'

--- a/mock/datasets/no-layers.data.mdx
+++ b/mock/datasets/no-layers.data.mdx
@@ -1,0 +1,25 @@
+---
+id: no-layers
+name: 'No layers dataset'
+description: "No layers"
+media:
+  src: ::file ./no2--dataset-cover.jpg
+  alt: Power plant shooting steam at the sky.
+  author:
+    name: Mick Truyts
+    url: https://unsplash.com/photos/x6WQeNYJC1w
+taxonomy:
+  - name: Topics
+    values:
+      - Covid 19
+  - name: Sector
+    values:
+      - Agriculture, Forestry and Land Use
+      - Energy
+  - name: Producer
+    values:
+      - NIST
+  - name: Gas Emission
+    values:
+      - COx
+---


### PR DESCRIPTION
# Description
For the GHG center dashboard, we're experimenting with datasets that don't have raster layers. For such datasets, we embed custom interfaces in the dataset overview page. For such datasets, that don't have "layers", the "Explore" button shouldn't be visible.

# Changes made
- Added a conditional so that the "Explore" button is shown only if the layers are populated
- Added a mock dataset with no layer to test the feature out
- Filter only datasets that have layers in the analysis page