### PR TITLE
Docs about zoom extent

### DIFF
--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -68,7 +68,8 @@ Define the initial date that is shown when enabling a timeseries layer. This val
 
 **zoomExtent**  
 `[int, int] | fn(bag)`  
-Minimum and maximum zoom values for the layer. Below the minimum zoom level the layer will not be shown, but markers will be displayed to indicate where data is available.
+Minimum and maximum zoom values for the layer. Below the minimum zoom level the layer will not be shown, but markers will be displayed to indicate where data is available. 
+For raster and zarr layer, only minimum zoom will be respected and the maximum zoom will be automatically fetched from STAC endpoint.
 
 **sourceParams**  
 `object`  
@@ -80,6 +81,11 @@ These values may vary greatly depending on the layer being added but some may be
 - **colormap_name**  
   `string`  
   The colormap to use for the layer. One of https://cogeotiff.github.io/rio-tiler/colormap/#default-rio-tilers-colormaps
+- **minzoom**
+The minimum zoom of the layer. The tiles below the minzoom won't be fetched from titiler.
+- **maxzoom**
+The maximum zoom of the layer. The tiles over the maxzoom won't be fetched from titiler.
+
 
 **bounds**  
 `[int, int, int, int] | fn(bag)`  


### PR DESCRIPTION
Close #754 

<strike> @slesaad This PR changes the default way of resampling the raster when it is upsampled. Please check if this configuration works with the gridded dataset, and also the other datasets and if it would be ok to change the default method to this one. </strike>

As it turned out it was data problem, I will hold the code change and merge only doc change.