### PR TITLE
Separate out precommit configuration

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  '*.(js|ts|tsx|jsx)': ['yarn eslint', 'yarn stylelint', () => 'yarn ts-check']
+};

--- a/package.json
+++ b/package.json
@@ -196,12 +196,5 @@
     "$utils": "~/app/scripts/utils",
     "$context": "~/app/scripts/context",
     "$test": "~/test"
-  },
-  "lint-staged": {
-    "*.(js|ts|tsx|jsx)": [
-      "yarn eslint",
-      "yarn stylelint",
-      "yarn ts-check"
-    ]
   }
 }


### PR DESCRIPTION
Fixed the problem (ts check does not scope the type check to the staged files. ex. throwing module not found error if the module is imported in a staged file, but not added to the stage) of ts-check in precommit hook by following:  https://github.com/lint-staged/lint-staged/issues/825#issuecomment-620018284
