### PR TITLE
Add styles to make panel scrollable

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -100,13 +100,40 @@ const DatesWrapper = styled.div`
   position: relative;
   z-index: 10;
   box-shadow: 0 1px 0 0 ${themeVal('color.base-100a')};
-
   > ${PanelWidget} {
     width: 100%;
     position: relative;
     z-index: 10;
     box-shadow: 0 -1px 0 0 ${themeVal('color.base-100a')};
   }
+`;
+
+const PositionPlaceHoderForScroll = styled.div`
+  position: absolute;
+  pointer-events: none;
+  z-index: 1000;
+  top: 0px;
+  left: 0px;
+  width: 1.5rem;
+  height: 100%;
+  background: linear-gradient(
+    to left,
+    rgba(255, 255, 255, 0) 0%,
+    rgb(255, 255, 255) 100%
+  );
+`;
+
+const ScrollArea = styled.div`
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  height: 100%;
+`;
+
+const ScrollAreaInner = styled.div`
+  position: absolute;
+  inset: 0px;
+  overflow: scroll;
 `;
 
 const isSelectedDateValid = (dateList, selectedDate) => {
@@ -557,7 +584,7 @@ function DatasetsExplore() {
         }}
         hideFooter
       />
-      <PageMainContent>
+      <PageMainContent id='page-main-content'>
         <PageHero title={`${dataset.data.name} Exploration`} isHidden />
         <Explorer>
           <Panel revealed={panelRevealed} onClick={onPanelClick}>
@@ -587,52 +614,57 @@ function DatasetsExplore() {
                 </PanelActions>
               </PanelHeader>
               <PanelBody>
-                <DatesWrapper>
-                  {activeLayerTimeseries && (
-                    <PanelDateWidget
-                      title='Date'
-                      value={datePickerValue}
-                      onConfirm={datePickerConfirm}
-                      timeDensity={activeLayerTimeseries.timeDensity}
-                      availableDates={availableActiveLayerDates}
-                    >
-                      {activeLayerCompareTimeseries && (
-                        <FormSwitch
-                          id='compare-date-toggle'
-                          name='compare-date-toggle'
-                          value='compare-date-toggle'
-                          checked={isComparing}
-                          textPlacement='right'
-                          onChange={() => setIsComparing((v) => !v)}
+                <PositionPlaceHoderForScroll />
+                <ScrollArea>
+                  <ScrollAreaInner>
+                    <DatesWrapper>
+                      {activeLayerTimeseries && (
+                        <PanelDateWidget
+                          title='Date'
+                          value={datePickerValue}
+                          onConfirm={datePickerConfirm}
+                          timeDensity={activeLayerTimeseries.timeDensity}
+                          availableDates={availableActiveLayerDates}
                         >
-                          Toggle date comparison
-                        </FormSwitch>
+                          {activeLayerCompareTimeseries && (
+                            <FormSwitch
+                              id='compare-date-toggle'
+                              name='compare-date-toggle'
+                              value='compare-date-toggle'
+                              checked={isComparing}
+                              textPlacement='right'
+                              onChange={() => setIsComparing((v) => !v)}
+                            >
+                              Toggle date comparison
+                            </FormSwitch>
+                          )}
+                        </PanelDateWidget>
                       )}
-                    </PanelDateWidget>
-                  )}
-                  {isComparing && activeLayerCompareTimeseries && (
-                    <PanelDateWidget
-                      title='Date comparison'
-                      value={datePickerCompareValue}
-                      onConfirm={datePickerCompareConfirm}
-                      timeDensity={activeLayerCompareTimeseries.timeDensity}
-                      availableDates={availableActiveLayerCompareDates}
-                    />
-                  )}
-                </DatesWrapper>
-                <PanelWidget>
-                  <PanelWidgetHeader>
-                    <PanelWidgetTitle>Layers</PanelWidgetTitle>
-                  </PanelWidgetHeader>
-                  <PanelWidgetBody>
-                    <DatasetLayers
-                      datasetId={dataset.data.id}
-                      asyncLayers={asyncLayers}
-                      selectedLayerId={selectedLayerId ?? undefined}
-                      onAction={onLayerAction}
-                    />
-                  </PanelWidgetBody>
-                </PanelWidget>
+                      {isComparing && activeLayerCompareTimeseries && (
+                        <PanelDateWidget
+                          title='Date comparison'
+                          value={datePickerCompareValue}
+                          onConfirm={datePickerCompareConfirm}
+                          timeDensity={activeLayerCompareTimeseries.timeDensity}
+                          availableDates={availableActiveLayerCompareDates}
+                        />
+                      )}
+                    </DatesWrapper>
+                    <PanelWidget id='panel-widget'>
+                      <PanelWidgetHeader>
+                        <PanelWidgetTitle>Layers</PanelWidgetTitle>
+                      </PanelWidgetHeader>
+                      <PanelWidgetBody>
+                        <DatasetLayers
+                          datasetId={dataset.data.id}
+                          asyncLayers={asyncLayers}
+                          selectedLayerId={selectedLayerId ?? undefined}
+                          onAction={onLayerAction}
+                        />
+                      </PanelWidgetBody>
+                    </PanelWidget>
+                  </ScrollAreaInner>
+                </ScrollArea>
               </PanelBody>
             </PanelInner>
           </Panel>

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -108,7 +108,7 @@ const DatesWrapper = styled.div`
   }
 `;
 
-const PositionPlaceHoderForScroll = styled.div`
+const PositionPlaceHolderForScroll = styled.div`
   position: absolute;
   pointer-events: none;
   z-index: 1000;
@@ -584,7 +584,7 @@ function DatasetsExplore() {
         }}
         hideFooter
       />
-      <PageMainContent id='page-main-content'>
+      <PageMainContent>
         <PageHero title={`${dataset.data.name} Exploration`} isHidden />
         <Explorer>
           <Panel revealed={panelRevealed} onClick={onPanelClick}>
@@ -614,7 +614,7 @@ function DatasetsExplore() {
                 </PanelActions>
               </PanelHeader>
               <PanelBody>
-                <PositionPlaceHoderForScroll />
+                <PositionPlaceHolderForScroll />
                 <ScrollArea>
                   <ScrollAreaInner>
                     <DatesWrapper>

--- a/app/scripts/styles/panel.tsx
+++ b/app/scripts/styles/panel.tsx
@@ -105,6 +105,7 @@ export const PanelBody = styled.div`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  position:relative;
 
   > div > div:nth-child(2),
   > div > div:nth-child(3) {


### PR DESCRIPTION
Follow up of : https://github.com/NASA-IMPACT/veda-ui/pull/691
Fixing panel overflowing problem in https://deploy-preview-201--ghg-demo.netlify.app/data-catalog/epa-ch4emission-yeargrid-v2express/explore?projection=equirectangular%7C%7C&basemapid=light&datetime=2020-01-01T00%3A00%3A00.000Z

Wow Scroll is hard. It will be ideal if we can find a way to stick the date widget and make only layers roll, but I am giving up here.. This change basically resurrects what `ShadowScroll` does for HTML and CSS sans some unnecessary elements for this case. 

I noticed that the window scroll sometimes pops up if you scroll very fast on the panel area. (Sorry, I cannot reproduce stably enough to grab a screen recording.) this error happens in production environment, too, so this PR doesn't necessarily introduce the error. But with the default (thicker) scroll, the error seems more noticeable. 

