### PR TITLE
Lazy iframe

### DIFF
--- a/app/scripts/components/common/blocks/embed.tsx
+++ b/app/scripts/components/common/blocks/embed.tsx
@@ -5,7 +5,7 @@ import BrowserFrame from '$styles/browser-frame';
 
 const EmbedWrapper = styled.div`
   width: 100%;
-  
+
   > div {
     width: 100%;
   }
@@ -30,7 +30,7 @@ export default function Embed({ src, height = 800 }: EmbedProps) {
   return (
     <EmbedWrapper>
       <BrowserFrame link={src}>
-        <IframeWrapper src={src} height={height} />
+        <IframeWrapper loading='lazy' src={src} height={height} />
       </BrowserFrame>
     </EmbedWrapper>
   );

--- a/app/scripts/components/common/blocks/lazy-components.js
+++ b/app/scripts/components/common/blocks/lazy-components.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import T from 'prop-types';
 import LazyLoad from 'react-lazyload';
 
 import Chart from '$components/common/chart/block';
@@ -8,7 +9,7 @@ import Table, { tableHeight } from '$components/common/table';
 import CompareImage from '$components/common/blocks/images/compare';
 
 import Map, { mapHeight } from '$components/common/blocks/block-map';
-
+import Embed from '$components/common/blocks/embed';
 import {
   ScrollytellingBlock,
   scrollyMapHeight
@@ -72,3 +73,21 @@ export function LazyTable(props) {
     </LazyLoad>
   );
 }
+
+export function LazyEmbed(props) {
+  return (
+    <LazyLoad
+      // eslint-disable-next-line react/prop-types
+      placeholder={<LoadingSkeleton height={props.height} />}
+      offset={50}
+      once
+    >
+      <Embed {...props} />
+    </LazyLoad>
+  );
+}
+
+LazyEmbed.propTypes = {
+  src: T.string,
+  height: T.number
+};

--- a/app/scripts/components/common/mdx-content.js
+++ b/app/scripts/components/common/mdx-content.js
@@ -15,11 +15,11 @@ import {
   LazyCompareImage,
   LazyScrollyTelling,
   LazyMap,
-  LazyTable
+  LazyTable,
+  LazyEmbed
 } from '$components/common/blocks/lazy-components';
 import { NotebookConnectCalloutBlock } from '$components/common/notebook-connect';
 import SmartLink from '$components/common/smart-link';
-import Embed from '$components/common/blocks/embed';
 
 function MdxContent(props) {
   const pageMdx = useMdxPageLoader(props.loader);
@@ -45,7 +45,7 @@ function MdxContent(props) {
           NotebookConnectCallout: NotebookConnectCalloutBlock,
           Link: SmartLink,
           Table: LazyTable,
-          Embed
+          Embed: LazyEmbed
         }}
       >
         <pageMdx.MdxContent {...(props.throughProps || {})} />

--- a/mock/stories/life-of-water.stories.mdx
+++ b/mock/stories/life-of-water.stories.mdx
@@ -2,7 +2,7 @@
 featured: true
 id: 'life-of-water'
 name: This is the life of water
-description: "Sed sed lectus vitae odio vestibulum mattis. Integer iaculis nisl lectus, vel aliquet nulla imperdiet in."
+description: 'Sed sed lectus vitae odio vestibulum mattis. Integer iaculis nisl lectus, vel aliquet nulla imperdiet in.'
 media:
   src: ::file ./img-placeholder-6.jpg
   alt: Generic placeholder by Unsplash
@@ -39,5 +39,11 @@ Vestibulum justo ante, bibendum at vehicula sit amet, dignissim sit amet augue. 
 Cras eget eleifend ligula. Curabitur ac nisi tempor, molestie lorem vitae, consectetur turpis. Etiam hendrerit et sapien ac interdum.
 
 Vestibulum justo ante, bibendum at vehicula sit amet, dignissim sit amet augue. Nunc luctus orci mi, sed pretium nibh consequat sit amet. In congue metus a ullamcorper sollicitudin.
+
 </Prose>
+</Block>
+<Block>
+<Figure>
+<Embed height="600" src="https://developmentseed.org"></Embed>
+</Figure>
 </Block>


### PR DESCRIPTION
It seems EIC will require plenty of Embedded content. This PR wraps `Embed` component (which is essentially iframe) into `<Lazyload >` element, so embedded contents can load only when it is in the view. 

Lazy embed example: https://deploy-preview-743--veda-ui.netlify.app/stories/life-of-water