### PR TITLE
Exploration features

### DIFF
--- a/.env
+++ b/.env
@@ -4,7 +4,6 @@ APP_CONTACT_EMAIL=email@example.org
 
 API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
 API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
-API_XARRAY_ENDPOINT='https://dev-titiler-xarray.delta-backend.com/tilejson.json'
 
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:

--- a/app/scripts/components/common/map/controls/aoi/atoms.ts
+++ b/app/scripts/components/common/map/controls/aoi/atoms.ts
@@ -11,7 +11,14 @@ const aoisSerialized = atom(
   (get) => get(aoisAtom).searchParams?.get('aois'),
   (get, set, aois) => {
     set(aoisAtom, (prev) => {
-      const searchParams = prev.searchParams ?? new URLSearchParams();
+      // Start from what's on the url because another atom might have updated it.
+      const searchParams = new URLSearchParams(window.location.search);
+      const prevSearchParams = prev.searchParams ?? new URLSearchParams();
+  
+      prevSearchParams.forEach((value, name) => {
+        searchParams.set(name, value);
+      });
+  
       searchParams.set('aois', aois as string);
 
       return { ...prev, searchParams };

--- a/app/scripts/components/common/map/controls/hooks/use-themed-control.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-themed-control.tsx
@@ -30,10 +30,15 @@ export default function useThemedControl(
     }
 
     onRemove() {
-      // Cleanup if necessary
-      if (elementRef.current) {
-        rootRef.current?.unmount();
-      }
+      // Cleanup if necessary.
+      // Defer to next tick.
+      setTimeout(() => {
+        if (elementRef.current) {
+          rootRef.current?.unmount();
+          rootRef.current = null;
+        }
+
+      }, 1);
     }
   }
 
@@ -45,6 +50,8 @@ export default function useThemedControl(
       );
     }
   }, [renderFn, theme]);
+
   useControl(() => new ThemedControl(), opts);
+
   return null;
 }

--- a/app/scripts/components/common/map/maps.tsx
+++ b/app/scripts/components/common/map/maps.tsx
@@ -18,7 +18,7 @@ import useDimensions from 'react-cool-dimensions';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
 import MapboxStyleOverride from './mapbox-style-override';
-import { Styles } from './styles';
+import { ExtendedStyle, Styles } from './styles';
 import useMapCompare from './hooks/use-map-compare';
 import MapComponent from './map-component';
 import useMaps, { useMapsContext } from './hooks/use-maps';
@@ -78,11 +78,14 @@ const MapsContainer = styled.div`
   }
 `;
 
