### PR TITLE
Manually center geocoding result

### DIFF
--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -3,8 +3,7 @@ import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 
 import { useControl } from 'react-map-gl';
 
-
-function getZoomFromBbox(bbox: [number, number, number, number]): number {
+export function getZoomFromBbox(bbox: [number, number, number, number]): number {
   const latMax = Math.max(bbox[3], bbox[1]);
   const lngMax = Math.max(bbox[2], bbox[0]);
   const latMin = Math.min(bbox[3], bbox[1]);
@@ -21,7 +20,9 @@ function getZoomFromBbox(bbox: [number, number, number, number]): number {
 
 export default function GeocoderControl() {
 
-  const handleGeocoderResult = useCallback((map) => ({ result }) => {
+  const handleGeocoderResult = useCallback((map, geocoder) => ({ result }) => {
+    geocoder.clear();
+    geocoder._inputEl.blur();
     // Pass arbiturary number for zoom if there is no bbox
     const zoom = result.bbox? getZoomFromBbox(result.bbox): 14;
     map.flyTo({
@@ -29,7 +30,7 @@ export default function GeocoderControl() {
       zoom
     });
   }, []);
-  
+
   useControl(
     ({ map }) => {
       const geocoder = new MapboxGeocoder({
@@ -40,7 +41,7 @@ export default function GeocoderControl() {
         // We are doing manual centering for now
         flyTo: false
       });
-      geocoder.on('result', handleGeocoderResult(map));
+      geocoder.on('result', handleGeocoderResult(map, geocoder));
       return geocoder;
     },
     {

--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -1,15 +1,44 @@
+import { useCallback } from 'react';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 
 import { useControl } from 'react-map-gl';
 
+
+function getZoomFromBbox(bbox: [number, number, number, number]): number {
+  const latMax = Math.max(bbox[3], bbox[1]);
+  const lngMax = Math.max(bbox[2], bbox[0]);
+  const latMin = Math.min(bbox[3], bbox[1]);
+  const lngMin = Math.min(bbox[2], bbox[0]);
+  const maxDiff = Math.max(latMax - latMin, lngMax - lngMin);
+  if (maxDiff < 360 / Math.pow(2, 20)) {
+    return 21;
+} else {
+    const zoomLevel = Math.floor(-1*( (Math.log(maxDiff)/Math.log(2)) - (Math.log(360)/Math.log(2))));
+    if (zoomLevel < 1) return 1;
+    else return zoomLevel;
+  }
+}
+
 export default function GeocoderControl() {
+
+  const handleGeocoderResult = useCallback((map) => ({ result }) => {
+    const zoom = result.bbox? getZoomFromBbox(result.bbox): 14;
+    map.flyTo({
+      center: result.center,
+      zoom
+    });
+  }, []);
+  
   useControl(
-    () => {
-      return new MapboxGeocoder({
+    ({ map }) => {
+      const geocoder = new MapboxGeocoder({
         accessToken: process.env.MAPBOX_TOKEN,
         marker: false,
-        collapsed: true
+        collapsed: true,
+        flyTo: false
       });
+      geocoder.on('result', handleGeocoderResult(map));
+      return geocoder;
     },
     {
       position: 'top-right'

--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -22,6 +22,7 @@ function getZoomFromBbox(bbox: [number, number, number, number]): number {
 export default function GeocoderControl() {
 
   const handleGeocoderResult = useCallback((map) => ({ result }) => {
+    // Pass arbiturary number for zoom if there is no bbox
     const zoom = result.bbox? getZoomFromBbox(result.bbox): 14;
     map.flyTo({
       center: result.center,
@@ -35,6 +36,8 @@ export default function GeocoderControl() {
         accessToken: process.env.MAPBOX_TOKEN,
         marker: false,
         collapsed: true,
+        // Because of Mapbox issue: https://github.com/mapbox/mapbox-gl-js/issues/12565
+        // We are doing manual centering for now
         flyTo: false
       });
       geocoder.on('result', handleGeocoderResult(map));


### PR DESCRIPTION
Close #813 

It seems to be a known bug : https://github.com/mapbox/mapbox-gl-js/issues/12565

I put a manual workaround to center the map with the result from the geocoder for now. But hopefully, we can get rid of this workaround soon with Mapbox resolving the issue. 

(Sorry for confusing branch name, I thought bumping Mapbox would resolve the issue at first, but it seems not all the fixes have made it to production yet.)