### PR TITLE
Adds option to hide dataset explore button

### DIFF
--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -44,7 +44,10 @@ function DatasetsOverview() {
           parentTo: DATASETS_PATH,
           items: allDatasetsProps,
           currentId: dataset.data.id,
-          localMenuCmp: <DatasetsLocalMenu dataset={dataset} />
+          localMenuCmp:
+            dataset?.data.disableExplore !== true ? (
+              <DatasetsLocalMenu dataset={dataset} />
+            ) : null
         }}
       />
 
@@ -53,7 +56,8 @@ function DatasetsOverview() {
           title={`${dataset.data.name} Overview`}
           description={dataset.data.description}
           renderBetaBlock={() => (
-              <PageActions>
+            <PageActions>
+              {dataset?.data.disableExplore !== true && (
                 <Button
                   forwardedAs={Link}
                   to={getDatasetExplorePath(dataset.data)}
@@ -63,13 +67,14 @@ function DatasetsOverview() {
                   <CollecticonCompass />
                   Explore data
                 </Button>
-                <NotebookConnectButton
-                  dataset={dataset.data}
-                  size='large'
-                  compact={false}
-                  variation='achromic-outline'
-                />
-              </PageActions>
+              )}
+              <NotebookConnectButton
+                dataset={dataset.data}
+                size='large'
+                compact={false}
+                variation='achromic-outline'
+              />
+            </PageActions>
           )}
           renderDetailsBlock={() => (
             <>

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -59,7 +59,7 @@ function DatasetsOverview() {
             <PageActions>
               {dataset?.data.disableExplore !== true && (
                 <Button
-                  forwardedAs={Link}
+                  forwardedAs={Link as any}
                   to={getDatasetExplorePath(dataset.data)}
                   size='large'
                   variation='achromic-outline'

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -5,7 +5,7 @@ import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { DevseedUiThemeProvider as DsTp } from '@devseed-ui/theme-provider';
 import { userPages } from 'veda';
 
-import { discoveryRoutes, thematicRoutes } from './redirects';
+import { DatasetExploreRedirect, discoveryRoutes, thematicRoutes } from './redirects';
 
 import theme, { GlobalStyles } from '$styles/theme';
 import { getAppURL } from '$utils/history';
@@ -28,7 +28,6 @@ const StoriesHub = lazy(() => import('$components/stories/hub'));
 const StoriesSingle = lazy(() => import('$components/stories/single'));
 
 const DataCatalog = lazy(() => import('$components/data-catalog'));
-const DatasetsExplore = lazy(() => import('$components/datasets/s-explore'));
 const DatasetsOverview = lazy(() => import('$components/datasets/s-overview'));
 
 const Analysis = lazy(() => import('$components/analysis/define'));
@@ -95,7 +94,7 @@ function Root() {
                 />
                 <Route
                   path={`${DATASETS_PATH}/:datasetId/explore`}
-                  element={<DatasetsExplore />}
+                  element={<DatasetExploreRedirect />}
                 />
                 <Route path={STORIES_PATH} element={<StoriesHub />} />
                 <Route

--- a/app/scripts/redirects.tsx
+++ b/app/scripts/redirects.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { Navigate, Route, useParams } from 'react-router';
 
 import { STORIES_PATH } from '$utils/routes';
+import { useDataset } from '$utils/veda-data';
+import DatasetsOverview from '$components/datasets/s-overview';
+import DatasetsExplore from '$components/datasets/s-explore';
 
 function DiscoveryRedirect() {
   const { discoveryId } = useParams();
@@ -52,3 +55,8 @@ export const discoveryRoutes = (
     <Route path='discoveries/:discoveryId' element={<DiscoveryRedirect />} />
   </Route>
 );
+
+export function DatasetExploreRedirect() {
+  const dataset = useDataset();
+  return dataset?.data.disableExplore ? <DatasetsOverview /> : <DatasetsExplore />;
+}

--- a/app/scripts/redirects.tsx
+++ b/app/scripts/redirects.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import { Navigate, Route, useParams } from 'react-router';
 
-import { STORIES_PATH } from '$utils/routes';
+import { DATASETS_PATH, STORIES_PATH } from '$utils/routes';
 import { useDataset } from '$utils/veda-data';
-import DatasetsOverview from '$components/datasets/s-overview';
 import DatasetsExplore from '$components/datasets/s-explore';
 
 function DiscoveryRedirect() {
@@ -58,5 +57,10 @@ export const discoveryRoutes = (
 
 export function DatasetExploreRedirect() {
   const dataset = useDataset();
-  return dataset?.data.disableExplore ? <DatasetsOverview /> : <DatasetsExplore />;
+  const url = `${DATASETS_PATH}/${dataset?.data.id}`;
+  return dataset?.data.disableExplore ? (
+    <Navigate replace to={url} />
+  ) : (
+    <DatasetsExplore />
+  );
 }

--- a/docs/content/CONTENT.md
+++ b/docs/content/CONTENT.md
@@ -50,6 +50,7 @@ media: Media
 thematics: string[]
 sources: string[]
 featured: boolean
+disableExplore: boolean
 
 layers: Layer[]
 related: Related[]
@@ -108,6 +109,11 @@ taxonomy:
 `boolean`  
 Whether this dataset is featured
 ![](./media/fm-featured-dataset.png)
+
+**disableExplore**  
+`boolean`  
+When set to true, the 'explore data' section won't be available for this dataset.
+
 
 **layers**  
 `Layer[]`  

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -151,6 +151,7 @@ declare module 'veda' {
     media?: Media;
     layers: DatasetLayer[];
     related?: RelatedContentData[];
+    disableExplore?: boolean;
   }
 
   // ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Adds a `disableExplore` parameter on the dataset frontmatter
- When set to true, the 'Explore data' button and the 'Overview/Exploration' submenu are not shown on the overview page
- When set to true, the `/[dataset]/exploration' route redirects to `/[dataset]`

Added for https://github.com/NASA-IMPACT/veda-config-ghg/issues/132