### PR TITLE
Store exploration dates on url

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/atoms.ts
+++ b/app/scripts/components/common/map/controls/aoi/atoms.ts
@@ -1,22 +1,23 @@
-import { atom } from "jotai";
-import { atomWithLocation } from "jotai-location";
-import { Feature, Polygon } from "geojson";
-import { AoIFeature } from "../../types";
-import { decodeAois, encodeAois } from "$utils/polygon-url";
+import { atom } from 'jotai';
+import { atomWithLocation } from 'jotai-location';
+import { Feature, Polygon } from 'geojson';
+import { AoIFeature } from '../../types';
+import { decodeAois, encodeAois } from '$utils/polygon-url';
 
 // This is the atom acting as a single source of truth for the AOIs.
 export const aoisAtom = atomWithLocation();
 
 const aoisSerialized = atom(
-  (get) => get(aoisAtom).searchParams?.get("aois"),
+  (get) => get(aoisAtom).searchParams?.get('aois'),
   (get, set, aois) => {
-    set(aoisAtom, (prev) => ({
-      ...prev,
-      searchParams: new URLSearchParams([["aois", aois as string]])
-    }));
+    set(aoisAtom, (prev) => {
+      const searchParams = prev.searchParams ?? new URLSearchParams();
+      searchParams.set('aois', aois as string);
+
+      return { ...prev, searchParams };
+    });
   }
 );
-
 
 // Getter atom to get AoiS as GeoJSON features from the hash.
 export const aoisFeaturesAtom = atom<AoIFeature[]>((get) => {


### PR DESCRIPTION
This PR achieves 2 things:
- store the dates info in the url for sharing purposes (contribute to https://github.com/NASA-IMPACT/veda-ui/issues/527)
- Ensure that items in the url do not override each other. Since `URLSearchParams` were being initialized every time, adding something new, removed the previous ones.

Add the following the the preview url to see this working. You should see a dataset being compared and, a date range and an AOI.

```
/exploration?datasets=%5B%7B%22id%22%3A%22no2-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22min%22%2C%22label%22%3A%22Min%22%2C%22chartLabel%22%3A%22Min%22%2C%22themeColor%22%3A%22infographicA%22%7D%2C%7B%22id%22%3A%22max%22%2C%22label%22%3A%22Max%22%2C%22chartLabel%22%3A%22Max%22%2C%22themeColor%22%3A%22infographicC%22%7D%5D%7D%7D%5D&aois=%5B%22l_%7EtSc%7Efx%40ybwjP%7Bvc%60Fd%7BhyBtmyfG%22%2C%222aa8de%22%2Cfalse%5D&date=2018-11-13T00%3A00%3A00.000Z&dateRange=2017-02-14T00%3A00%3A00.000Z%7C2018-03-18T00%3A00%3A00.000Z&dateCompare=2022-07-05T23%3A00%3A00.000Z
```

Direct [Link](https://deploy-preview-713--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22no2-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22min%22%2C%22label%22%3A%22Min%22%2C%22chartLabel%22%3A%22Min%22%2C%22themeColor%22%3A%22infographicA%22%7D%2C%7B%22id%22%3A%22max%22%2C%22label%22%3A%22Max%22%2C%22chartLabel%22%3A%22Max%22%2C%22themeColor%22%3A%22infographicC%22%7D%5D%7D%7D%5D&aois=%5B%22l_%7EtSc%7Efx%40ybwjP%7Bvc%60Fd%7BhyBtmyfG%22%2C%222aa8de%22%2Cfalse%5D&date=2018-11-13T00%3A00%3A00.000Z&dateRange=2017-02-14T00%3A00%3A00.000Z%7C2018-03-18T00%3A00%3A00.000Z&dateCompare=2022-07-05T23%3A00%3A00.000Z) for convenience

