### PR TITLE
Add discoveries redirection back

### DIFF
--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { DevseedUiThemeProvider as DsTp } from '@devseed-ui/theme-provider';
 import { userPages } from 'veda';
 
+import { discoveryRoutes } from './redirects';
 import theme, { GlobalStyles } from '$styles/theme';
 import { getAppURL } from '$utils/history';
 import LayoutRoot, {
@@ -14,7 +15,6 @@ import { useScrollbarWidthAsCssVar } from '$utils/use-scrollbar-width-css';
 
 // Page loading
 import { PageLoading } from '$components/common/loading-skeleton';
-
 // Views
 import UhOh from '$components/uhoh';
 import ErrorBoundary from '$components/uhoh/fatal-error';
@@ -110,6 +110,10 @@ function Root() {
                 {process.env.NODE_ENV !== 'production' && (
                   <Route path='/sandbox/*' element={<Sandbox />} />
                 )}
+
+                {/* Legacy: Routes related to renaming /discoveries to /stories. */}
+                {discoveryRoutes}
+
                 {userPages.map((p) => (
                   <Route
                     key={p}


### PR DESCRIPTION
This PR reintroduces the redirection of the discoveries -> stories. 

Close https://github.com/NASA-IMPACT/veda-ui/issues/729

Since we could not figure out the root cause of the app crash other than there was a problem with a combination of redirecting and shadow scroll, I generally want to be careful about this change. I tested it a bit and it seems working as expected without overheads. 
