### PR TITLE
Pass other props for iframe

### DIFF
--- a/app/scripts/components/common/blocks/embed.tsx
+++ b/app/scripts/components/common/blocks/embed.tsx
@@ -22,7 +22,7 @@ interface EmbedProps {
   height: number;
 }
 
-export default function Embed({ src, height = 800 }: EmbedProps) {
+export default function Embed({ src, height = 800, ...props}: EmbedProps) {
   if (!src) {
     throw new HintedError('Embed block requires a URL');
   }
@@ -30,7 +30,7 @@ export default function Embed({ src, height = 800 }: EmbedProps) {
   return (
     <EmbedWrapper>
       <BrowserFrame link={src}>
-        <IframeWrapper loading='lazy' src={src} height={height} />
+        <IframeWrapper loading='lazy' src={src} height={height} {...props} />
       </BrowserFrame>
     </EmbedWrapper>
   );


### PR DESCRIPTION
I realized that there are multiple props that iframe can accept to make the communication safe/ more compatible with standard (such as https://github.com/NASA-IMPACT/veda-config-eic/pull/23/files#diff-9a900b0095d3eecf847dc69b3300d909fb529d47ce3ffe375330081d0bcdee76R145) 

This PR makes all those props be passed to iframe element.