### PR TITLE
update styles based on hideBrowserFrame prop

### DIFF
--- a/app/scripts/styles/browser-frame.tsx
+++ b/app/scripts/styles/browser-frame.tsx
@@ -3,11 +3,14 @@ import styled from 'styled-components';
 import { themeVal } from '@devseed-ui/theme-provider';
 import { CollecticonExpandTopRight } from '@devseed-ui/collecticons';
 
-function BrowserFrameComponent(props: { children: ReactNode; link?: string }) {
-  const { children, link, ...rest } = props;
+function BrowserFrameComponent(props: { children: ReactNode; link?: string, hideBrowserFrame?: boolean }) {
+  const { children, link, hideBrowserFrame, ...rest } = props;
+
+  const styleControls = hideBrowserFrame ? {display: 'none'}: undefined;
+  const stylePadding = hideBrowserFrame ? {padding: 0}: undefined;
   return (
-    <div {...rest}>
-      <div className='controls'>
+    <div {...rest} style={stylePadding}>
+      <div className='controls' style={styleControls}>
         <div className='buttons'>
           <span />
           <span />


### PR DESCRIPTION
closes #778 

This adds a prop to the existing `BrowserFrameComponent` that will hide the controls and change the padding which gives the illusion of the gray bar at the bottom of a browser.  By default, instances of the component already used will be unchanged, so only passing that prop as true will change things

Here's a screenshot with the `<BrowserFrame hideBrowserFrame={true}>` setting on the first occurrence of the component, but the second one is untouched.

<img width="1484" alt="Screenshot 2023-12-18 at 12 51 48 PM" src="https://github.com/NASA-IMPACT/veda-ui/assets/7388976/45b07cbb-2d17-4c10-9630-b25aaaf102fc">
