### PR TITLE
Add user page items to main nav

### DIFF
--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -354,12 +354,12 @@ function PageHeader() {
 
   const userPagesMainNavItem = userPages.map((id) => {
     const page = getOverride(id as any);
-    if (!page?.data.navMainItem) return false;
+    if (!(page?.data.mainNavItem && page.data.mainNavItem.navTitle)) return false;
 
     return (
       <li key={id}>
         <GlobalMenuLink to={id} onClick={closeNavOnClick}>
-          {page.data.navTitle}
+          {page.data.mainNavItem.navTitle }
         </GlobalMenuLink>
       </li>
     );
@@ -511,7 +511,7 @@ function UserPagesDotMenu(props: {
     return menuItems;
   }, []);
 
-  if (!dotMenuItems.length) return <>{false}</>;
+  if (!dotMenuItems.length) return false;
 
   if (isMediumDown) {
     return (

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -511,7 +511,7 @@ function UserPagesDotMenu(props: {
     return menuItems;
   }, []);
 
-  if (!dotMenuItems.length) return false;
+  if (!dotMenuItems.length) return <>{false}</>;
 
   if (isMediumDown) {
     return (

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -342,15 +342,28 @@ function PageHeader() {
   useEffect(() => {
     // Close global nav when media query changes.
     // NOTE: isMediumDown is returning document.body's width, not the whole window width
-    // which conflicts with how mediaquery decides the width. 
+    // which conflicts with how mediaquery decides the width.
     // JSX element susing isMediumDown is also protected with css logic because of this.
-    // ex. Look at GlobalNavActions 
+    // ex. Look at GlobalNavActions
     if (!isMediumDown) setGlobalNavRevealed(false);
   }, [isMediumDown]);
 
   const closeNavOnClick = useCallback(() => {
     setGlobalNavRevealed(false);
   }, []);
+
+  const userPagesMainNavItem = userPages.map((id) => {
+    const page = getOverride(id as any);
+    if (!page?.data.navMainItem) return false;
+
+    return (
+      <li key={id}>
+        <GlobalMenuLink to={id} onClick={closeNavOnClick}>
+          {page.data.navTitle}
+        </GlobalMenuLink>
+      </li>
+    );
+  });
 
   return (
     <PageHeaderSelf id={HEADER_ID}>
@@ -420,10 +433,7 @@ function PageHeader() {
                     </GlobalMenuLink>
                   </li>
                   <li>
-                    <GlobalMenuLink
-                      to={STORIES_PATH}
-                      onClick={closeNavOnClick}
-                    >
+                    <GlobalMenuLink to={STORIES_PATH} onClick={closeNavOnClick}>
                       {getString('stories').other}
                     </GlobalMenuLink>
                   </li>
@@ -451,6 +461,7 @@ function PageHeader() {
               <SectionsNavBlock>
                 <GlobalNavBlockTitle>Meta</GlobalNavBlockTitle>
                 <GlobalMenu>
+                  {userPagesMainNavItem}
                   <li>
                     <GlobalMenuLink to={ABOUT_PATH} onClick={closeNavOnClick}>
                       About
@@ -462,7 +473,7 @@ function PageHeader() {
                     </li>
                   )}
 
-                  <UserPagesMenu
+                  <UserPagesDotMenu
                     onItemClick={closeNavOnClick}
                     isMediumDown={isMediumDown}
                   />
@@ -478,25 +489,41 @@ function PageHeader() {
 
 export default PageHeader;
 
-function UserPagesMenu(props: {
+interface DotMenuItem {
+  id: any;
+  menu: string;
+}
+
+function UserPagesDotMenu(props: {
   isMediumDown: boolean;
   onItemClick: () => void;
 }) {
   const { isMediumDown, onItemClick } = props;
 
-  if (!userPages.length) return <>{false}</>;
+  const dotMenuItems = userPages.reduce((menuItems: DotMenuItem[], id: any) => {
+    const page = getOverride(id as any);
+    if (page?.data.menu)
+      // eslint-disable-next-line fp/no-mutating-methods
+      return menuItems.concat({
+        id,
+        menu: page.data.menu
+      });
+    return menuItems;
+  }, []);
+
+  if (!dotMenuItems.length) return <>{false}</>;
 
   if (isMediumDown) {
     return (
       <>
-        {userPages.map((id) => {
-          const page = getOverride(id as any);
+        {dotMenuItems.map((menuItem) => {
+          const page = getOverride(menuItem.id as any);
           if (!page?.data.menu) return false;
 
           return (
-            <li key={id}>
-              <GlobalMenuLink to={id} onClick={onItemClick}>
-                {page.data.menu}
+            <li key={menuItem.id}>
+              <GlobalMenuLink to={menuItem.id} onClick={onItemClick}>
+                {menuItem.menu}
               </GlobalMenuLink>
             </li>
           );

--- a/app/scripts/components/user-pages/index.tsx
+++ b/app/scripts/components/user-pages/index.tsx
@@ -18,7 +18,7 @@ function UserPages(props: { id: any }) {
 
   return (
     <PageMainContent>
-      <LayoutProps title='UserPages' />
+      <LayoutProps title={page.data.title} />
       <PageHero
         title={page.data.title || 'Page title is missing'}
         description={page.data.description}


### PR DESCRIPTION
I made this change because of the strong request from EIC. 

I am very hesitant about suggesting this change because there is no way to prevent the navigation bar from breaking with this change when a user passes too many 'navMainItem' (or even items with long names). We have to clearly communicate that veda-ui is not in charge of the breaks that can be introduced from`navMainItem`. 

Look at how it can look like : https://github.com/NASA-IMPACT/veda-config-eic/pull/24 