### PR TITLE
Add Back Button on Explore page

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -12,7 +12,8 @@ import { isSameDay } from 'date-fns';
 import { themeVal } from '@devseed-ui/theme-provider';
 import {
   CollecticonExpandFromLeft,
-  CollecticonShrinkToLeft
+  CollecticonShrinkToLeft,
+  CollecticonArrowLeft,
 } from '@devseed-ui/collecticons';
 import { ProjectionOptions } from 'veda';
 import { FormSwitch } from '@devseed-ui/form';
@@ -21,6 +22,7 @@ import LayerVisibilityToggleButton from './layer-visibility-toggle';
 import TileLinkButton from './tile-link';
 import DatasetLayers from './dataset-layers';
 import { PanelDateWidget } from './panel-date-widget';
+import { DATASETS_PATH } from '$utils/routes';
 import { resourceNotFound } from '$components/uhoh';
 import { LayoutProps } from '$components/common/layout-root';
 import MapboxMap, { MapboxMapRef } from '$components/common/mapbox';
@@ -42,6 +44,7 @@ import {
   PANEL_REVEAL_DURATION
 } from '$styles/panel';
 
+
 import { useDataset } from '$utils/veda-data';
 import { useMediaQuery } from '$utils/use-media-query';
 import { useEffectPrevious } from '$utils/use-effect-previous';
@@ -60,6 +63,25 @@ import {
   BasemapId,
   BASEMAP_ID_DEFAULT
 } from '$components/common/mapbox/map-options/basemaps';
+
+const BackLink = styled.a`
+  display: flex;
+  padding: ${variableGlsp(0.5)};
+  font-size: 1rem;
+  font-weight: ${themeVal('type.base.bold')};
+  color: ${themeVal('color.primary')};
+  background-color: ${themeVal('color.surface')};
+  cursor: pointer;
+
+  & > svg {
+    flex: 0 0 auto;
+    margin: 0.25rem 0.5rem 0 0;
+  }
+
+  &:hover {
+    opacity: 0.8;
+  }
+`;
 
 const Explorer = styled.div`
   position: relative;
@@ -607,6 +629,11 @@ function DatasetsExplore() {
                 <PositionPlaceHolderForScroll />
                 <ScrollArea>
                   <ScrollAreaInner>
+                    <BackLink
+                      href={`${DATASETS_PATH}/${dataset.data.id}`}
+                    >
+                      <CollecticonArrowLeft /> Back to dataset overview
+                    </BackLink>
                     <DatesWrapper>
                       {activeLayerTimeseries && (
                         <PanelDateWidget

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router';
+import { Link } from 'react-router-dom';
 import useQsStateCreator from 'qs-state-hook';
 import { isSameDay } from 'date-fns';
 import { themeVal } from '@devseed-ui/theme-provider';
@@ -64,12 +65,12 @@ import {
   BASEMAP_ID_DEFAULT
 } from '$components/common/mapbox/map-options/basemaps';
 
-const BackLink = styled.a`
+const BackLink = styled(Link)`
   display: flex;
   padding: ${variableGlsp(0.5)};
   font-size: 1rem;
   font-weight: ${themeVal('type.base.bold')};
-  color: ${themeVal('color.primary')};
+  color: ${themeVal('color.link')};
   background-color: ${themeVal('color.surface')};
   cursor: pointer;
 
@@ -630,7 +631,7 @@ function DatasetsExplore() {
                 <ScrollArea>
                   <ScrollAreaInner>
                     <BackLink
-                      href={`${DATASETS_PATH}/${dataset.data.id}`}
+                      to={`${DATASETS_PATH}/${dataset.data.id}`}
                     >
                       <CollecticonArrowLeft /> Back to dataset overview
                     </BackLink>


### PR DESCRIPTION
close #776 

This adds a styled link to go to the dataset overview page. I parse the href as `${DATASETS_PATH}/${dataset.data.id}` in case the user had navigated directly to allow them to return to that overview page instead of simply a back button.

<img width="1271" alt="Screenshot 2023-12-14 at 5 10 22 PM" src="https://github.com/NASA-IMPACT/veda-ui/assets/7388976/d2464da7-4ec4-49b8-a84b-8805f108fccf">
