### PR TITLE
Check only day level equality for selected date

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -8,6 +8,7 @@ import React, {
 import styled from 'styled-components';
 import { useNavigate } from 'react-router';
 import useQsStateCreator from 'qs-state-hook';
+import { isSameDay } from 'date-fns';
 import { themeVal } from '@devseed-ui/theme-provider';
 import {
   CollecticonExpandFromLeft,
@@ -113,9 +114,10 @@ const isSelectedDateValid = (dateList, selectedDate) => {
     // Since the available dates changes, check if the currently selected
     // one is valid.
     const validDate = !!dateList.find(
-      (d) => d.getTime() === selectedDate?.getTime()
+      // Only check if the date of the selected date is in the range.
+      // Because Dashboard can only provide daily level selection.
+      (d) => isSameDay(new Date(d), new Date(selectedDate))
     );
-
     return !!validDate;
   }
   return true;
@@ -175,7 +177,6 @@ const useDatePickerValue = (
     }),
     [value]
   );
-
   return [val, onConfirm] as [typeof val, typeof onConfirm];
 };
 
@@ -518,6 +519,7 @@ function DatasetsExplore() {
     selectedDatetime,
     setSelectedDatetime
   );
+
   const [datePickerCompareValue, datePickerCompareConfirm] = useDatePickerValue(
     selectedCompareDatetime,
     setSelectedCompareDatetime


### PR DESCRIPTION
The date gets set back when I try to change the date for Plume datasets: https://ghg-demo.netlify.app/data-catalog/emit-ch4plume-v1/explore?projection=mercator%7C%7C&basemapid=satellite&datetime=2023-07-29T10%3A06%3A30.000Z

This is because when a user inputs the date, the code checks if the date is in datetime list of the collection. Since Dashboard only provides daily level selection, selected datetime gets rounded down to the midnight of the selected date. Plume data datetimes don't have 00:00 timestamps, the selected date gets invalidated. I changed the code to check only day-level equality to align with dashboard capacity. 