### PR TITLE
Fix critical error on /exploration

### DIFF
--- a/app/scripts/components/common/map/index.tsx
+++ b/app/scripts/components/common/map/index.tsx
@@ -2,9 +2,19 @@ import React, { ReactNode } from 'react';
 import { MapProvider } from 'react-map-gl';
 import Maps, { MapsContextWrapperProps } from './maps';
 
+export const COMPARE_CONTAINER_NAME = 'CompareContainer';
 export function Compare({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
+
+Compare.displayName = COMPARE_CONTAINER_NAME;
+
+export const CONTROLS_CONTAINER_NAME = 'MapControlsContainer';
+export function MapControls({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}
+
+MapControls.displayName = CONTROLS_CONTAINER_NAME;
 
 export default function MapProviderWrapper(props: MapsContextWrapperProps) {
   return (

--- a/app/scripts/components/common/map/maps.tsx
+++ b/app/scripts/components/common/map/maps.tsx
@@ -3,7 +3,6 @@ import React, {
   Children,
   useMemo,
   ReactElement,
-  JSXElementConstructor,
   useState,
   createContext
 } from 'react';
@@ -23,6 +22,7 @@ import { Styles } from './styles';
 import useMapCompare from './hooks/use-map-compare';
 import MapComponent from './map-component';
 import useMaps, { useMapsContext } from './hooks/use-maps';
+import { COMPARE_CONTAINER_NAME, CONTROLS_CONTAINER_NAME } from '.';
 
 const chevronRightURI = () =>
   iconDataURI(CollecticonChevronRightSmall, {
@@ -92,13 +92,19 @@ function Maps({ children, projection }: MapsProps) {
 
     const sortedChildren = childrenArr.reduce(
       (acc, child) => {
-        const componentName = (child.type as JSXElementConstructor<any>).name;
-        if (componentName === 'Compare') {
+        // This is added so that we can use the component name in production
+        // where the function names are minified
+        // @ts-expect-error displayName is not in the type
+        const componentName = child.type.displayName ?? '';
+
+        if (componentName === COMPARE_CONTAINER_NAME) {
           acc.compareGenerators = Children.toArray(
             child.props.children
           ) as ReactElement[];
-        } else if (componentName.endsWith('Control')) {
-          acc.controls = [...acc.controls, child];
+        } else if (componentName == CONTROLS_CONTAINER_NAME) {
+          acc.controls = Children.toArray(
+            child.props.children
+          ) as ReactElement[];
         } else {
           acc.generators = [...acc.generators, child];
         }

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -2,7 +2,11 @@ import React, { useState } from 'react';
 import { useAtomValue } from 'jotai';
 
 import { useStacMetadataOnDatasets } from '../../hooks/use-stac-metadata-datasets';
-import { selectedCompareDateAtom, selectedDateAtom, timelineDatasetsAtom } from '../../atoms/atoms';
+import {
+  selectedCompareDateAtom,
+  selectedDateAtom,
+  timelineDatasetsAtom
+} from '../../atoms/atoms';
 import {
   TimelineDatasetStatus,
   TimelineDatasetSuccess
@@ -10,7 +14,7 @@ import {
 import { Layer } from './layer';
 import { AnalysisMessageControl } from './analysis-message-control';
 
-import Map, { Compare } from '$components/common/map';
+import Map, { Compare, MapControls } from '$components/common/map';
 import { Basemap } from '$components/common/map/style-generators/basemap';
 import GeocoderControl from '$components/common/map/controls/geocoder';
 import { ScaleControl } from '$components/common/map/controls';
@@ -71,31 +75,33 @@ export function ExplorationMap() {
           />
         ))}
       {/* Map controls */}
-      <DrawControl
-        displayControlsDefault={false}
-        controls={
-          {
-            polygon: true,
-            trash: true
-          } as any
-        }
-      />
-      <CustomAoIControl />
-      <ResetAoIControl />
-      <AnalysisMessageControl />
-      <GeocoderControl />
-      <MapOptionsControl
-        projection={projection}
-        onProjectionChange={setProjection}
-        basemapStyleId={mapBasemapId}
-        onBasemapStyleIdChange={setBasemapId}
-        labelsOption={labelsOption}
-        boundariesOption={boundariesOption}
-        onOptionChange={onOptionChange}
-      />
+      <MapControls>
+        <DrawControl
+          displayControlsDefault={false}
+          controls={
+            {
+              polygon: true,
+              trash: true
+            } as any
+          }
+        />
+        <CustomAoIControl />
+        <ResetAoIControl />
+        <AnalysisMessageControl />
+        <GeocoderControl />
+        <MapOptionsControl
+          projection={projection}
+          onProjectionChange={setProjection}
+          basemapStyleId={mapBasemapId}
+          onBasemapStyleIdChange={setBasemapId}
+          labelsOption={labelsOption}
+          boundariesOption={boundariesOption}
+          onOptionChange={onOptionChange}
+        />
 
-      <ScaleControl />
-      <MapCoordsControl />
+        <ScaleControl />
+        <MapCoordsControl />
+      </MapControls>
       {comparing && (
         // Compare map layers
         <Compare>


### PR DESCRIPTION
The error identified in https://github.com/NASA-IMPACT/veda-ui/pull/708 was introduced by the commit 6721546004ff38bbac40eb9e44e3a6c57342ba47.

https://github.com/NASA-IMPACT/veda-ui/blob/bd3440cafe950d335e31543eefa91512ae04fa42/app/scripts/components/common/map/maps.tsx#L95-L103

The code here uses the `name` property (which is derived from the function name) to understand what to do with the component being rendered. The problem is that in a `production` environment, the code is minified and function names change making this property unreliable and unpredictable.

The solution I found was to use the `displayName` property that react allows us to attach to components to give them some names. This is a paradigm we already use in the app with the blocks for the scrollytelling ([eg1](https://github.com/NASA-IMPACT/veda-ui/blob/0a84a5e14d2978aca66bb180304a6412c4368e84/app/scripts/components/common/blocks/figure.js), [eg2](https://github.com/NASA-IMPACT/veda-ui/blob/0a84a5e14d2978aca66bb180304a6412c4368e84/app/scripts/components/common/blocks/images/index.js))

**The only thing to keep in mind is that if we create a new map control, we have to give it a `displayName`.**

