### PR TITLE
Get rid of prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lint:scripts": "eslint app/scripts/",
     "lint:css": "stylelint 'app/styles/**/**' 'app/scripts/**/*.(js|ts|tsx|jsx)'",
     "ts-check": "yarn tsc --noEmit --skipLibCheck",
-    "test": "jest",
-    "prepare": "husky install"
+    "test": "jest"
   },
   "engines": {
     "node": "16.x"


### PR DESCRIPTION
I forgot to include this change in the follow pr -_-; I don't see why we need prepare script for husky, unless if you had any specific intention with it? @stephenkilbourn 