### PR TITLE
Add no layer status

### DIFF
--- a/.env
+++ b/.env
@@ -11,4 +11,3 @@ API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
 
 # Google form for feedback
 GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'
-FEATURE_NEW_EXPLORATION= 'TRUE'

--- a/.env
+++ b/.env
@@ -11,3 +11,4 @@ API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
 
 # Google form for feedback
 GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'
+FEATURE_NEW_EXPLORATION= 'TRUE'

--- a/app/scripts/components/exploration/components/dataset-selector-modal.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal.tsx
@@ -261,8 +261,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       size='xlarge'
       title='Select data layers'
       revealed={revealed}
-      disableKeyboardClose={isFirstSelection}
-      closeButton={!isFirstSelection}
       onCloseClick={close}
       renderHeadline={() => (
         <ModalHeadline>

--- a/app/scripts/components/exploration/components/datasets/dataset-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-options.tsx
@@ -94,12 +94,12 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
         <DropMenu>
           <li>
             <Tip
-              disabled={datasets.length > 1}
+              disabled={datasets.length > 0}
               content="It's not possible to remove the last dataset. Add another before removing this one."
             >
               <RemoveButton
                 variation='danger'
-                visuallyDisabled={datasets.length === 1}
+                // visuallyDisabled={datasets.length === 1}
                 onClick={() => {
                   setDatasets((datasets) =>
                     datasets.filter((d) => d.data.id !== dataset.data.id)

--- a/app/scripts/components/exploration/components/datasets/dataset-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-options.tsx
@@ -33,7 +33,7 @@ interface DatasetOptionsProps {
 export default function DatasetOptions(props: DatasetOptionsProps) {
   const { datasetAtom } = props;
 
-  const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
+  const [, setDatasets] = useAtom(timelineDatasetsAtom);
   const dataset = useAtomValue(datasetAtom);
   const [getSettings, setSetting] = useTimelineDatasetSettings(datasetAtom);
 
@@ -93,22 +93,16 @@ export default function DatasetOptions(props: DatasetOptionsProps) {
         </DropMenu>
         <DropMenu>
           <li>
-            <Tip
-              disabled={datasets.length > 0}
-              content="It's not possible to remove the last dataset. Add another before removing this one."
+            <RemoveButton
+              variation='danger'
+              onClick={() => {
+                setDatasets((datasets) =>
+                  datasets.filter((d) => d.data.id !== dataset.data.id)
+                );
+              }}
             >
-              <RemoveButton
-                variation='danger'
-                // visuallyDisabled={datasets.length === 1}
-                onClick={() => {
-                  setDatasets((datasets) =>
-                    datasets.filter((d) => d.data.id !== dataset.data.id)
-                  );
-                }}
-              >
-                <CollecticonTrashBin /> Remove dataset
-              </RemoveButton>
-            </Tip>
+              <CollecticonTrashBin /> Remove dataset
+            </RemoveButton>
           </li>
         </DropMenu>
       </Dropdown>

--- a/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
@@ -104,9 +104,7 @@ export function TimelineControls(props: TimelineControlsProps) {
   const { features } = useAois();
 
   // Scale to use when there are no datasets with data (loading or error)
-  const initialScale = useMemo(() => {
-    return getInitialScale(width);
-  },[width]);
+  const initialScale = useMemo(() => getInitialScale(width) ,[width]);
 
   return (
     <TimelineControlsSelf>

--- a/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
@@ -68,18 +68,20 @@ interface TimelineControlsProps {
 }
 
 
-export function useInitialScale(width) {
-  return useMemo(() => {
-    const now = new Date();
-    return scaleTime()
-      .domain([startOfYear(now), endOfYear(now)])
-      .range([0, width]);
-  }, [width]);
+export function getInitialScale(width) {
+  const now = new Date();
+  return scaleTime()
+    .domain([startOfYear(now), endOfYear(now)])
+    .range([0, width]);
 }
 
 export function TimelineDateAxis(props: Omit<TimelineControlsProps, "onZoom">) {
   const { xScaled, width } = props;
-  const initialScale = useInitialScale(width);
+
+  const initialScale = useMemo(() => {
+    return getInitialScale(width);
+  }, [width]);
+  
   return (
     <TimelineControlsSelf>
       <EmptyDateAxisWrapper>
@@ -102,7 +104,9 @@ export function TimelineControls(props: TimelineControlsProps) {
   const { features } = useAois();
 
   // Scale to use when there are no datasets with data (loading or error)
-  const initialScale = useInitialScale(width);
+  const initialScale = useMemo(() => {
+    return getInitialScale(width);
+  },[width]);
 
   return (
     <TimelineControlsSelf>

--- a/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
@@ -57,10 +57,36 @@ const DatePickerButton = styled(TipButton)`
   }
 `;
 
+const EmptyDateAxisWrapper = styled.div`
+  padding-top: ${glsp(3)};
+`;
+
 interface TimelineControlsProps {
   xScaled?: ScaleTime<number, number>;
   width: number;
   onZoom: (zoom: number) => void;
+}
+
+
+export function useInitialScale(width) {
+  return useMemo(() => {
+    const now = new Date();
+    return scaleTime()
+      .domain([startOfYear(now), endOfYear(now)])
+      .range([0, width]);
+  }, [width]);
+}
+
+export function TimelineDateAxis(props: Omit<TimelineControlsProps, "onZoom">) {
+  const { xScaled, width } = props;
+  const initialScale = useInitialScale(width);
+  return (
+    <TimelineControlsSelf>
+      <EmptyDateAxisWrapper>
+        <DateAxis xScaled={xScaled ?? initialScale} width={width} />
+      </EmptyDateAxisWrapper>
+    </TimelineControlsSelf>
+  );
 }
 
 export function TimelineControls(props: TimelineControlsProps) {
@@ -76,12 +102,7 @@ export function TimelineControls(props: TimelineControlsProps) {
   const { features } = useAois();
 
   // Scale to use when there are no datasets with data (loading or error)
-  const initialScale = useMemo(() => {
-    const now = new Date();
-    return scaleTime()
-      .domain([startOfYear(now), endOfYear(now)])
-      .range([0, width]);
-  }, [width]);
+  const initialScale = useInitialScale(width);
 
   return (
     <TimelineControlsSelf>

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -507,7 +507,23 @@ export default function Timeline(props: TimelineProps) {
   // Attach the needed event listeners to the interaction rectangle to capture
   // the mouse position. See source file for more information.
   useInteractionRectHover(interactionRef.current);
-  // Scale for no data
+  const CommonTimelineHeadline = () => {
+    return (
+      <Headline>
+        <Heading as='h2' size='xsmall'>
+          Data layers
+        </Heading>
+        <Button
+          variation='base-text'
+          size='small'
+          onClick={onDatasetAddClick}
+        >
+          <CollecticonPlusSmall title='Add layer' /> Add layer
+        </Button>
+      </Headline>);
+  };
+
+  // Stub scale for no data
   const mockedScale = useInitialScale(width);
   // Some of these values depend on each other, but we check all of them so
   // typescript doesn't complain.
@@ -516,18 +532,7 @@ export default function Timeline(props: TimelineProps) {
       <TimelineWrapper ref={observe}>
       <TimelineHeader>
         <TimelineDetails>
-          <Headline>
-            <Heading as='h2' size='xsmall'>
-              Data layers
-            </Heading>
-            <Button
-              variation='base-text'
-              size='small'
-              onClick={onDatasetAddClick}
-            >
-              <CollecticonPlusSmall title='Add layer' /> Add layer
-            </Button>
-          </Headline>
+          {CommonTimelineHeadline()}
         </TimelineDetails>
         <TimelineDateAxis
           xScaled={mockedScale}
@@ -560,18 +565,7 @@ export default function Timeline(props: TimelineProps) {
       />
       <TimelineHeader>
         <TimelineDetails>
-          <Headline>
-            <Heading as='h2' size='xsmall'>
-              Data layers
-            </Heading>
-            <Button
-              variation='base-text'
-              size='small'
-              onClick={onDatasetAddClick}
-            >
-              <CollecticonPlusSmall title='Add layer' /> Add layer
-            </Button>
-          </Headline>
+        {CommonTimelineHeadline()}
           <small>
             <Pluralize
               count={datasets.length}

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -523,9 +523,7 @@ export default function Timeline(props: TimelineProps) {
       </Headline>);
   };
   // Stub scale for when there is no layers
-  const initialScale = useMemo(() => {
-    return getInitialScale(width);
-  }, [width]);
+  const initialScale = useMemo(() => getInitialScale(width) ,[width]);
 
   // Some of these values depend on each other, but we check all of them so
   // typescript doesn't complain.

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -547,7 +547,7 @@ export default function Timeline(props: TimelineProps) {
             <div>
               <CollecticonIsoStack size='xxlarge' />
               <p>No data layer added to the map!</p> 
-              <Button variation='base-text' size='small' onClick={onDatasetAddClick}>Add a Layer here</Button>
+              <Button variation='base-text' size='small' onClick={onDatasetAddClick}>Add a layer here</Button>
             </div>
           </LayerActionBox>
         </EmptyTimelineContentInner>

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 import { DatasetList } from '../datasets/dataset-list';
 
 import { applyTransform, isEqualTransform, rescaleX } from './timeline-utils';
-import { TimelineControls, useInitialScale, TimelineDateAxis } from './timeline-controls';
+import { TimelineControls, getInitialScale, TimelineDateAxis } from './timeline-controls';
 import {
   TimelineHeadIn,
   TimelineHeadPoint,
@@ -522,9 +522,11 @@ export default function Timeline(props: TimelineProps) {
         </Button>
       </Headline>);
   };
+  // Stub scale for when there is no layers
+  const initialScale = useMemo(() => {
+    return getInitialScale(width);
+  }, [width]);
 
-  // Stub scale for no data
-  const mockedScale = useInitialScale(width);
   // Some of these values depend on each other, but we check all of them so
   // typescript doesn't complain.
   if (datasets.length === 0) {
@@ -535,14 +537,14 @@ export default function Timeline(props: TimelineProps) {
           {CommonTimelineHeadline()}
         </TimelineDetails>
         <TimelineDateAxis
-          xScaled={mockedScale}
+          xScaled={initialScale}
           width={width}
         />
       </TimelineHeader>
         <TimelineContent>
         <TimelineDetails />
         <EmptyTimelineContentInner>
-          <DateGrid width={width} xScaled={mockedScale} />
+          <DateGrid width={width} xScaled={initialScale} />
           <LayerActionBox>
             <div>
               <CollecticonIsoStack size='xxlarge' />

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@devseed-ui/button';
-import { CollecticonPlusSmall } from '@devseed-ui/collecticons';
+import { CollecticonIsoStack, CollecticonPlusSmall } from '@devseed-ui/collecticons';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Heading } from '@devseed-ui/typography';
 import { select, zoom } from 'd3';
@@ -26,7 +26,7 @@ import styled from 'styled-components';
 import { DatasetList } from '../datasets/dataset-list';
 
 import { applyTransform, isEqualTransform, rescaleX } from './timeline-utils';
-import { TimelineControls } from './timeline-controls';
+import { TimelineControls, useInitialScale, TimelineDateAxis } from './timeline-controls';
 import {
   TimelineHeadIn,
   TimelineHeadPoint,
@@ -78,16 +78,6 @@ const TimelineWrapper = styled.div`
   }
 `;
 
-const NoData = styled.div`
-  display: flex;
-  flex-flow: column;
-  align-items: center;
-  max-width: 20rem;
-  margin: auto;
-  padding: 2rem;
-  gap: 1rem;
-`;
-
 const InteractionRect = styled.div`
   position: absolute;
   left: 20rem;
@@ -129,14 +119,32 @@ const TimelineContent = styled.div`
   position: relative;
 `;
 
-const TimelineContentInner = styled.div`
+const EmptyTimelineContentInner = styled.div`
   height: 100%;
   min-height: 0;
   display: flex;
-  overflow-y: scroll;
   overflow-x: hidden;
   width: 100%;
   position: relative;
+`;
+
+const TimelineContentInner = styled(EmptyTimelineContentInner)`
+  overflow-y: scroll;
+`;
+
+const LayerActionBox = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  svg {
+    fill: ${themeVal('color.base-300')}
+  }
 `;
 
 interface TimelineProps {
@@ -499,15 +507,46 @@ export default function Timeline(props: TimelineProps) {
   // Attach the needed event listeners to the interaction rectangle to capture
   // the mouse position. See source file for more information.
   useInteractionRectHover(interactionRef.current);
-
+  // Scale for no data
+  const mockedScale = useInitialScale(width);
   // Some of these values depend on each other, but we check all of them so
   // typescript doesn't complain.
   if (datasets.length === 0) {
     return (
       <TimelineWrapper ref={observe}>
-        <NoData>
-          <p>Select a data layer to start exploration</p>
-        </NoData>
+      <TimelineHeader>
+        <TimelineDetails>
+          <Headline>
+            <Heading as='h2' size='xsmall'>
+              Data layers
+            </Heading>
+            <Button
+              variation='base-text'
+              size='small'
+              onClick={onDatasetAddClick}
+            >
+              <CollecticonPlusSmall title='Add layer' /> Add layer
+            </Button>
+          </Headline>
+        </TimelineDetails>
+        <TimelineDateAxis
+          xScaled={mockedScale}
+          width={width}
+        />
+      </TimelineHeader>
+        <TimelineContent>
+        <TimelineDetails />
+        <EmptyTimelineContentInner>
+          <DateGrid width={width} xScaled={mockedScale} />
+          <LayerActionBox>
+            <div>
+              <CollecticonIsoStack size='xxlarge' />
+              <p>No data layer added to the map!</p> 
+              <Button variation='base-text' size='small' onClick={onDatasetAddClick}>Add a Layer here</Button>
+            </div>
+          </LayerActionBox>
+        </EmptyTimelineContentInner>
+        </TimelineContent>
       </TimelineWrapper>
     );
   }

--- a/app/scripts/utils/polygon-url.ts
+++ b/app/scripts/utils/polygon-url.ts
@@ -79,7 +79,7 @@ export function decodeAois(aois: string): AoIFeature[] {
   const features: AoIFeature[] = chunk(decoded, 3).map((data) => {
     const [polygon, id, selected] = data;
     const decodedFeature = decodeFeature(polygon) as AoIFeature;
-    return { ...decodedFeature, id, selected };
+    return { ...decodedFeature, id, selected: selected as unknown as boolean };
   });
   return features!;
 }


### PR DESCRIPTION
Close #791 

@faustoperez : I took a liberty and removed all the controls - including zoom control - for no layer status. I couldn't think of any way to make a zoom control meaningful when there is no dataset. lmk if you have a different idea!