### PR TITLE
Add 'skip to main' to navigation

### DIFF
--- a/app/scripts/components/common/layout-root.tsx
+++ b/app/scripts/components/common/layout-root.tsx
@@ -58,7 +58,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
         thumbnail={thumbnail}
       />
       <NavWrapper />
-      <PageBody id={PAGE_BODY_ID}>
+      <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
       </PageBody>

--- a/app/scripts/components/common/layout-root.tsx
+++ b/app/scripts/components/common/layout-root.tsx
@@ -58,7 +58,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
         thumbnail={thumbnail}
       />
       <NavWrapper />
-      <PageBody>
+      <PageBody id='pagebody'>
         <Outlet />
         {children}
       </PageBody>

--- a/app/scripts/components/common/layout-root.tsx
+++ b/app/scripts/components/common/layout-root.tsx
@@ -22,7 +22,7 @@ import NavWrapper from '$components/common/nav-wrapper';
 
 const appTitle = process.env.APP_TITLE;
 const appDescription = process.env.APP_DESCRIPTION;
-export const PAGE_BODY_ID = 'pagebody'
+export const PAGE_BODY_ID = 'pagebody';
 const Page = styled.div`
   display: flex;
   flex-direction: column;

--- a/app/scripts/components/common/layout-root.tsx
+++ b/app/scripts/components/common/layout-root.tsx
@@ -22,7 +22,7 @@ import NavWrapper from '$components/common/nav-wrapper';
 
 const appTitle = process.env.APP_TITLE;
 const appDescription = process.env.APP_DESCRIPTION;
-
+export const PAGE_BODY_ID = 'pagebody'
 const Page = styled.div`
   display: flex;
   flex-direction: column;
@@ -58,7 +58,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
         thumbnail={thumbnail}
       />
       <NavWrapper />
-      <PageBody id='pagebody'>
+      <PageBody id={PAGE_BODY_ID}>
         <Outlet />
         {children}
       </PageBody>

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -284,6 +284,19 @@ const NavBlock = styled.div`
   `}
 `;
 
+const SROnly = styled.a`
+  height: 1px;
+  left: -10000px;
+  overflow: hidden;
+  position: absolute;
+  top: auto;
+  width: 1px;
+  &:focus {
+    overflow: visible;
+    position: static;
+  }
+`;
+
 const SectionsNavBlock = styled(NavBlock)`
   /* styled-component */
 `;
@@ -366,8 +379,26 @@ function PageHeader() {
     );
   });
 
+  function skipNav(e) {
+    // a tag won't appear for keyboard focus without href
+    // so we are preventing the default behaviour of a link here
+    e.preventDefault();
+    // Then find a next focusable element in pagebody,focus it.
+    const pageBody = document.getElementById('pagebody');
+    if (pageBody) {
+      const keyboardfocusableElements = Array.from(pageBody.querySelectorAll(
+          'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'
+        )
+      ).filter(el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
+      (keyboardfocusableElements[0] as HTMLElement).focus();
+    }
+  }
+
   return (
+    <>
+    <SROnly href='#' onClick={skipNav}>Skip to main content</SROnly>
     <PageHeaderSelf id={HEADER_ID}>
+      
       {globalNavRevealed && isMediumDown && <UnscrollableBody />}
       <ComponentOverride with='headerBrand'>
         <Brand>
@@ -494,6 +525,7 @@ function PageHeader() {
         </GlobalNavInner>
       </GlobalNav>
     </PageHeaderSelf>
+    </>
   );
 }
 

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -34,6 +34,7 @@ import {
   ABOUT_PATH,
   EXPLORATION_PATH
 } from '$utils/routes';
+import { PAGE_BODY_ID } from '$components/common/layout-root';
 import GlobalMenuLinkCSS from '$styles/menu-link';
 import { useMediaQuery } from '$utils/use-media-query';
 import { HEADER_ID } from '$utils/use-sliding-sticky-header';
@@ -384,7 +385,7 @@ function PageHeader() {
     // so we are preventing the default behaviour of a link here
     e.preventDefault();
     // Then find a next focusable element in pagebody,focus it.
-    const pageBody = document.getElementById('pagebody');
+    const pageBody = document.getElementById(PAGE_BODY_ID);
     if (pageBody) {
       const keyboardfocusableElements = Array.from(pageBody.querySelectorAll(
           'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -392,11 +392,7 @@ function PageHeader() {
     // Then find a next focusable element in pagebody,focus it.
     const pageBody = document.getElementById(PAGE_BODY_ID);
     if (pageBody) {
-      const keyboardfocusableElements = Array.from(pageBody.querySelectorAll(
-          'a[href], button, input, textarea, select, details, [tabindex]:not([tabindex="-1"])'
-        )
-      ).filter(el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'));
-      (keyboardfocusableElements[0] as HTMLElement).focus();
+        pageBody.focus();
     }
   }
 

--- a/app/scripts/components/common/page-header.tsx
+++ b/app/scripts/components/common/page-header.tsx
@@ -292,9 +292,14 @@ const SROnly = styled.a`
   position: absolute;
   top: auto;
   width: 1px;
+  color: ${themeVal('color.link')};
   &:focus {
-    overflow: visible;
-    position: static;
+    top: 0;
+    left: 0;
+    background-color: ${themeVal('color.surface')};
+    padding: ${glsp(0.25)};
+    height: auto;
+    width: auto;
   }
 `;
 


### PR DESCRIPTION
Add keyboard focusable 'Skip to main content' Button.
part of https://github.com/NASA-IMPACT/veda-ui/issues/807
Since we don't have an anchor link, We have to rely on some workaround (Manually focusing page body).

You should be able to see it by trying to keyboard navigate the page, but this is the screenshot.

![Screen Shot 2024-01-22 at 12 21 03 PM](https://github.com/NASA-IMPACT/veda-ui/assets/4583806/5936f015-61c3-49a6-bd1a-8ac20f1ae05c)
