### PR TITLE
Fix ts warning by setting up TimeseriesWithMissingSummaries, InvalidDatasets explicitly

### DIFF
--- a/app/scripts/components/analysis/define/index.tsx
+++ b/app/scripts/components/analysis/define/index.tsx
@@ -516,8 +516,8 @@ export default function Analysis() {
                             </Overline>
                             {datasetLayer.name}
                             <DataPointsWarning>
-                              <CollecticonSignDanger />~
-                              {datasetLayer.numberOfItems ? `${datasetLayer.numberOfItems} data points`: "Data temporarily unavailable"}
+                              <CollecticonSignDanger />
+                              {'numberOfItems' in datasetLayer ? `${datasetLayer.numberOfItems} data points`: 'Data temporarily unavailable'}
                             </DataPointsWarning>
                           </FormCheckableUnselectable>
                         ))}

--- a/app/scripts/components/analysis/results/timeseries-data.ts
+++ b/app/scripts/components/analysis/results/timeseries-data.ts
@@ -38,6 +38,13 @@ export interface TimeseriesDataResult {
   timeseries: TimeseriesDataUnit[];
 }
 
+export interface TimeseriesMissingSummaries {
+  isPeriodic: boolean;
+  timeDensity: TimeDensity;
+  domain: string[];
+  timeseries?: unknown;
+}
+
 // Different options based on status.
 export type TimeseriesData =
   | {


### PR DESCRIPTION
I meant to just see if I can fix a ts warning (that timeseries can be undefined ) and then ended up with a bigger change -_-; 

- I made an explicit type for `TimeseriesMissingSummaries` and also `InvalidDatasets` which can be both DatasetWithTimeseriesData or DatasetMissingSummaries. 