### PR TITLE
Add Media as an optional attribute for a layer

### DIFF
--- a/app/scripts/components/exploration/components/dataset-selector-modal.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal.tsx
@@ -396,8 +396,8 @@ function DatasetLayerCard(props: DatasetLayerProps) {
           </TextHighlight>
         </>
       }
-      imgSrc={parent.media?.src}
-      imgAlt={parent.media?.alt}
+      imgSrc={layer.media?.src ?? parent.media?.src}
+      imgAlt={layer.media?.alt ?? parent.media?.alt}
       footerContent={
         <>
           {topics?.length ? (

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -50,6 +50,9 @@ layers:
   - id: no2-monthly
     stacCol: no2-monthly
     name: No2 PT
+    media:
+      src: ::file ./img-placeholder-3.jpg
+      alt: Placeholder Image
     type: raster
     projection:
       id: polarNorth

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -59,6 +59,7 @@ declare module 'veda' {
   export interface DatasetLayer extends DatasetLayerCommonProps {
     id: string;
     stacCol: string;
+    media?: Media;
     stacApiEndpoint?: string;
     tileApiEndpoint?: string;
     name: string;


### PR DESCRIPTION
Part of #828 

This adds 'meda' as an optional attribute for a layer so that the media can be used for each layer. I am making a small PR so that it is clear how to add a media for each layer.