### PR TITLE
777 critical error link

### DIFF
--- a/app/scripts/components/uhoh/fatal-error.js
+++ b/app/scripts/components/uhoh/fatal-error.js
@@ -119,6 +119,12 @@ function Child(props) {
                 <p>{nl2br(error.stack)}</p>
               </details>
             )}
+
+            <p>
+              <a href={makeAbsUrl('/')} title='Visit homepage'>
+                Go back to homepage
+              </a>
+            </p>
           </FoldProse>
         </PageMainContent>
       </LayoutRoot>

--- a/app/scripts/components/uhoh/fatal-error.js
+++ b/app/scripts/components/uhoh/fatal-error.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import T from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import nl2br from 'react-nl2br';
+import { CollecticonArrowRight } from '@devseed-ui/collecticons';
 
 import UhOh from '.';
 import LayoutRoot, {
@@ -121,9 +122,12 @@ function Child(props) {
             )}
 
             <p>
-              <a href={makeAbsUrl('/')} title='Visit homepage'>
-                Go back to homepage
-              </a>
+              <strong>
+                <a href={makeAbsUrl('/')} title='Go back to homepage'>
+                  <CollecticonArrowRight size='small' />
+                  <span>&nbsp;Go back to homepage</span>
+                </a>
+              </strong>
             </p>
           </FoldProse>
         </PageMainContent>


### PR DESCRIPTION
Added a more explicit link to the homepage from the critical error page.

![Screen Shot 2024-01-19 at 11 16 34 AM](https://github.com/NASA-IMPACT/veda-ui/assets/4583806/5d291b69-cc6b-4293-bdc8-0694d64f9a36)
