### PR TITLE
Fix last domain date not being included

### DIFF
--- a/app/scripts/components/exploration/atoms/hooks.ts
+++ b/app/scripts/components/exploration/atoms/hooks.ts
@@ -6,11 +6,22 @@ import { add, max } from 'date-fns';
 
 import { DAY_SIZE_MAX } from '../constants';
 import {
+  TimeDensity,
   TimelineDataset,
   TimelineDatasetStatus,
   TimelineDatasetSuccess
 } from '../types.d.ts';
 import { timelineDatasetsAtom, timelineSizesAtom } from './atoms';
+
+function addDurationToDate(date, timeDensity: TimeDensity) {
+  const duration = {
+    [TimeDensity.YEAR]: { years: 1 },
+    [TimeDensity.MONTH]: { months: 1 },
+    [TimeDensity.DAY]: { days: 1 }
+  }[timeDensity];
+
+  return add(date, duration);
+}
 
 /**
  * Calculates the date domain of the datasets, if any are selected.
@@ -33,7 +44,12 @@ export function useTimelineDatasetsDomain() {
     // is ordered and only look at first and last dates.
     const [start, end] = extent(
       successDatasets.flatMap((d) =>
-        d.data.domain.length ? [d.data.domain[0], d.data.domain.last] : []
+        d.data.domain.length
+          ? [
+              d.data.domain[0],
+              addDurationToDate(d.data.domain.last, d.data.timeDensity)
+            ]
+          : []
       )
     ) as [Date, Date];
 

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -9,6 +9,7 @@ import { useAtom } from 'jotai';
 import { timelineDatasetsAtom } from '../atoms/atoms';
 import {
   StacDatasetData,
+  TimeDensity,
   TimelineDataset,
   TimelineDatasetStatus
 } from '../types.d.ts';
@@ -79,8 +80,8 @@ async function fetchStacDatasetById(
   );
 
   const commonTimeseriesParams = {
-    isPeriodic: data['dashboard:is_periodic'],
-    timeDensity: data['dashboard:time_density']
+    isPeriodic: !!data['dashboard:is_periodic'],
+    timeDensity: data['dashboard:time_density'] || TimeDensity.DAY
   };
 
   if (type === 'vector') {

--- a/mock/datasets/sandbox.data.mdx
+++ b/mock/datasets/sandbox.data.mdx
@@ -161,6 +161,32 @@ layers:
           label: "Out of season"
         - color: "#804115"
           label: "No data"
+  - id: facebook_population_density
+    stacCol: facebook_population_density
+    name: 'Facebook Population Density'
+    type: raster
+    description: 'Facebook high-resolution population density with a 30m² resolution'
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+      resampling: bilinear
+      bidx: 1
+      colormap_name: ylorrd
+      rescale:
+        - 0
+        - 69
+    legend:
+      type: gradient
+      min: "0"
+      max: "69"
+      stops:
+      - "#ffffcc"
+      - "#fee187"
+      - "#feab49"
+      - "#fc5b2e"
+      - "#d41020"
+      - "#800026"
 related:
   - type: dataset
     id: no2


### PR DESCRIPTION
Fixes the problem identified in https://github.com/NASA-IMPACT/veda-ui/pull/645#pullrequestreview-1614873277

The problem was that the timeline domain was not including the last time period. It was considering the last date returned by the dataset time extend to be the end, while the end should be that date plus one unit of whatever is the dataset's time density.