### PR TITLE
Add documentations for the features introduced by eic

### DIFF
--- a/docs/content/CONTENT.md
+++ b/docs/content/CONTENT.md
@@ -194,6 +194,9 @@ related: Related[]
   - type: string
     id: string
     thematic: string
+
+asLink:
+  url: string;
 ---
 
 <Block>
@@ -262,4 +265,14 @@ Each content should be formatted like below
     id: dataset-id
   - type: story
     id: story-id
+```
+
+**asLink**
+
+If the story doesn't hold any contents but the link to outside, use `asLink` property to indicate it. Note that `id` 
+of the story that has `asLink` won't generate the url for the story.
+
+```
+asLink:
+  url: https://developmentseed.org
 ```

--- a/docs/content/CONTENT.md
+++ b/docs/content/CONTENT.md
@@ -269,7 +269,7 @@ Each content should be formatted like below
 
 **asLink**
 
-If the story doesn't hold any contents but the link to outside, use `asLink` property to indicate it. Note that `id` 
+If the story doesn't hold any contents but links externally. Use `asLink` property to indicate it. Note that `id` 
 of the story that has `asLink` won't generate the url for the story.
 
 ```

--- a/docs/content/CUSTOM_PAGES.md
+++ b/docs/content/CUSTOM_PAGES.md
@@ -22,6 +22,14 @@ Each custom page has the following properties:
 `string`  
 The menu label for this page.
 
+**mainNavItem**
+_⚠️ VEDA UI cannot prevent the style bugs from the customized mainNavItem._
+
+Use this property when this page needs to be displayed as an item in the main nav.
+
+**mainNavItem.navTitle**
+title to display on the main nav for the custom page.
+
 **title**  
 `string`  
 Title for this page shown on the header.

--- a/docs/content/PAGE_OVERRIDES.md
+++ b/docs/content/PAGE_OVERRIDES.md
@@ -4,10 +4,13 @@
   - [Content Override reference](#content-override-reference)
     - [aboutContent](#aboutcontent)
     - [homeContent](#homecontent)
+    - [developmentContent](#developmentcontent)
+    - [storeisHubContent](#storiesHubcontent)
   - [Component Override reference](#component-override-reference)
     - [headerBrand](#headerbrand)
     - [pageFooter](#pagefooter)
     - [homeHero](#homehero)
+    - [storiesHubHero](#storiesHubHero)
   - [Creating complex overrides](#creating-complex-overrides)
 
 
@@ -121,6 +124,10 @@ description: A brief description
 </Block>
 ```
 
+### storiesHubContent
+storiesHubContent allows you to write your own custom page for StoriesHub. You can find the example of 
+this override from [veda-config-eic repo](https://github.com/NASA-IMPACT/veda-config-eic/blob/c02477b5ff5d4db53ed31117bb845728c1f418c4/overrides/theme/content/index.mdx).
+
 ## Component Override reference
 
 ### headerBrand
@@ -148,6 +155,13 @@ _⚠️ Note that on a component override the `<Block>` components are not avail
 
 The `homeHero` override can be used to replace the page hero section on the homepage.  
 It is likely that some styling is needed to ensure that it is displayed properly.
+
+### storiesHubHero
+`Component Override` 
+_⚠️ Note that on a component override the `<Block>` components are not available and should not be used._
+
+The `storiesHubHero` can be used to replace the Stories Hub page. With the combinatino of `storiesHubContent`, 
+storiesHub page can be totally customized.
 
 ## Creating complex overrides
 

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -11,6 +11,8 @@
 ```yaml
 id: string
 stacCol: string
+stacApiEndpoint: string
+tileApiEndpoint: string
 name: string
 type: string
 initialDatetime: 'oldest' | 'newest' | Date(YYYY-MM-DD) = 'newest'
@@ -38,6 +40,14 @@ Must be unique in a dataset.
 **stacCol**  
 `string`  
 The stac collection that this layer should load.
+
+**stacApiEndpoint**  
+`string`  
+The stac api endpoint that has the collection. If not defined, environment variable `API_STAC_ENDPOINT` is used.
+
+**tileApiEndpoint**  
+`string`  
+The tile endpoint to use. If not defined, environment variable `API_RASTER_ENDPOINT` is used.
 
 **name**  
 `string`  


### PR DESCRIPTION
Close https://github.com/NASA-IMPACT/veda-ui/issues/742

+ I get the intention of separating contents of the dataset layer (https://github.com/NASA-IMPACT/veda-ui/blob/213d9c25a469121d2c420d0e952042bb596b855f/docs/content/CONTENT.md#datasets) from the data(STAC) related properties https://github.com/NASA-IMPACT/veda-ui/blob/213d9c25a469121d2c420d0e952042bb596b855f/docs/content/frontmatter/layer.md but this ends up being confusing. Would it be better just to merge the dataset layer properties into one file? 