### PR TITLE
Update titler-xarray-endpoint to production

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,7 @@ APP_CONTACT_EMAIL=email@example.org
 
 API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
 API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
-API_XARRAY_ENDPOINT='https://dev-titiler-xarray.delta-backend.com/tilejson.json'
+API_XARRAY_ENDPOINT='https://prod-titiler-xarray.delta-backend.com/tilejson.json'
 
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:


### PR DESCRIPTION
There are now 2 deployments of titiler-xarray: one production endpoint and one dev. Dev will be reserved for new feature development and testing, so we should use the production endpoint in VEDA dashboard services. I will make an equivalent PR to veda-config.