### PR TITLE
Remove check map bbox, add bbox validation

### DIFF
--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -435,6 +435,17 @@ export function useLayerInteraction({
 type OptionalBbox = number[] | undefined | null;
 
 /**
+ * MapboxGL requires maxX value to be 180, minX -180, maxY 90, minY -90
+ * @param bounds Bounding box to fit layer
+ * @returns Boolean
+ */
+
+function isBboxToFitValid(bounds) {
+  const [minX, minY, maxX, maxY] = bounds;
+  return minX >= -180 && maxX <= 180 && minY >= -90 && maxY <= 90;
+}
+
+/**
  * Centers on the given bounds if the current position is not within the bounds,
  * and there's no user defined position (via user initiated map movement). Gives
  * preference to the layer defined bounds over the STAC collection bounds.
@@ -458,7 +469,7 @@ export function useFitBbox(
       | [number, number, number, number]
       | undefined;
 
-    if (bounds?.length && checkFitBoundsFromLayer(bounds, mapInstance)) {
+    if (bounds?.length && isBboxToFitValid(bounds)) {
       mapInstance.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
     }
   }, [mapInstance, isUserPositionSet, initialBbox, stacBbox]);

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -372,30 +372,6 @@ export function getMergedBBox(features: StacFeature[]) {
 
 export const FIT_BOUNDS_PADDING = 32;
 
-export function checkFitBoundsFromLayer(
-  layerBounds?: [number, number, number, number],
-  mapInstance?: MapboxMap
-) {
-  if (!layerBounds || !mapInstance) return false;
-
-  const [minXLayer, minYLayer, maxXLayer, maxYLayer] = layerBounds;
-  const [[minXMap, minYMap], [maxXMap, maxYMap]] = mapInstance
-    .getBounds()
-    .toArray();
-  const isOutside =
-    maxXLayer < minXMap ||
-    minXLayer > maxXMap ||
-    maxYLayer < minYMap ||
-    minYLayer > maxYMap;
-  const layerExtentSmaller =
-    maxXLayer - minXLayer < maxXMap - minXMap &&
-    maxYLayer - minYLayer < maxYMap - minYMap;
-
-  // only fitBounds if layer extent is smaller than viewport extent (ie zoom to area of interest),
-  // or if layer extent does not overlap at all with viewport extent (ie pan to area of interest)
-  return layerExtentSmaller || isOutside;
-}
-
 interface LayerInteractionHookOptions {
   layerId: string;
   mapInstance: MapboxMap;


### PR DESCRIPTION
As far as I can read, the code requires the new bound either to totally fit into the current bound or totally outside of the current bound. This blocks me from setting up the initial view as [-180, -90, 180, 90] for this issue: https://github.com/NASA-IMPACT/veda-ui/issues/656 (It looks like Mapbox's default viewport for equirectangular projection is somewhere [-190, -59, 190, 59]... pretty sure it changes depending on the screen size.) 

I don't have much background context but I wonder if we really need to check the current bound? (If not, we can just merge this change to `main` instead of `ghg` - and I will remove the function.) This PR skips this check and just validate the bbox against Mapbox's requirement. 