-type MapsProps = Pick<MapsContextWrapperProps, 'projection'> & {
+type MapsProps = Pick<
+  MapsContextWrapperProps,
+  'projection' | 'onStyleUpdate'
+> & {
   children: ReactNode;
 };
 
-function Maps({ children, projection }: MapsProps) {
+function Maps({ children, projection, onStyleUpdate }: MapsProps) {
   // Instantiate MGL Compare, if compare is enabled
   useMapCompare();
 
@@ -135,7 +138,7 @@ function Maps({ children, projection }: MapsProps) {
 
   return (
     <MapsContainer id={containerId} ref={observe}>
-      <Styles>
+      <Styles onStyleUpdate={onStyleUpdate}>
         {generators}
         <MapComponent controls={controls} projection={projection} />
       </Styles>
@@ -157,6 +160,7 @@ export interface MapsContextWrapperProps {
   children: ReactNode;
   id: string;
   projection?: ProjectionOptions;
+  onStyleUpdate?: (style: ExtendedStyle) => void;
 }
 
 export default function MapsContextWrapper(props: MapsContextWrapperProps) {

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -145,7 +145,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   //
   const [stacCollection, setStacCollection] = useState<StacFeature[]>([]);
   useEffect(() => {
-    if (!id || !stacCol || !date) return;
+    if (!id || !stacCol) return;
 
     const controller = new AbortController();
 
@@ -173,7 +173,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         LOG && console.groupEnd();
         /* eslint-enable no-console */
 
-        const responseData = await requestQuickCache({
+        const responseData = await requestQuickCache<any>({
           url: `${stacApiEndpointToUse}/search`,
           payload,
           controller
@@ -212,7 +212,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
       controller.abort();
       changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
     };
-  }, [id, changeStatus, stacCol, date]);
+  }, [id, changeStatus, stacCol, date, stacApiEndpointToUse]);
 
   //
   // Markers
@@ -270,7 +270,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         LOG && console.groupEnd();
         /* eslint-enable no-console */
 
-        const responseData = await requestQuickCache({
+        const responseData = await requestQuickCache<any>({
           url: `${tileApiEndpointToUse}/mosaic/register`,
           payload,
           controller
@@ -309,9 +309,6 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
       changeStatus({ status: 'idle', context: STATUS_KEY.Layer });
     };
   }, [
-    // The `showMarkers` and `isHidden` dep are left out on purpose, as visibility
-    // is controlled below, but we need the value to initialize the layer
-    // visibility.
     stacCollection
     // This hook depends on a series of properties, but whenever they change the
     // `stacCollection` is guaranteed to change because a new STAC request is
@@ -338,40 +335,36 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
 
   const generatorParams = useGeneratorParams(props);
 
-  useEffect(
-    () => {
-      const controller = new AbortController();
+  useEffect(() => {
+    const controller = new AbortController();
 
-      async function run() {
-        let layers: AnyLayer[] = [];
-        let sources: Record<string, AnySourceImpl> = {};
+    async function run() {
+      let layers: AnyLayer[] = [];
+      let sources: Record<string, AnySourceImpl> = {};
 
-        if (mosaicUrl) {
-          const tileParams = qs.stringify(
-            {
-              assets: 'cog_default',
-              ...(sourceParams ?? {})
-            },
-            // Temporary solution to pass different tile parameters for hls data
-            {
-              arrayFormat: id.toLowerCase().includes('hls') ? 'repeat' : 'comma'
-            }
-          );
-
-          const tilejsonUrl = `${mosaicUrl}?${tileParams}`;
-
-          let tileServerUrl: string | undefined = undefined;
-          try {
-            const tilejsonData = await requestQuickCache({
-              url: tilejsonUrl,
-              method: 'GET',
-              payload: null,
-              controller
-            });
-            tileServerUrl = tilejsonData.tiles[0];
-          } catch (error) {
-            // Ignore errors.
+      if (mosaicUrl) {
+        const tileParams = qs.stringify(
+          {
+            assets: 'cog_default',
+            ...(sourceParams ?? {})
+          },
+          // Temporary solution to pass different tile parameters for hls data
+          {
+            arrayFormat: id.toLowerCase().includes('hls') ? 'repeat' : 'comma'
           }
+        );
+
+        const tilejsonUrl = `${mosaicUrl}?${tileParams}`;
+
+        try {
+          const tilejsonData = await requestQuickCache<any>({
+            url: tilejsonUrl,
+            method: 'GET',
+            payload: null,
+            controller
+          });
+
+          const tileServerUrl = tilejsonData.tiles[0];
 
           const wmtsBaseUrl = mosaicUrl.replace(
             'tilejson.json',
@@ -409,76 +402,97 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             [id]: mosaicSource
           };
           layers = [...layers, mosaicLayer];
+        } catch (error) {
+          if (!controller.signal.aborted) {
+            sources = {};
+            layers = [];
+            changeStatus({
+              status: S_FAILED,
+              context: STATUS_KEY.StacSearch
+            });
+          }
+          LOG &&
+            /* eslint-disable-next-line no-console */
+            console.log(
+              'MapLayerRasterTimeseries %cAborted Mosaic',
+              'color: red;',
+              id
+            );
+          // Continue to the style is updated to empty.
         }
-
-        if (points && minZoom > 0) {
-          const pointsSourceId = `${id}-points`;
-          const pointsSource: GeoJSONSourceRaw = {
-            type: 'geojson',
-            data: featureCollection(
-              points.map((p) => point(p.center, { bounds: p.bounds }))
-            )
-          };
-
-          const pointsLayer: SymbolLayer = {
-            type: 'symbol',
-            id: pointsSourceId,
-            source: pointsSourceId,
-            layout: {
-              ...(MARKER_LAYOUT as any),
-              'icon-allow-overlap': true
-            },
-            paint: {
-              'icon-color': theme.color?.primary,
-              'icon-halo-color': theme.color?.base,
-              'icon-halo-width': 1
-            },
-            maxzoom: minZoom,
-            metadata: {
-              layerOrderPosition: 'markers'
-            }
-          };
-          sources = {
-            ...sources,
-            [pointsSourceId]: pointsSource as AnySourceImpl
-          };
-          layers = [...layers, pointsLayer];
-        }
-
-        updateStyle({
-          generatorId,
-          sources,
-          layers,
-          params: generatorParams
-        });
       }
 
-      run();
+      if (points && minZoom > 0) {
+        const pointsSourceId = `${id}-points`;
+        const pointsSource: GeoJSONSourceRaw = {
+          type: 'geojson',
+          data: featureCollection(
+            points.map((p) => point(p.center, { bounds: p.bounds }))
+          )
+        };
 
-      return () => {
-        controller.abort();
-      };
-    },
-    // sourceParams not included, but using a stringified version of it to
-    // detect changes (haveSourceParamsChanged)
-    [
-      updateStyle,
-      id,
-      mosaicUrl,
-      minZoom,
-      points,
-      haveSourceParamsChanged,
-      generatorParams,
-      // generatorParams includes hidden and opacity
-      // hidden,
-      // opacity,
-      // generatorId, // - dependent on id
-      // sourceParams, // tracked by haveSourceParamsChanged
-      // Theme is stable
-      // theme.color?.base,
-      // theme.color?.primary
-    ]
-  );
+        const pointsLayer: SymbolLayer = {
+          type: 'symbol',
+          id: pointsSourceId,
+          source: pointsSourceId,
+          layout: {
+            ...(MARKER_LAYOUT as any),
+            'icon-allow-overlap': true
+          },
+          paint: {
+            'icon-color': theme.color?.primary,
+            'icon-halo-color': theme.color?.base,
+            'icon-halo-width': 1
+          },
+          maxzoom: minZoom,
+          metadata: {
+            layerOrderPosition: 'markers'
+          }
+        };
+        sources = {
+          ...sources,
+          [pointsSourceId]: pointsSource as AnySourceImpl
+        };
+        layers = [...layers, pointsLayer];
+      }
+
+      updateStyle({
+        generatorId,
+        sources,
+        layers,
+        params: generatorParams
+      });
+    }
+
+    run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [
+    mosaicUrl,
+    points,
+    minZoom,
+    haveSourceParamsChanged,
+    generatorParams
+    // This hook depends on a series of properties, but whenever they change the
+    // `mosaicUrl` is guaranteed to change because a new STAC request is
+    // needed to show the data. The following properties are therefore removed
+    // from the dependency array:
+    // - id
+    // - changeStatus
+    // - stacCol
+    // - date
+    // Keeping then in would cause multiple requests because for example when
+    // `date` changes the hook runs, then the request in the hook above
+    // fires and `mosaicUrl` changes, causing this hook to run again. This
+    // resulted in a race condition when adding the source to the map leading to
+    // an error.
+    // Other:
+    // -- generatorParams includes hidden and opacity
+    // -- sourceParams is tracked by haveSourceParamsChanged
+    // -- theme and updateStyle are stable
+  ]);
 
   //
   // Cleanup layers on unmount.

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -468,7 +468,15 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
       minZoom,
       points,
       haveSourceParamsChanged,
-      generatorParams
+      generatorParams,
+      // generatorParams includes hidden and opacity
+      // hidden,
+      // opacity,
+      // generatorId, // - dependent on id
+      // sourceParams, // tracked by haveSourceParamsChanged
+      // Theme is stable
+      // theme.color?.base,
+      // theme.color?.primary
     ]
   );
 

--- a/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
@@ -81,7 +81,7 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
     async function load() {
       try {
         onStatusChange?.({ status: S_LOADING, id });
-        const data = await requestQuickCache({
+        const data = await requestQuickCache<any>({
           url: `${stacApiEndpointToUse}/collections/${stacCol}`,
           method: 'GET',
           controller
@@ -90,7 +90,7 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
         const endpoint = data.links.find((l) => l.rel === 'external').href;
         setFeaturesApiEndpoint(endpoint);
 
-        const featuresData = await requestQuickCache({
+        const featuresData = await requestQuickCache<any>({
           url: endpoint,
           method: 'GET',
           controller

--- a/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
@@ -115,7 +115,7 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
     return () => {
       controller.abort();
     };
-  }, [mapInstance, id, stacCol, stacApiEndpointToUse, date, onStatusChange]);
+  }, [id, stacCol, stacApiEndpointToUse, onStatusChange]);
 
 
   //

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -52,7 +52,7 @@ export function ZarrTimeseries(props: ZarrTimeseriesProps) {
     async function load() {
       try {
         onStatusChange?.({ status: S_LOADING, id });
-        const data = await requestQuickCache({
+        const data = await requestQuickCache<any>({
           url: `${stacApiEndpointToUse}/collections/${stacCol}`,
           method: 'GET',
           controller

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState } from 'react';
+import qs from 'qs';
+import { RasterSource, RasterLayer } from 'mapbox-gl';
+
+import { requestQuickCache } from '../utils';
+import useMapStyle from '../hooks/use-map-style';
+import useGeneratorParams from '../hooks/use-generator-params';
+import { BaseGeneratorParams } from '../types';
+
+import { ActionStatus, S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
+
+export interface ZarrTimeseriesProps extends BaseGeneratorParams {
+  id: string;
+  stacCol: string;
+  date?: Date;
+  sourceParams?: Record<string, any>;
+  stacApiEndpoint?: string;
+  tileApiEndpoint?: string;
+  zoomExtent?: number[];
+  onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
+}
+
+export function ZarrTimeseries(props: ZarrTimeseriesProps) {
+  const {
+    id,
+    stacCol,
+    stacApiEndpoint,
+    tileApiEndpoint,
+    date,
+    sourceParams,
+    zoomExtent,
+    onStatusChange,
+    hidden,
+    opacity
+  } = props;
+
+  const { updateStyle } = useMapStyle();
+  const [assetUrl, setAssetUrl] = useState('');
+
+  const [minZoom] = zoomExtent ?? [0, 20];
+
+  const stacApiEndpointToUse = stacApiEndpoint ?? process.env.API_STAC_ENDPOINT;
+
+  const generatorId = `zarr-timeseries-${id}`;
+
+  //
+  // Get the asset url
+  //
+  useEffect(() => {
+    const controller = new AbortController();
+
+    async function load() {
+      try {
+        onStatusChange?.({ status: S_LOADING, id });
+        const data = await requestQuickCache({
+          url: `${stacApiEndpointToUse}/collections/${stacCol}`,
+          method: 'GET',
+          controller
+        });
+
+        setAssetUrl(data.assets.zarr.href);
+        onStatusChange?.({ status: S_SUCCEEDED, id });
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setAssetUrl('');
+          onStatusChange?.({ status: S_FAILED, id });
+        }
+        return;
+      }
+    }
+
+    load();
+
+    return () => {
+      controller.abort();
+    };
+  }, [id, stacCol, stacApiEndpointToUse, date, onStatusChange]);
+
+  //
+  // Generate Mapbox GL layers and sources for raster timeseries
+  //
+  const haveSourceParamsChanged = useMemo(
+    () => JSON.stringify(sourceParams),
+    [sourceParams]
+  );
+
+  const generatorParams = useGeneratorParams(props);
+
+  useEffect(
+    () => {
+      if (!tileApiEndpoint) return;
+
+      const tileParams = qs.stringify({
+        url: assetUrl,
+        time_slice: date,
+        ...sourceParams
+      });
+
+      const zarrSource: RasterSource = {
+        type: 'raster',
+        url: `${tileApiEndpoint}?${tileParams}`
+      };
+
+      const rasterOpacity = typeof opacity === 'number' ? opacity / 100 : 1;
+
+      const zarrLayer: RasterLayer = {
+        id: id,
+        type: 'raster',
+        source: id,
+        paint: {
+          'raster-opacity': hidden ? 0 : rasterOpacity,
+          'raster-opacity-transition': {
+            duration: 320
+          }
+        },
+        minzoom: minZoom,
+        metadata: {
+          layerOrderPosition: 'raster'
+        }
+      };
+
+      const sources = {
+        [id]: zarrSource
+      };
+      const layers = [zarrLayer];
+
+      updateStyle({
+        generatorId,
+        sources,
+        layers,
+        params: generatorParams
+      });
+    },
+    // sourceParams not included, but using a stringified version of it to
+    // detect changes (haveSourceParamsChanged)
+    [
+      updateStyle,
+      id,
+      date,
+      assetUrl,
+      minZoom,
+      tileApiEndpoint,
+      haveSourceParamsChanged,
+      generatorParams
+      // generatorParams includes hidden and opacity
+      // hidden,
+      // opacity,
+      // generatorId, // - dependent on id
+      // sourceParams, // tracked by haveSourceParamsChanged
+    ]
+  );
+
+  //
+  // Cleanup layers on unmount.
+  //
+  useEffect(() => {
+    return () => {
+      updateStyle({
+        generatorId,
+        sources: {},
+        layers: []
+      });
+    };
+  }, [updateStyle, generatorId]);
+
+  return null;
+}

--- a/app/scripts/components/common/map/styles.tsx
+++ b/app/scripts/components/common/map/styles.tsx
@@ -116,15 +116,12 @@ export function Styles({
 
   const [style, setStyle] = useState<Style | undefined>();
 
-  const updateStyle = useCallback(
-    (params: GeneratorStyleParams) => {
-      setStylesData((prevStyle) => ({
-        ...prevStyle,
-        [params.generatorId]: params
-      }));
-    },
-    [setStylesData]
-  );
+  const updateStyle = useCallback((params: GeneratorStyleParams) => {
+    setStylesData((prevStyle) => ({
+      ...prevStyle,
+      [params.generatorId]: params
+    }));
+  }, []);
 
   useEffect(() => {
     const style = generateStyle(stylesData);

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -30,6 +30,7 @@ import { variableGlsp } from '$styles/variable-utils';
 import {
   STORIES_PATH,
   DATASETS_PATH,
+  ANALYSIS_PATH,
   ABOUT_PATH,
   EXPLORATION_PATH
 } from '$utils/routes';
@@ -342,9 +343,9 @@ function PageHeader() {
   useEffect(() => {
     // Close global nav when media query changes.
     // NOTE: isMediumDown is returning document.body's width, not the whole window width
-    // which conflicts with how mediaquery decides the width. 
+    // which conflicts with how mediaquery decides the width.
     // JSX element susing isMediumDown is also protected with css logic because of this.
-    // ex. Look at GlobalNavActions 
+    // ex. Look at GlobalNavActions
     if (!isMediumDown) setGlobalNavRevealed(false);
   }, [isMediumDown]);
 
@@ -412,18 +413,24 @@ function PageHeader() {
                     </GlobalMenuLink>
                   </li>
                   <li>
-                    <GlobalMenuLink
-                      to={EXPLORATION_PATH}
-                      onClick={closeNavOnClick}
-                    >
-                      Exploration
-                    </GlobalMenuLink>
+                    {process.env.FEATURE_NEW_EXPLORATION ? (
+                      <GlobalMenuLink
+                        to={EXPLORATION_PATH}
+                        onClick={closeNavOnClick}
+                      >
+                        Exploration
+                      </GlobalMenuLink>
+                    ) : (
+                      <GlobalMenuLink
+                        to={ANALYSIS_PATH}
+                        onClick={closeNavOnClick}
+                      >
+                        Data Analysis
+                      </GlobalMenuLink>
+                    )}
                   </li>
                   <li>
-                    <GlobalMenuLink
-                      to={STORIES_PATH}
-                      onClick={closeNavOnClick}
-                    >
+                    <GlobalMenuLink to={STORIES_PATH} onClick={closeNavOnClick}>
                       {getString('stories').other}
                     </GlobalMenuLink>
                   </li>

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -95,6 +95,13 @@ export async function requestDatasetTimeseriesData({
   const datasetData = dataset.data;
   const datasetAnalysis = dataset.analysis;
 
+  if (datasetData.type !== 'raster') {
+    throw new ExtendedError(
+      'Analysis is only supported for raster datasets',
+      'ANALYSIS_NOT_SUPPORTED'
+    );
+  }
+
   const id = datasetData.id;
 
   onProgress({

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -96,10 +96,16 @@ export async function requestDatasetTimeseriesData({
   const datasetAnalysis = dataset.analysis;
 
   if (datasetData.type !== 'raster') {
-    throw new ExtendedError(
-      'Analysis is only supported for raster datasets',
-      'ANALYSIS_NOT_SUPPORTED'
-    );
+    onProgress({
+      status: TimelineDatasetStatus.ERROR,
+      meta: {},
+      error: new ExtendedError(
+        'Analysis is only supported for raster datasets',
+        'ANALYSIS_NOT_SUPPORTED'
+      ),
+      data: null
+    });
+    return;
   }
 
   const id = datasetData.id;
@@ -154,7 +160,7 @@ export async function requestDatasetTimeseriesData({
     if (assets.length > maxItems) {
       const e = new ExtendedError(
         'Too many assets to analyze',
-        'TOO_MANY_ASSETS'
+        'ANALYSIS_TOO_MANY_ASSETS'
       );
       e.details = {
         assetCount: assets.length
@@ -164,6 +170,19 @@ export async function requestDatasetTimeseriesData({
         ...datasetAnalysis,
         status: TimelineDatasetStatus.ERROR,
         error: e,
+        data: null
+      });
+      return;
+    }
+
+    if (!assets.length) {
+      onProgress({
+        ...datasetAnalysis,
+        status: TimelineDatasetStatus.ERROR,
+        error: new ExtendedError(
+          'No data in the given time range and area of interest',
+          'ANALYSIS_NO_DATA'
+        ),
         data: null
       });
       return;

--- a/app/scripts/components/exploration/atoms/dates.ts
+++ b/app/scripts/components/exploration/atoms/dates.ts
@@ -24,6 +24,10 @@ export const selectedDateAtom = atomWithUrlValueStability<Date | null>({
   initialValue: hydrateDate(initialParams.get('date')),
   urlParam: 'date',
   hydrate: hydrateDate,
+  areEqual(prev, next) {
+    if (!prev || !next) return prev === next;
+    return prev.getTime() === next.getTime();
+  },
   dehydrate: (date) => {
     return date?.toISOString() ?? '';
   }
@@ -34,6 +38,10 @@ export const selectedCompareDateAtom = atomWithUrlValueStability<Date | null>({
   initialValue: hydrateDate(initialParams.get('dateCompare')),
   urlParam: 'dateCompare',
   hydrate: hydrateDate,
+  areEqual(prev, next) {
+    if (!prev || !next) return prev === next;
+    return prev.getTime() === next.getTime();
+  },
   dehydrate: (date) => {
     return date?.toISOString() ?? '';
   }
@@ -57,6 +65,12 @@ export const selectedIntervalAtom = atomWithUrlValueStability<DateRange | null>(
     initialValue: hydrateRange(initialParams.get('dateRange')),
     urlParam: 'dateRange',
     hydrate: hydrateRange,
+    areEqual(prev, next) {
+      if (!prev || !next) return prev === next;
+
+      return prev.start.getTime() === next.start.getTime() &&
+        prev.end.getTime() === next.end.getTime();
+    },
     dehydrate: (range) => {
       return range
         ? `${range.start.toISOString()}|${range.end.toISOString()}`

--- a/app/scripts/components/exploration/atoms/url.ts
+++ b/app/scripts/components/exploration/atoms/url.ts
@@ -68,7 +68,14 @@ export const urlAtom = atomWithDebouncedLocation();
  */
 export function setUrlParam(name: string, value: string) {
   return (prev) => {
-    const searchParams = prev.searchParams ?? new URLSearchParams();
+    // Start from what's on the url because another atom might have updated it.
+    const searchParams = new URLSearchParams(window.location.search);
+    const prevSearchParams = prev.searchParams ?? new URLSearchParams();
+
+    prevSearchParams.forEach((value, name) => {
+      searchParams.set(name, value);
+    });
+
     searchParams.set(name, value);
 
     return { ...prev, searchParams };

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
@@ -118,8 +118,22 @@ export function DatasetTrackError(props: {
         <TrackMessage isError>
           <p>
             Analysis is limited to {MAX_QUERY_NUM} data points. Your selection
-            includes {error.details?.assetCount} points. Please select a shorter time range.
+            includes {error.details?.assetCount} points. Please select a shorter
+            time range.
           </p>
+        </TrackMessage>
+      </>
+    );
+  }
+  if (
+    error instanceof ExtendedError &&
+    error.code === 'ANALYSIS_NOT_SUPPORTED'
+  ) {
+    return (
+      <>
+        {patternContent}
+        <TrackMessage isError>
+          <p>Analysis is not supported for this dataset.</p>
         </TrackMessage>
       </>
     );

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
@@ -111,7 +111,10 @@ export function DatasetTrackError(props: {
     </TrackError>
   );
 
-  if (error instanceof ExtendedError && error.code === 'TOO_MANY_ASSETS') {
+  if (
+    error instanceof ExtendedError &&
+    error.code === 'ANALYSIS_TOO_MANY_ASSETS'
+  ) {
     return (
       <>
         {patternContent}
@@ -125,6 +128,7 @@ export function DatasetTrackError(props: {
       </>
     );
   }
+
   if (
     error instanceof ExtendedError &&
     error.code === 'ANALYSIS_NOT_SUPPORTED'
@@ -132,8 +136,19 @@ export function DatasetTrackError(props: {
     return (
       <>
         {patternContent}
-        <TrackMessage isError>
+        <TrackMessage>
           <p>Analysis is not supported for this dataset.</p>
+        </TrackMessage>
+      </>
+    );
+  }
+
+  if (error instanceof ExtendedError && error.code === 'ANALYSIS_NO_DATA') {
+    return (
+      <>
+        {patternContent}
+        <TrackMessage>
+          <p>No data for the selected time range and area of interest.</p>
         </TrackMessage>
       </>
     );

--- a/app/scripts/components/exploration/components/datasets/dataset-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-options.tsx
@@ -76,7 +76,7 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
           <li>
             <Tip
               disabled={!!dataset.meta?.tileUrls}
-              content='Current dataset does not offer tile urls'
+              content='This dataset does not offer tile URLs'
               placement='left'
             >
               <TileModalButton
@@ -84,7 +84,7 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
                 type='button'
                 onClick={() => setTileModalRevealed(true)}
               >
-                <CollecticonMap title='Open tile url options' /> View tile urls
+                <CollecticonMap title='Open tile URL options' /> Load into GIS
               </TileModalButton>
             </Tip>
           </li>

--- a/app/scripts/components/exploration/components/datasets/dataset-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-options.tsx
@@ -48,6 +48,7 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
     <>
       <Dropdown
         alignment='right'
+        direction='up'
         triggerElement={(props) => (
           <Button
             variation='base-text'

--- a/app/scripts/components/exploration/components/datasets/dataset-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-options.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import { PrimitiveAtom, useAtomValue, useAtom } from 'jotai';
 import 'react-range-slider-input/dist/style.css';
 import styled from 'styled-components';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Dropdown, DropMenu, DropTitle } from '@devseed-ui/dropdown';
 import { Button } from '@devseed-ui/button';
-import { CollecticonCog, CollecticonTrashBin } from '@devseed-ui/collecticons';
+import {
+  CollecticonCog,
+  CollecticonMap,
+  CollecticonTrashBin
+} from '@devseed-ui/collecticons';
 import { Overline } from '@devseed-ui/typography';
 
 import AnalysisMetrics from './analysis-metrics';
+import { TileUrlModal } from './tile-link-modal';
 
 import DropMenuItemButton from '$styles/drop-menu-item-button';
 import { SliderInput, SliderInputProps } from '$styles/range-slider';
@@ -17,7 +22,9 @@ import { Tip } from '$components/common/tip';
 import { TimelineDataset } from '$components/exploration/types.d.ts';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
 import { useTimelineDatasetSettings } from '$components/exploration/atoms/hooks';
+
 const RemoveButton = composeVisuallyDisabled(DropMenuItemButton);
+const TileModalButton = composeVisuallyDisabled(DropMenuItemButton);
 
 interface DatasetOptionsProps {
   datasetAtom: PrimitiveAtom<TimelineDataset>;
@@ -30,53 +37,87 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
   const dataset = useAtomValue(datasetAtom);
   const [getSettings, setSetting] = useTimelineDatasetSettings(datasetAtom);
 
+  const [tileModalRevealed, setTileModalRevealed] = useState(false);
+  const closeTileModal = useCallback(() => setTileModalRevealed(false), []);
+
   const opacity = (getSettings('opacity') ?? 100) as number;
 
-  const activeMetrics = (getSettings('analysisMetrics') ?? []);
+  const activeMetrics = getSettings('analysisMetrics') ?? [];
 
   return (
-    <Dropdown
-      alignment='right'
-      triggerElement={(props) => (
-        <Button variation='base-text' size='small' fitting='skinny' {...props}>
-          <CollecticonCog meaningful title='View dataset options' />
-        </Button>
-      )}
-    >
-      <DropTitle>Display options</DropTitle>
-      <DropMenu>
-        <li>
-          <OpacityControl
-            value={opacity}
-            onInput={(v) => setSetting('opacity', v)}
-          />
-        </li>
-      </DropMenu>
-      <AnalysisMetrics
-        activeMetrics={activeMetrics}
-        onMetricsChange={(m) => setSetting('analysisMetrics', m)}
-      />
-      <DropMenu>
-        <li>
-          <Tip
-            disabled={datasets.length > 1}
-            content="It's not possible to remove the last dataset. Add another before removing this one."
+    <>
+      <Dropdown
+        alignment='right'
+        triggerElement={(props) => (
+          <Button
+            variation='base-text'
+            size='small'
+            fitting='skinny'
+            {...props}
           >
-            <RemoveButton
-              variation='danger'
-              visuallyDisabled={datasets.length === 1}
-              onClick={() => {
-                setDatasets((datasets) =>
-                  datasets.filter((d) => d.data.id !== dataset.data.id)
-                );
-              }}
+            <CollecticonCog meaningful title='View dataset options' />
+          </Button>
+        )}
+      >
+        <DropTitle>Display options</DropTitle>
+        <DropMenu>
+          <li>
+            <OpacityControl
+              value={opacity}
+              onInput={(v) => setSetting('opacity', v)}
+            />
+          </li>
+        </DropMenu>
+        <AnalysisMetrics
+          activeMetrics={activeMetrics}
+          onMetricsChange={(m) => setSetting('analysisMetrics', m)}
+        />
+        <DropMenu>
+          <li>
+            <Tip
+              disabled={!!dataset.meta?.tileUrls}
+              content='Current dataset does not offer tile urls'
+              placement='left'
             >
-              <CollecticonTrashBin /> Remove dataset
-            </RemoveButton>
-          </Tip>
-        </li>
-      </DropMenu>
-    </Dropdown>
+              <TileModalButton
+                visuallyDisabled={!dataset.meta?.tileUrls}
+                type='button'
+                onClick={() => setTileModalRevealed(true)}
+              >
+                <CollecticonMap title='Open tile url options' /> View tile urls
+              </TileModalButton>
+            </Tip>
+          </li>
+        </DropMenu>
+        <DropMenu>
+          <li>
+            <Tip
+              disabled={datasets.length > 1}
+              content="It's not possible to remove the last dataset. Add another before removing this one."
+            >
+              <RemoveButton
+                variation='danger'
+                visuallyDisabled={datasets.length === 1}
+                onClick={() => {
+                  setDatasets((datasets) =>
+                    datasets.filter((d) => d.data.id !== dataset.data.id)
+                  );
+                }}
+              >
+                <CollecticonTrashBin /> Remove dataset
+              </RemoveButton>
+            </Tip>
+          </li>
+        </DropMenu>
+      </Dropdown>
+
+      <TileUrlModal
+        datasetName={dataset.data.name}
+        revealed={tileModalRevealed}
+        onClose={closeTileModal}
+        tileUrls={dataset.meta?.tileUrls}
+      />
+    </>
   );
 }
 

--- a/app/scripts/components/exploration/components/datasets/tile-link-modal.tsx
+++ b/app/scripts/components/exploration/components/datasets/tile-link-modal.tsx
@@ -49,8 +49,8 @@ export function TileUrlModal(props: {
       content={
         <Form>
           {[
-            { label: 'XYZ Tile Url', value: tileUrls?.xyzTileUrl },
-            { label: 'WMTS Tile Url', value: tileUrls?.wmtsTileUrl }
+            { label: 'XYZ Tile URL', value: tileUrls?.xyzTileUrl },
+            { label: 'WMTS Tile URL', value: tileUrls?.wmtsTileUrl }
           ].map((tileUrl) =>
             tileUrl.value ? (
               <FormGroupStructure

--- a/app/scripts/components/exploration/components/datasets/tile-link-modal.tsx
+++ b/app/scripts/components/exploration/components/datasets/tile-link-modal.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import styled from 'styled-components';
+import { themeVal } from '@devseed-ui/theme-provider';
+import { FormInput, FormGroupStructure, Form } from '@devseed-ui/form';
+import { Button } from '@devseed-ui/button';
+import { Heading, Overline } from '@devseed-ui/typography';
+import {
+  CollecticonClipboard,
+  CollecticonClipboardTick
+} from '@devseed-ui/collecticons';
+import { Modal, ModalHeadline } from '@devseed-ui/modal';
+import { CopyField } from '$components/common/copy-field';
+
+const FormInputSubmitWrapper = styled.div`
+  display: flex;
+
+  > input {
+    flex-grow: 1;
+    border-radius: ${themeVal('shape.rounded')} 0 0 ${themeVal('shape.rounded')};
+  }
+
+  > button {
+    border-radius: 0 ${themeVal('shape.rounded')} ${themeVal('shape.rounded')} 0;
+  }
+`;
+
+export function TileUrlModal(props: {
+  datasetName: string;
+  tileUrls?: Record<string, string>;
+  revealed: boolean;
+  onClose: () => void;
+}) {
+  const { datasetName, tileUrls, revealed, onClose } = props;
+
+  return (
+    <Modal
+      id='modal'
+      size='small'
+      revealed={revealed}
+      onCloseClick={onClose}
+      onOverlayClick={onClose}
+      closeButton
+      renderHeadline={() => (
+        <ModalHeadline>
+          <Overline>Dataset: {datasetName}</Overline>
+          <Heading size='small'>Use with GIS software</Heading>
+        </ModalHeadline>
+      )}
+      content={
+        <Form>
+          {[
+            { label: 'XYZ Tile Url', value: tileUrls?.xyzTileUrl },
+            { label: 'WMTS Tile Url', value: tileUrls?.wmtsTileUrl }
+          ].map((tileUrl) =>
+            tileUrl.value ? (
+              <FormGroupStructure
+                key={tileUrl.value}
+                id={tileUrl.label}
+                label={tileUrl.label}
+              >
+                <CopyField value={tileUrl.value}>
+                  {({ ref, showCopiedMsg }) => {
+                    return (
+                      <FormInputSubmitWrapper>
+                        <FormInput
+                          type='text'
+                          readOnly
+                          value={showCopiedMsg ? 'Copied!' : tileUrl.value}
+                        />
+                        <Button
+                          ref={ref}
+                          size='medium'
+                          variation='primary-fill'
+                        >
+                          {showCopiedMsg ? (
+                            <CollecticonClipboardTick
+                              meaningful
+                              title={`${tileUrl.label} was copied`}
+                            />
+                          ) : (
+                            <CollecticonClipboard
+                              meaningful
+                              title={`Copy ${tileUrl.label}`}
+                            />
+                          )}
+                        </Button>
+                      </FormInputSubmitWrapper>
+                    );
+                  }}
+                </CopyField>
+              </FormGroupStructure>
+            ) : null
+          )}
+        </Form>
+      }
+    />
+  );
+}

--- a/app/scripts/components/exploration/components/map/analysis-message-control.tsx
+++ b/app/scripts/components/exploration/components/map/analysis-message-control.tsx
@@ -82,12 +82,11 @@ export function AnalysisMessage() {
     formatDateRange(selectedInterval.start, selectedInterval.end);
 
   const selectedFeatures = features.filter((f) => f.selected);
-  const selectedFeatureIds = selectedFeatures.map((f) => f.id).join(',');
 
   useEffect(() => {
     // Set the analysis as obsolete when the selected features change.
     setObsolete();
-  }, [setObsolete, selectedFeatureIds]);
+  }, [setObsolete, features]);
 
   if (isAnalyzing) {
     return (

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
 
 import { useStacMetadataOnDatasets } from '../../hooks/use-stac-metadata-datasets';
@@ -22,6 +22,7 @@ import { useBasemap } from '$components/common/map/controls/hooks/use-basemap';
 import DrawControl from '$components/common/map/controls/aoi';
 import CustomAoIControl from '$components/common/map/controls/aoi/custom-aoi-control';
 import ResetAoIControl from '$components/common/map/controls/aoi/reset-aoi-control';
+import { usePreviousValue } from '$utils/use-effect-previous';
 
 export function ExplorationMap() {
   const [projection, setProjection] = useState(projectionDefault);
@@ -39,6 +40,34 @@ export function ExplorationMap() {
   const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
   const selectedDay = useAtomValue(selectedDateAtom);
   const selectedCompareDay = useAtomValue(selectedCompareDateAtom);
+
+  // Different datasets may have a different default projection.
+  // When datasets are selected the first time, we set the map projection to the
+  // first dataset's projection.
+  const prevDatasetCount = usePreviousValue(datasets.length);
+  useEffect(() => {
+    if (!prevDatasetCount && datasets.length > 0) {
+      setProjection(datasets[0].data.projection ?? projectionDefault);
+    }
+  }, [datasets, prevDatasetCount]);
+
+  // If all the datasets are changed through the modal, we also want to update
+  // the map projection, since it is as if the datasets were selected for the
+  // first time.
+  // The only case where we don't want to update the projection is when not all
+  // datasets are changed, because it is not possible to know which projection
+  // to use.
+  const prevDatasetsIds = usePreviousValue(datasets.map((d) => d.data.id));
+  useEffect(() => {
+    if (!prevDatasetsIds) return;
+
+    const newDatasetsIds = datasets.map((d) => d.data.id);
+    const hasSameId = newDatasetsIds.some((id) => prevDatasetsIds.includes(id));
+
+    if (!hasSameId && datasets.length > 0) {
+      setProjection(datasets[0].data.projection ?? projectionDefault);
+    }
+  }, [prevDatasetsIds, datasets]);
 
   const comparing = !!selectedCompareDay;
 

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -12,6 +12,7 @@ import {
 import { resolveConfigFunctions } from '$components/common/map/utils';
 import { RasterTimeseries } from '$components/common/map/style-generators/raster-timeseries';
 import { VectorTimeseries } from '$components/common/map/style-generators/vector-timeseries';
+import { ZarrTimeseries } from '$components/common/map/style-generators/zarr-timeseries';
 
 interface LayerProps {
   id: string;
@@ -46,34 +47,52 @@ export function Layer(props: LayerProps) {
     return resolveConfigFunctions(dataset.data, bag);
   }, [dataset, relevantDate]);
 
-  if (dataset.data.type === 'vector') {
-    return (
-      <VectorTimeseries
-        id={layerId}
-        stacCol={dataset.data.stacCol}
-        stacApiEndpoint={dataset.data.stacApiEndpoint}
-        date={relevantDate}
-        zoomExtent={params.zoomExtent}
-        sourceParams={params.sourceParams}
-        generatorOrder={order}
-        hidden={!isVisible}
-        opacity={opacity}
-      />
-    );
-  } else {
-    return (
-      <RasterTimeseries
-        id={layerId}
-        stacCol={dataset.data.stacCol}
-        stacApiEndpoint={dataset.data.stacApiEndpoint}
-        tileApiEndpoint={dataset.data.tileApiEndpoint}
-        date={relevantDate}
-        zoomExtent={params.zoomExtent}
-        sourceParams={params.sourceParams}
-        generatorOrder={order}
-        hidden={!isVisible}
-        opacity={opacity}
-      />
-    );
+  switch (dataset.data.type) {
+    case 'vector':
+      return (
+        <VectorTimeseries
+          id={layerId}
+          stacCol={dataset.data.stacCol}
+          stacApiEndpoint={dataset.data.stacApiEndpoint}
+          date={relevantDate}
+          zoomExtent={params.zoomExtent}
+          sourceParams={params.sourceParams}
+          generatorOrder={order}
+          hidden={!isVisible}
+          opacity={opacity}
+        />
+      );
+    case 'zarr':
+      return (
+        <ZarrTimeseries
+          id={layerId}
+          stacCol={dataset.data.stacCol}
+          stacApiEndpoint={dataset.data.stacApiEndpoint}
+          tileApiEndpoint={dataset.data.tileApiEndpoint}
+          date={relevantDate}
+          zoomExtent={params.zoomExtent}
+          sourceParams={params.sourceParams}
+          generatorOrder={order}
+          hidden={!isVisible}
+          opacity={opacity}
+        />
+      );
+    case 'raster':
+      return (
+        <RasterTimeseries
+          id={layerId}
+          stacCol={dataset.data.stacCol}
+          stacApiEndpoint={dataset.data.stacApiEndpoint}
+          tileApiEndpoint={dataset.data.tileApiEndpoint}
+          date={relevantDate}
+          zoomExtent={params.zoomExtent}
+          sourceParams={params.sourceParams}
+          generatorOrder={order}
+          hidden={!isVisible}
+          opacity={opacity}
+        />
+      );
+    default:
+      throw new Error(`No layer generator for type: ${dataset.data.type}`);
   }
 }

--- a/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
+++ b/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
@@ -56,7 +56,7 @@ export function useAnalysisController() {
           isObsolete: false
         })),
       [] // eslint-disable-line react-hooks/exhaustive-deps -- setController is stable
-    ),
+    )
   };
 }
 
@@ -92,6 +92,7 @@ export function useAnalysisDataRequest({
 
   useEffect(() => {
     if (
+      !isAnalyzing ||
       datasetStatus !== TimelineDatasetStatus.SUCCESS ||
       !selectedInterval ||
       !selectedFeatures.length ||
@@ -124,5 +125,5 @@ export function useAnalysisDataRequest({
     // when they enter the analysis. It is certain that when this effect runs
     // the other values will be up to date. Adding all dependencies would cause
     // the hook to continuously run.
-  }, [analysisRunId, datasetStatus]);
+  }, [analysisRunId, datasetStatus, isAnalyzing]);
 }

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -97,7 +97,7 @@ async function fetchStacDatasetById(
       domain: featuresApiData.extent.temporal.interval[0]
     };
   } else {
-    const domain = data.summaries
+    const domain = data.summaries?.datetime?.[0]
       ? data.summaries.datetime
       : data.extent.temporal.interval[0];
 

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -79,7 +79,7 @@ function Exploration() {
 
   const setUrl = useSetAtom(urlAtom);
   const { reset: resetAnalysisController } = useAnalysisController();
-  // Reset atoms when entering the page.
+  // Reset atoms when leaving the page.
   useEffect(() => {
     return () => {
       resetAnalysisController();

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -96,6 +96,10 @@ export interface TimelineDatasetSettings {
   analysisMetrics?: DataMetric[];
 }
 
+// Any sort of meta information the dataset like:
+// Tile endpoints for the layer given the current map view.
+type TimelineDatasetMeta = Record<string, any>;
+
 // TimelineDataset type discriminants
 export interface TimelineDatasetIdle {
   status: TimelineDatasetStatus.IDLE;
@@ -104,6 +108,7 @@ export interface TimelineDatasetIdle {
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
   analysis: TimelineDatasetAnalysisIdle;
+  meta?: TimelineDatasetMeta;
 }
 export interface TimelineDatasetLoading {
   status: TimelineDatasetStatus.LOADING;
@@ -112,6 +117,7 @@ export interface TimelineDatasetLoading {
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
   analysis: TimelineDatasetAnalysisIdle;
+  meta?: TimelineDatasetMeta;
 }
 export interface TimelineDatasetError {
   status: TimelineDatasetStatus.ERROR;
@@ -120,6 +126,7 @@ export interface TimelineDatasetError {
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
   analysis: TimelineDatasetAnalysisIdle;
+  meta?: TimelineDatasetMeta;
 }
 export interface TimelineDatasetSuccess {
   status: TimelineDatasetStatus.SUCCESS;
@@ -128,6 +135,7 @@ export interface TimelineDatasetSuccess {
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
   analysis: TimelineDatasetAnalysis;
+  meta?: TimelineDatasetMeta;
 }
 
 export type TimelineDataset =

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -26,7 +26,11 @@ const StoriesHub = lazy(() => import('$components/stories/hub'));
 const StoriesSingle = lazy(() => import('$components/stories/single'));
 
 const DataCatalog = lazy(() => import('$components/data-catalog'));
+const DatasetsExplore = lazy(() => import('$components/datasets/s-explore'));
 const DatasetsOverview = lazy(() => import('$components/datasets/s-overview'));
+
+const Analysis = lazy(() => import('$components/analysis/define'));
+const AnalysisResults = lazy(() => import('$components/analysis/results'));
 
 const Exploration = lazy(() => import('$components/exploration'));
 
@@ -41,6 +45,8 @@ const DevseedUiThemeProvider = DsTp as any;
 import { ReactQueryProvider } from '$context/react-query';
 import {
   ABOUT_PATH,
+  ANALYSIS_PATH,
+  ANALYSIS_RESULTS_PATH,
   DATASETS_PATH,
   STORIES_PATH
 } from '$utils/routes';
@@ -51,6 +57,8 @@ const composingComponents = [
   ReactQueryProvider,
   LayoutRootContextProvider
 ];
+
+const useNewExploration = !!process.env.FEATURE_NEW_EXPLORATION;
 
 function ScrollTop() {
   const { pathname } = useLocation();
@@ -92,9 +100,26 @@ function Root() {
                   path={`${STORIES_PATH}/:storyId`}
                   element={<StoriesSingle />}
                 />
+
+                {!useNewExploration && (
+                  <>
+                    <Route
+                      path={`${DATASETS_PATH}/:datasetId/explore`}
+                      element={<DatasetsExplore />}
+                    />
+                    <Route path={ANALYSIS_PATH} element={<Analysis />} />
+                    <Route
+                      path={ANALYSIS_RESULTS_PATH}
+                      element={<AnalysisResults />}
+                    />
+                  </>
+                )}
+
                 <Route path='development' element={<Development />} />
 
-                <Route path='exploration' element={<Exploration />} />
+                {useNewExploration && (
+                  <Route path='exploration' element={<Exploration />} />
+                )}
 
                 {process.env.NODE_ENV !== 'production' && (
                   <Route path='/sandbox/*' element={<Sandbox />} />

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -117,9 +117,9 @@ function Root() {
 
                 <Route path='development' element={<Development />} />
 
-                {useNewExploration && (
+                {/* {useNewExploration && ( */}
                   <Route path='exploration' element={<Exploration />} />
-                )}
+                {/* )} */}
 
                 {process.env.NODE_ENV !== 'production' && (
                   <Route path='/sandbox/*' element={<Sandbox />} />

--- a/app/scripts/utils/routes.ts
+++ b/app/scripts/utils/routes.ts
@@ -14,6 +14,10 @@ export const getDatasetPath = (d: DatasetData | string) =>
   `${DATASETS_PATH}/${typeof d === 'string' ? d : d.id}`;
 
 export const getDatasetExplorePath = (d: DatasetData | string) => {
+  if (!process.env.FEATURE_NEW_EXPLORATION) {
+    return `${DATASETS_PATH}/${typeof d === 'string' ? d : d.id}/explore`;
+  }
+
   const id = typeof d === 'string' ? d : d.id;
   return `${EXPLORATION_PATH}?search=${id}`;
 };

--- a/mock/datasets/sandbox.data.mdx
+++ b/mock/datasets/sandbox.data.mdx
@@ -18,6 +18,35 @@ taxonomy:
       - Experimental
       - Untested
 layers:
+  - id: combined_CMIP6_daily_GISS-E2-1-G_tas_kerchunk_DEMO
+    stacCol: combined_CMIP6_daily_GISS-E2-1-G_tas_kerchunk_DEMO
+    name: CMIP6 Daily GISS-E2-1-G Near-Surface Air Temperature (demo subset)
+    type: zarr
+    tileApiEndpoint: https://dev-titiler-xarray.delta-backend.com/tilejson.json
+    description: "Historical (1950-2014) daily-mean near-surface (usually, 2 meter) air temperature in Kelvin."
+    zoomExtent:
+      - 0
+      - 20
+    sourceParams:
+      reference: "true"
+      resampling_method: bilinear
+      variable: tas
+      colormap_name: coolwarm
+      rescale: 232,312
+      maxzoom: 12
+    legend:
+      unit: 
+        label: K
+      type: gradient
+      min: 232
+      max: 312
+      stops:
+      - '#3b4cc0'
+      - '#7b9ff9'
+      - '#c0d4f5'
+      - '#f2cbb7'
+      - '#ee8468'
+      - '#b40426'
   - id: blue-tarp-planetscope
     stacCol: blue-tarp-planetscope
     name: Blue tarp test


### PR DESCRIPTION
This PR adds the features to A&E recently discussed:

- [x] Zarr layer type support
- [x] Modal to get dataset layer tiles (through dataset options menu)
- [x] Show error on non supported datasets for analysis (non raster)
- [x] Fix a couple of nasty bugs
- [x] Add a feature flag to enable the new exploration
   If the site is built with any truthy value set on `FEATURE_NEW_EXPLORATION`, the app shows the page, otherwise all normal business
- [x] Fix the analysis state upon selecting / deselecting AOIs or changing parameters + adding datasets
- [x] Resolve race condition with URL parameters
- [ ] https://github.com/NASA-IMPACT/veda-ui/issues/761
- [ ] https://github.com/NASA-IMPACT/veda-ui/issues/755

