### PR TITLE
Use allDatasets without 'disableExplore' flagging for data catalog page

### DIFF
--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -7,6 +7,7 @@ import { Subtitle } from '@devseed-ui/typography';
 import { Button } from '@devseed-ui/button';
 import { CollecticonXmarkSmall } from '@devseed-ui/collecticons';
 import { VerticalDivider } from '@devseed-ui/toolbar';
+import { datasets } from 'veda';
 
 import DatasetMenu from './dataset-menu';
 
@@ -47,7 +48,8 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { DatasetClassification } from '$components/common/dataset-classification';
-import { allDatasets } from '$components/exploration/data-utils';
+
+const allDatasets = Object.values(datasets).map((d) => d!.data);
 
 const DatasetCount = styled(Subtitle)`
   grid-column: 1 / -1;

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -49,7 +49,7 @@ import {
 } from '$utils/veda-data';
 import { DatasetClassification } from '$components/common/dataset-classification';
 
-const allDatasets = Object.values(datasets).map((d) => d!.data);
+const allDatasetsForCatalog = Object.values(datasets).map((d) => d!.data);
 
 const DatasetCount = styled(Subtitle)`
   grid-column: 1 / -1;
@@ -137,7 +137,7 @@ function DataCatalog() {
 
   const displayDatasets = useMemo(
     () =>
-      prepareDatasets(allDatasets, {
+      prepareDatasets(allDatasetsForCatalog, {
         search,
         taxonomies,
         sortField,
@@ -193,7 +193,7 @@ function DataCatalog() {
               count={displayDatasets.length}
               showCount={true}
             />{' '}
-            out of {allDatasets.length}.
+            out of {allDatasetsForCatalog.length}.
           </span>
           {isFiltering && (
             <Button forwardedAs={Link} to={DATASETS_PATH} size='small'>


### PR DESCRIPTION
Fix the problem of the current GHG Instance that the datasets with the `disableExplore` flag don't show up on the catalog page - for the context, this flag was introduced because some datasets cannot use the default explorer. ex. https://earth.gov/ghgcenter/data-catalog/emit-ch4plume-v1 

For the data catalog page, show all the datasets whether 'disableExplore' is flagged. (The 'explore' button won't show up anyway)