### PR TITLE
Fix user defined position setup for block maps (when compare slider is used)

### DIFF
--- a/app/scripts/components/common/mapbox/index.tsx
+++ b/app/scripts/components/common/mapbox/index.tsx
@@ -264,7 +264,6 @@ function MapboxMapComponent(
     baseTimeDensity,
     compareTimeDensity
   ]);
-
   return (
     <>
       {/*
@@ -475,6 +474,7 @@ function MapboxMapComponent(
                   stacApiEndpoint={compareLayerResolvedData.stacApiEndpoint}
                   tileApiEndpoint={compareLayerResolvedData.tileApiEndpoint}
                   mapInstance={mapCompareRef.current}
+                  isPositionSet={!!initialPosition}
                   date={compareToDate ?? undefined}
                   sourceParams={compareLayerResolvedData.sourceParams}
                   zoomExtent={compareLayerResolvedData.zoomExtent}


### PR DESCRIPTION
Close https://github.com/NASA-IMPACT/veda-config/issues/352

+ While looking at this issue, I realized that we are retiring the way of using the layers for the exploration page, but not for the stories. I will make a ticket with more details, but we should consolidate how the layers/maps are used throughout the application.