### PR TITLE
Add 'reopen guide' button

### DIFF
--- a/app/scripts/components/common/map/controls/map-options/index.tsx
+++ b/app/scripts/components/common/map/controls/map-options/index.tsx
@@ -8,7 +8,7 @@ import {
   DropMenuItem,
   DropTitle
 } from '@devseed-ui/dropdown';
-import { createButtonStyles } from '@devseed-ui/button';
+
 import { FormSwitch } from '@devseed-ui/form';
 import { Subtitle } from '@devseed-ui/typography';
 
@@ -22,7 +22,7 @@ import { MapOptionsProps } from './types';
 import { projectionsList } from './projections';
 import { BASEMAP_STYLES } from './basemap';
 
-import { TipButton } from '$components/common/tip-button';
+import { SelectorButton } from '$components/common/map/style/button';
 
 const DropHeader = styled.div`
   padding: ${glsp()};
@@ -50,27 +50,6 @@ const MapOptionsDropdown = styled(Dropdown)`
     margin: 0;
     padding-top: 0;
     padding-bottom: 0;
-  }
-`;
-
-// Why you ask? Very well:
-// Mapbox's css has an instruction that sets the hover color for buttons to
-// near black. The only way to override it is to increase the specificity and
-// we need the button functions to get the correct color.
-// The infamous instruction:
-// .mapboxgl-ctrl button:not(:disabled):hover {
-//   background-color: rgba(0, 0, 0, 0.05);
-// }
-const SelectorButton = styled(TipButton)`
-  &&& {
-    ${createButtonStyles({ variation: 'surface-fill', fitting: 'skinny' } as any)}
-    background-color: ${themeVal('color.surface')};
-    &:hover {
-      background-color: ${themeVal('color.surface')};
-    }
-    & path {
-      fill: ${themeVal('color.base')};
-    }
   }
 `;
 

--- a/app/scripts/components/common/map/style/button.tsx
+++ b/app/scripts/components/common/map/style/button.tsx
@@ -4,15 +4,9 @@ import { themeVal } from '@devseed-ui/theme-provider';
 
 import { TipButton } from '$components/common/tip-button';
 
-// Why you ask? Very well:
-// Mapbox's css has an instruction that sets the hover color for buttons to
-// near black. The only way to override it is to increase the specificity and
-// we need the button functions to get the correct color.
-// The infamous instruction:
-// .mapboxgl-ctrl button:not(:disabled):hover {
-//   background-color: rgba(0, 0, 0, 0.05);
-// }
-
+// &&&: To increase the specificity of css class
+// https://styled-components.com/docs/faqs#how-can-i-override-styles-with-higher-specificity
+// so we can override the derived selectors from Mapbox .mapboxgl-ctrl button
 export const SelectorButton = styled(TipButton)`
   &&& {
     ${createButtonStyles({ variation: 'surface-fill', fitting: 'skinny' } as any)}

--- a/app/scripts/components/common/map/style/button.tsx
+++ b/app/scripts/components/common/map/style/button.tsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+import { createButtonStyles } from '@devseed-ui/button';
+import { themeVal } from '@devseed-ui/theme-provider';
+
+import { TipButton } from '$components/common/tip-button';
+
+// Why you ask? Very well:
+// Mapbox's css has an instruction that sets the hover color for buttons to
+// near black. The only way to override it is to increase the specificity and
+// we need the button functions to get the correct color.
+// The infamous instruction:
+// .mapboxgl-ctrl button:not(:disabled):hover {
+//   background-color: rgba(0, 0, 0, 0.05);
+// }
+
+export const SelectorButton = styled(TipButton)`
+  &&& {
+    ${createButtonStyles({ variation: 'surface-fill', fitting: 'skinny' } as any)}
+    background-color: ${themeVal('color.surface')};
+    &:hover {
+      background-color: ${themeVal('color.surface')};
+    }
+    & path {
+      fill: ${themeVal('color.base')};
+    }
+  }
+`;

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../types.d.ts';
 import { Layer } from './layer';
 import { AnalysisMessageControl } from './analysis-message-control';
-import { TourDashboardControl } from './tour-control';
+import { ShowTourControl } from './tour-control';
 
 import Map, { Compare, MapControls } from '$components/common/map';
 import { Basemap } from '$components/common/map/style-generators/basemap';
@@ -156,7 +156,7 @@ export function ExplorationMap() {
           onOptionChange={onOptionChange}
         />
         <ScaleControl />
-        <TourDashboardControl />
+        <ShowTourControl />
         <MapCoordsControl />
         <NavigationControl />
         

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
+import { useTour } from '@reactour/tour';
 
 import { useStacMetadataOnDatasets } from '../../hooks/use-stac-metadata-datasets';
 import { selectedCompareDateAtom, selectedDateAtom } from '../../atoms/dates';
@@ -25,9 +26,12 @@ import { useBasemap } from '$components/common/map/controls/hooks/use-basemap';
 import DrawControl from '$components/common/map/controls/aoi';
 import CustomAoIControl from '$components/common/map/controls/aoi/custom-aoi-control';
 import { usePreviousValue } from '$utils/use-effect-previous';
+import { TourManagerInvokingButton } from '$components/exploration/tour-manager';
 
 export function ExplorationMap() {
   const [projection, setProjection] = useState(projectionDefault);
+
+  const { setIsOpen } = useTour();
 
   const {
     mapBasemapId,
@@ -155,9 +159,16 @@ export function ExplorationMap() {
           onOptionChange={onOptionChange}
         />
 
+        <TourManagerInvokingButton 
+          id='yaho' 
+          onClick={() => {console.log('yaho'); setIsOpen(true);}}
+        >
+          Invoke
+        </TourManagerInvokingButton>
         <ScaleControl />
         <MapCoordsControl />
         <NavigationControl />
+        
       </MapControls>
       {comparing && (
         // Compare map layers

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../types.d.ts';
 import { Layer } from './layer';
 import { AnalysisMessageControl } from './analysis-message-control';
+import { TourDashboardControl } from './tour-control';
 
 import Map, { Compare, MapControls } from '$components/common/map';
 import { Basemap } from '$components/common/map/style-generators/basemap';
@@ -25,7 +26,6 @@ import { useBasemap } from '$components/common/map/controls/hooks/use-basemap';
 import DrawControl from '$components/common/map/controls/aoi';
 import CustomAoIControl from '$components/common/map/controls/aoi/custom-aoi-control';
 import { usePreviousValue } from '$utils/use-effect-previous';
-import { TourManagerInvokingButton } from '$components/exploration/tour-manager';
 
 export function ExplorationMap() {
   const [projection, setProjection] = useState(projectionDefault);
@@ -156,7 +156,7 @@ export function ExplorationMap() {
           onOptionChange={onOptionChange}
         />
         <ScaleControl />
-        <TourManagerInvokingButton />
+        <TourDashboardControl />
         <MapCoordsControl />
         <NavigationControl />
         

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useAtom, useAtomValue } from 'jotai';
-import { useTour } from '@reactour/tour';
 
 import { useStacMetadataOnDatasets } from '../../hooks/use-stac-metadata-datasets';
 import { selectedCompareDateAtom, selectedDateAtom } from '../../atoms/dates';
@@ -30,8 +29,6 @@ import { TourManagerInvokingButton } from '$components/exploration/tour-manager'
 
 export function ExplorationMap() {
   const [projection, setProjection] = useState(projectionDefault);
-
-  const { setIsOpen } = useTour();
 
   const {
     mapBasemapId,
@@ -158,14 +155,8 @@ export function ExplorationMap() {
           boundariesOption={boundariesOption}
           onOptionChange={onOptionChange}
         />
-
-        <TourManagerInvokingButton 
-          id='yaho' 
-          onClick={() => {console.log('yaho'); setIsOpen(true);}}
-        >
-          Invoke
-        </TourManagerInvokingButton>
         <ScaleControl />
+        <TourManagerInvokingButton />
         <MapCoordsControl />
         <NavigationControl />
         

--- a/app/scripts/components/exploration/components/map/tour-control.tsx
+++ b/app/scripts/components/exploration/components/map/tour-control.tsx
@@ -23,23 +23,19 @@ export function TourButtonComponent({onClick, disabled}: {
   </SelectorButton>);
 }
 
-export function TourInvokingControl(props) {
-  useThemedControl(() => <TourButtonComponent {...props} />, {
-    position: 'top-right'
-  });
-  return null;
-}
-
-export function TourDashboardControl() {
+export function ShowTourControl() {
   const { setIsOpen, setCurrentStep, setSteps } = useTour();
+  const datasets = useAtomValue(timelineDatasetsAtom);
+  const disabled = datasets.length === 0;
 
   const reopenTour = useCallback(() => {
     setCurrentStep(0);
     setSteps?.(introTourSteps);
     setIsOpen(true);
-  },[setIsOpen]);
+  },[setIsOpen, setCurrentStep, setSteps]);
 
-  const datasets = useAtomValue(timelineDatasetsAtom);
-  const disabled = datasets.length === 0;
-  return <TourInvokingControl onClick={reopenTour} disabled={disabled} />;
+  useThemedControl(() => <TourButtonComponent onClick={reopenTour} disabled={disabled} />, {
+    position: 'top-right'
+  });
+  return null;
 }

--- a/app/scripts/components/exploration/components/map/tour-control.tsx
+++ b/app/scripts/components/exploration/components/map/tour-control.tsx
@@ -1,0 +1,45 @@
+import React, {useCallback} from 'react';
+import { useAtomValue } from 'jotai';
+import { useTour } from '@reactour/tour';
+import { CollecticonCircleQuestion } from '@devseed-ui/collecticons';
+
+import { SelectorButton } from '$components/common/map/style/button';
+import useThemedControl from '$components/common/map/controls/hooks/use-themed-control';
+import { introTourSteps } from '$components/exploration/tour-manager';
+import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
+
+export function TourButtonComponent({onClick, disabled}: {
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  disabled: boolean;
+}) {
+  return (
+  <SelectorButton
+    tipContent='Open guided tour'
+    tipProps={{ placement: 'left' }}
+    disabled={disabled}
+    onClick={onClick}
+  >
+    <CollecticonCircleQuestion />
+  </SelectorButton>);
+}
+
+export function TourInvokingControl(props) {
+  useThemedControl(() => <TourButtonComponent {...props} />, {
+    position: 'top-right'
+  });
+  return null;
+}
+
+export function TourDashboardControl() {
+  const { setIsOpen, setCurrentStep, setSteps } = useTour();
+
+  const reopenTour = useCallback(() => {
+    setCurrentStep(0);
+    setSteps?.(introTourSteps);
+    setIsOpen(true);
+  },[setIsOpen]);
+
+  const datasets = useAtomValue(timelineDatasetsAtom);
+  const disabled = datasets.length === 0;
+  return <TourInvokingControl onClick={reopenTour} disabled={disabled} />;
+}

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -100,7 +100,6 @@ function Exploration() {
       <TourManager />
       <PageMainContent>
         <PageHero title='Exploration' isHidden />
-
         <Container>
           <PanelGroup direction='vertical' className='panel-wrapper'>
             <Panel maxSize={75} className='panel'>

--- a/app/scripts/components/exploration/tour-manager.tsx
+++ b/app/scripts/components/exploration/tour-manager.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Button } from '@devseed-ui/button';
 import { Heading } from '@devseed-ui/typography';
-import { CollecticonCircleQuestion } from '@devseed-ui/collecticons';
+
 import {
   CollecticonChevronLeftSmall,
   CollecticonChevronRightSmall,
@@ -18,8 +18,6 @@ import tourAnalysisUrl from '../../../graphics/content/tour-analysis.gif';
 
 import { timelineDatasetsAtom } from './atoms/datasets';
 import { usePreviousValue } from '$utils/use-effect-previous';
-import { SelectorButton } from '$components/common/map/style/button';
-import useThemedControl from '$components/common/map/controls/hooks/use-themed-control';
 
 const Popover = styled.div`
   position: relative;
@@ -51,7 +49,7 @@ const PopoverFooter = styled.div`
   font-weight: ${themeVal('type.base.bold')};
 `;
 
-const introTourSteps = [
+export const introTourSteps = [
   {
     title: 'Time series analysis',
     selector: "[data-tour='analysis-tour']",
@@ -212,38 +210,4 @@ export function PopoverTourComponent(props: ExtendedPopoverContentProps) {
       )} */}
     </Popover>
   );
-}
-
-
-// Tour invoking button is not strictly a map control (It does nothing re: map) 
-// but it needs to be styled as one of map control
-// This is why these componets stay in this file, not where all other map control lives
-export function TourButtonComponent({onClick}: {
-  onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
-}) {
-  const datasets = useAtomValue(timelineDatasetsAtom);
-  const datasetCount = datasets.length;
-  return (
-  <SelectorButton
-    tipContent='Open guided tour'
-    tipProps={{ placement: 'left' }}
-    disabled={datasetCount === 0}
-    onClick={onClick}
-  >
-    <CollecticonCircleQuestion />
-  </SelectorButton>);
-}
-
-export function TourManagerInvokingButton(props) {
-  const { setIsOpen, setCurrentStep, setSteps } = useTour();
-  const reopenTour = useCallback(() => {
-    setCurrentStep(0);
-    setSteps?.(introTourSteps);
-    setIsOpen(true);
-  },[setIsOpen]);
-
-  useThemedControl(() => <TourButtonComponent {...props} onClick={reopenTour} />, {
-    position: 'top-right'
-  });
-  return null;
 }


### PR DESCRIPTION
Close #793 
Close #792 

+ Turning the a&e page on and off only through the environment file is cumbersome during active development. Test by directly typing the URL /exploration.  ex. https://deploy-preview-825--veda-ui.netlify.app/exploration 