### PR TITLE
Remove trailing Overview from page title

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -585,7 +585,7 @@ function DatasetsExplore() {
         hideFooter
       />
       <PageMainContent>
-        <PageHero title={dataset.data.name} />
+        <PageHero title={dataset.data.name} isHidden />
         <Explorer>
           <Panel revealed={panelRevealed} onClick={onPanelClick}>
             <PanelInner ref={panelBodyRef}>

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -571,7 +571,7 @@ function DatasetsExplore() {
   return (
     <>
       <LayoutProps
-        title={`${dataset.data.name} Exploration`}
+        title={`${dataset.data.name} - Exploration`}
         description={dataset.data.description}
         thumbnail={dataset.data.media?.src}
         localNavProps={{
@@ -585,7 +585,7 @@ function DatasetsExplore() {
         hideFooter
       />
       <PageMainContent>
-        <PageHero title={`${dataset.data.name} Exploration`} isHidden />
+        <PageHero title={dataset.data.name} isHidden />
         <Explorer>
           <Panel revealed={panelRevealed} onClick={onPanelClick}>
             <PanelInner ref={panelBodyRef}>

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -585,7 +585,7 @@ function DatasetsExplore() {
         hideFooter
       />
       <PageMainContent>
-        <PageHero title={dataset.data.name} isHidden />
+        <PageHero title={dataset.data.name} />
         <Explorer>
           <Panel revealed={panelRevealed} onClick={onPanelClick}>
             <PanelInner ref={panelBodyRef}>

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -35,7 +35,7 @@ function DatasetsOverview() {
   return (
     <>
       <LayoutProps
-        title={dataset.data.name}
+        title={`${dataset.data.name} Overview`}
         description={dataset.data.description}
         thumbnail={dataset.data.media?.src}
         localNavProps={{

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -53,7 +53,7 @@ function DatasetsOverview() {
 
       <PageMainContent>
         <PageHero
-          title={`${dataset.data.name} Overview`}
+          title={dataset.data.name}
           description={dataset.data.description}
           renderBetaBlock={() => (
             <PageActions>

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -35,7 +35,7 @@ function DatasetsOverview() {
   return (
     <>
       <LayoutProps
-        title={`${dataset.data.name} Overview`}
+        title={`${dataset.data.name} - Overview`}
         description={dataset.data.description}
         thumbnail={dataset.data.media?.src}
         localNavProps={{

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -35,7 +35,7 @@ function DatasetsOverview() {
   return (
     <>
       <LayoutProps
-        title={`${dataset.data.name} Overview`}
+        title={dataset.data.name}
         description={dataset.data.description}
         thumbnail={dataset.data.media?.src}
         localNavProps={{


### PR DESCRIPTION
This has been requested for a while now: dataset overview page titles are currently the dataset title plus the word "Overview", which cannot be visually distinguished from the dataset name and may be falsely taken to be part of it.

The suggestion is therefore to just remove the trailing "Overview". Since it has long been requested, I recommend that we accept this change and revisit any needs for highlighting that the page presents a "dataset overview" later, if it ever comes up.

Closes #738 