### PR TITLE
Make more space for units on map legend

### DIFF
--- a/app/scripts/components/common/mapbox/layer-legend.tsx
+++ b/app/scripts/components/common/mapbox/layer-legend.tsx
@@ -166,12 +166,17 @@ const LegendList = styled.dl`
     &:not(:first-of-type):not(:last-of-type) {
       ${visuallyHidden()}
     }
+  }
 
-    .unit {
+  .unit {
+    grid-row: 3;
       width: 100%;
       text-align: center;
+      font-size: 0.75rem;
+      line-height: 1rem;
     }
-  }
+
+
 `;
 
 const LegendSwatch = styled.span<LegendSwatchProps>`
@@ -338,9 +343,9 @@ export function LayerGradientGraphic(props: LayerLegendGradient) {
       </dt>
       <dd>
         <span>{printLegendVal(min)}</span>
-        {unit?.label && <span className='unit'>{unit.label}</span>}
         <span>{printLegendVal(max)}</span>
       </dd>
+      {unit?.label && <span className='unit'>{unit.label}</span>}
     </LegendList>
   );
 }


### PR DESCRIPTION
closes #686 

The map legend was set up as a grid with the units on a center column of the row. I moved units to a row below to allow more room for long unit types:


<img width="30%" alt="Legend-example" src="https://github.com/NASA-IMPACT/veda-ui/assets/7388976/b352d160-2706-4002-8028-2a03ffd24e2a">

<img width="30%" alt="Legend-short" src="https://github.com/NASA-IMPACT/veda-ui/assets/7388976/2e2fc2c0-9ab0-44b4-8fcc-326f61717054">

<img width="30%" alt="legend-really-long" src="https://github.com/NASA-IMPACT/veda-ui/assets/7388976/12d41b98-f39d-4510-830d-aa5b45bac5ab">

