### PR TITLE
Add params to analysis attribute

### DIFF
--- a/app/scripts/components/analysis/results/timeseries-data.ts
+++ b/app/scripts/components/analysis/results/timeseries-data.ts
@@ -267,7 +267,7 @@ async function requestTimeseries({
       }
     });
 
-    const analysisParams = layersBase.layer.analysis?.params;
+    const analysisParams = layersBase.layer.analysis?.sourceParams;
 
     const layerStatistics = await Promise.all(
       assets.map(async ({ date, url }) => {

--- a/app/scripts/components/analysis/results/timeseries-data.ts
+++ b/app/scripts/components/analysis/results/timeseries-data.ts
@@ -267,6 +267,8 @@ async function requestTimeseries({
       }
     });
 
+    const analysisParams = layersBase.layer.analysis?.params;
+
     const layerStatistics = await Promise.all(
       assets.map(async ({ date, url }) => {
         const statistics = await queryClient.fetchQuery(
@@ -274,10 +276,10 @@ async function requestTimeseries({
           async ({ signal }) => {
             return concurrencyManager.queue(async () => {
               const { data } = await axios.post(
-                `${process.env.API_RASTER_ENDPOINT}/cog/statistics?url=${url}`,
+                `${process.env.API_RASTER_ENDPOINT}/cog/statistics`,
                 // Making a request with a FC causes a 500 (as of 2023/01/20)
                 combineFeatureCollection(aoi),
-                { signal }
+                { params: { ...analysisParams, url }, signal }
               );
               return {
                 date,

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -213,6 +213,8 @@ Configuration options for the analysis of the dataset layer.
 
 ```yaml
 metrics: string[]
+sourceParams:
+  [key]: value
 exclude: boolean
 ```
 
@@ -225,7 +227,11 @@ Available metrics:
 - max (Max)
 - std (Standard Deviation)
 - median (Median)
-- 
+
+**analysis.sourceParams** 
+`object`
+Parameters to be appended to the `/statistics` endpoint as query parameters. Check [Titler documentations's /statistics POST request section](https://developmentseed.org/titiler/endpoints/cog/#statistics) to see which parameter is available. 
+
 **analysis.exclude**  
 `boolean`  
 Controls whether this layer should be excluded from the analysis page. If set to `true` the layer will not be available for analysis.

--- a/mock/datasets/oco2-geos-l3-daily.data.mdx
+++ b/mock/datasets/oco2-geos-l3-daily.data.mdx
@@ -18,6 +18,8 @@ layers:
     stacCol: oco2-geos-l3-daily
     name: Gridded Daily OCO-2 Carbon Dioxide assimilated dataset
     type: zarr
+    analysis:
+      exclude: true
     description:
       "The OCO-2 mission provides the highest quality space-based XCO2 retrievals to date. However, the instrument data are characterized by large gaps in coverage due to OCO-2’s narrow 10-km ground track and an inability to see through clouds and thick aerosols. This global gridded dataset is produced using a data assimilation technique commonly referred to as state estimation within the geophysical literature. Data assimilation synthesizes simulations and observations, adjusting the state of atmospheric constituents like CO2 to reflect observed values, thus gap-filling observations when and where they are unavailable based on previous observations and short transport simulations by GEOS. Compared to other methods, data assimilation has the advantage that it makes estimates based on our collective scientific understanding, notably of the Earth’s carbon cycle and atmospheric transport. OCO-2 GEOS (Goddard Earth Observing System) Level 3 data are produced by ingesting OCO-2 L2 retrievals every 6 hours with GEOS CoDAS, a modeling and data assimilation system maintained by NASA’s Global Modeling and Assimilation Office (GMAO). GEOS CoDAS uses a high-performance computing implementation of the Gridpoint Statistical Interpolation approach for solving the state estimation problem. GSI finds the analyzed state that minimizes the three-dimensional variational (3D-Var) cost function formulation of the state estimation problem."
     zoomExtent:

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -65,7 +65,7 @@ declare module 'veda' {
     analysis?: {
       metrics: string[];
       exclude: boolean;
-      params?: Record<string, any>;
+      sourceParams?: Record<string, any>;
     };
   }
 

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -65,7 +65,8 @@ declare module 'veda' {
     analysis?: {
       metrics: string[];
       exclude: boolean;
-    }
+      params?: Record<string, any>;
+    };
   }
 
   // A normalized compare layer is the result after the compare definition is


### PR DESCRIPTION
Close #756  Add `analysis.params` as a layer configuration to pass it to `/statistics` endpoint. 

🤚  I do not know how to test this functionality, I just checked the parameters get passed to the request. 
🤚  This also leaves me with a question if we need to merge this change to `main`, and bring all the changes that have been stacked to main to GHG, or make another feature branch for GHG. Considering there are not many changes stacked on main branch, I will say we just bring all the changes on main to GHG.


- [ ] Add documentation

