### PR TITLE
Add Layer info data as a layer attribute

### DIFF
--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeadline
+} from '@devseed-ui/modal';
+import { glsp, themeVal } from '@devseed-ui/theme-provider';
+import { createButtonStyles } from '@devseed-ui/button';
+import { Heading, Subtitle } from '@devseed-ui/typography';
+
+import { DatasetLayer } from 'veda';
+import { findParentDataset } from '../data-utils';
+
+import SmartLink from '$components/common/smart-link';
+import { getDatasetPath } from '$utils/routes';
+
+const DatasetModal = styled(Modal)`
+  z-index: ${themeVal('zIndices.modal')};
+
+  /* Override ModalContents */
+  > div {
+    display: flex;
+    flex-flow: column;
+  }
+
+  ${ModalBody} {
+    height: 100%;
+    min-height: 0;
+    display: flex;
+    flex-flow: column;
+    gap: ${glsp(1)};
+  }
+
+  ${ModalFooter} {
+    display: flex;
+    gap: ${glsp(1)};
+    align-items: center;
+    position: sticky;
+    bottom: ${glsp(-2)};
+    z-index: 100;
+  }
+`;
+
+
+const ButtonStyleLink = styled(SmartLink)<any>`
+  &&& {
+    ${({ variation, size }) => createButtonStyles({ variation, size })}
+  }
+`;
+
+interface LayerInfoModalProps {
+  revealed: boolean;
+  close: () => void;
+  datasetLayer: DatasetLayer;
+}
+
+export default function LayerInfoModal(props: LayerInfoModalProps) {
+  const { revealed, close, datasetLayer } = props;
+  const parent = findParentDataset(datasetLayer.id);
+  const dataCatalogPage = parent? getDatasetPath(parent) : '/';
+  return (
+    <DatasetModal
+      id='modal'
+      size='xlarge'
+      revealed={revealed}
+      onCloseClick={close}
+      renderHeadline={() => {
+        return (
+          <ModalHeadline>
+            <Heading size='small'>{datasetLayer.name}</Heading>
+            <Subtitle dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.subtitle?? '' }} />
+          </ModalHeadline>);
+      }}
+      content={
+        <div dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.contents?? 'Layer Information unvailable' }} />
+      }
+      footerContent={
+        <>
+          <ButtonStyleLink to={dataCatalogPage} variation='primary-fill' size='medium'>
+            Learn more
+          </ButtonStyleLink>
+        </>
+      }
+    />
+  );
+}

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -9,7 +9,7 @@ import {
 } from '@devseed-ui/modal';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { createButtonStyles } from '@devseed-ui/button';
-import { Heading, Subtitle } from '@devseed-ui/typography';
+import { Heading } from '@devseed-ui/typography';
 
 import { DatasetLayer } from 'veda';
 import { findParentDataset } from '../data-utils';
@@ -19,7 +19,6 @@ import { getDatasetPath } from '$utils/routes';
 
 const DatasetModal = styled(Modal)`
   z-index: ${themeVal('zIndices.modal')};
-
   /* Override ModalContents */
   > div {
     display: flex;
@@ -70,19 +69,17 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
       renderHeadline={() => {
         return (
           <ModalHeadline>
-            <Heading size='small'>{datasetLayer.name}</Heading>
-            <Subtitle dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.subtitle?? '' }} />
+            <Heading size='medium'>{datasetLayer.name}</Heading>
+            <p dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.subtitle?? '' }} />
           </ModalHeadline>);
       }}
       content={
-        <div dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.contents?? 'Layer Information unvailable' }} />
+        <div dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.contents?? 'Layer Information unvailable.' }} />
       }
       footerContent={
-        <>
-          <ButtonStyleLink to={dataCatalogPage} variation='primary-fill' size='medium'>
-            Learn more
-          </ButtonStyleLink>
-        </>
+        <ButtonStyleLink to={dataCatalogPage} variation='primary-fill' size='medium'>
+          Learn more
+        </ButtonStyleLink>
       }
     />
   );

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -11,8 +11,7 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { createButtonStyles } from '@devseed-ui/button';
 import { Heading } from '@devseed-ui/typography';
 
-import { DatasetLayer } from 'veda';
-import { findParentDataset } from '../data-utils';
+import { LayerInfo } from 'veda';
 
 import SmartLink from '$components/common/smart-link';
 import { getDatasetPath } from '$utils/routes';
@@ -53,13 +52,21 @@ const ButtonStyleLink = styled(SmartLink)<any>`
 interface LayerInfoModalProps {
   revealed: boolean;
   close: () => void;
-  datasetLayer: DatasetLayer;
+  layerData: {
+    name: string;
+    info: LayerInfo;
+    parentData: {
+      id: string;
+      infoDescription?: string;
+    }
+  }
 }
 
 export default function LayerInfoModal(props: LayerInfoModalProps) {
-  const { revealed, close, datasetLayer } = props;
-  const parent = findParentDataset(datasetLayer.id);
-  const dataCatalogPage = parent? getDatasetPath(parent) : '/';
+  const { revealed, close, layerData } = props;
+  const { parentData } = layerData;
+  const dataCatalogPage = getDatasetPath(parentData.id);
+
   return (
     <DatasetModal
       id='modal'
@@ -69,15 +76,24 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
       renderHeadline={() => {
         return (
           <ModalHeadline>
-            <Heading size='medium'>{datasetLayer.name}</Heading>
-            <p dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.subtitle?? '' }} />
+            <Heading size='medium'>{layerData.name}</Heading>
+            <p>
+              {Object.keys(layerData.info).map((key, idx, arr) => {
+                const currentValue = layerData.info[key];
+                return idx !== arr.length - 1 ? (
+                  <span>{currentValue} · </span>
+                ) : (
+                  <span>{currentValue} </span>
+                );
+              })}
+            </p>
           </ModalHeadline>);
       }}
       content={
-        <div dangerouslySetInnerHTML={{__html: datasetLayer.info?.modal.contents?? 'Layer Information unvailable.' }} />
+        <div dangerouslySetInnerHTML={{__html: parentData.infoDescription?? 'Layer Information unvailable.' }} />
       }
       footerContent={
-        <ButtonStyleLink to={dataCatalogPage} variation='primary-fill' size='medium'>
+        <ButtonStyleLink to={dataCatalogPage} onClick={close} variation='primary-fill' size='medium'>
           Learn more
         </ButtonStyleLink>
       }

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -17,6 +17,7 @@ import SandboxRequest from './request';
 import SandboxColors from './colors';
 import SandboxMDXEditor from './mdx-editor';
 import SandboxTable from './table';
+import SandboxLayerInfo from './layer-info';
 import { resourceNotFound } from '$components/uhoh';
 import { Card, CardList } from '$components/common/card';
 import { Fold, FoldHeader, FoldTitle } from '$components/common/fold';
@@ -104,6 +105,11 @@ const pages = [
     id: 'sandboxtable',
     name: 'Table',
     component: SandboxTable
+  },
+  {
+    id: 'sandboxLayerInfo',
+    name: 'Layer Info',
+    component: SandboxLayerInfo
   }
 ];
 

--- a/app/scripts/components/sandbox/layer-info/index.js
+++ b/app/scripts/components/sandbox/layer-info/index.js
@@ -1,30 +1,46 @@
-import React from 'react';
+import React, { useState, useCallback } from 'react';
 import { datasets } from 'veda';
+import LayerInfoModal from '$components/exploration/components/layer-info-modal';
 import Block from '$components/common/blocks';
-
 import { ContentBlockProse } from '$styles/content-block';
 
 export default function SandboxMDXPage() {
-  const data = datasets['no2'].data.layers[0];
-  const layerInfoMdxContent = data.info?.description;
-  const layerInfoTable = data.info.table;
+  const [revealed, setRevealed] = useState(false);
 
-  return layerInfoMdxContent ? (
-    <Block>
-      <ContentBlockProse>
-        <h2>{data.name} Layer Info</h2>
-        <div dangerouslySetInnerHTML={{ __html: layerInfoMdxContent }} />
-        <ul>
-          {Object.keys(layerInfoTable).map((key) => {
-            return (
-              <li key={key}>
-                <b>{key} : </b> <span>{layerInfoTable[key]}</span>
-              </li>
+  const openModal = useCallback(() => setRevealed(true), []);
+  const closeModal = useCallback(() => setRevealed(false), []);
+
+  const layer = datasets['no2'].data.layers[0];
+  return layer && layer.info ? (
+    <>
+      <Block>
+        <ContentBlockProse>
+          <button type='button' onClick={openModal}>
+            Open {layer.name} Layer Information Modal
+          </button>
+          {revealed && (
+            <LayerInfoModal
+              revealed={revealed}
+              close={closeModal}
+              datasetLayer={layer}
+            />
+          )}
+        </ContentBlockProse>
+      </Block>
+      <Block>
+        <ContentBlockProse>
+          <h4> Templated layer info</h4>
+          {Object.keys(layer.info.template).map((key, idx, arr) => {
+            const currentValue = layer.info.template[key];
+            return idx !== arr.length - 1 ? (
+              <span>{currentValue} · </span>
+            ) : (
+              <span>{currentValue} </span>
             );
           })}
-        </ul>
-      </ContentBlockProse>
-    </Block>
+        </ContentBlockProse>
+      </Block>
+    </>
   ) : (
     <div> Cannot find layer info fron dataset no2</div>
   );

--- a/app/scripts/components/sandbox/layer-info/index.js
+++ b/app/scripts/components/sandbox/layer-info/index.js
@@ -4,13 +4,16 @@ import LayerInfoModal from '$components/exploration/components/layer-info-modal'
 import Block from '$components/common/blocks';
 import { ContentBlockProse } from '$styles/content-block';
 
+const selectedDatasetId = 'no2';
+
 export default function SandboxMDXPage() {
   const [revealed, setRevealed] = useState(false);
 
   const openModal = useCallback(() => setRevealed(true), []);
   const closeModal = useCallback(() => setRevealed(false), []);
 
-  const layer = datasets['no2'].data.layers[0];
+  const layer = datasets[selectedDatasetId]?.data.layers[0];
+
   return layer && layer.info ? (
     <>
       <Block>
@@ -42,6 +45,6 @@ export default function SandboxMDXPage() {
       </Block>
     </>
   ) : (
-    <div> Cannot find layer info fron dataset no2</div>
+    <div> Cannot find layer info from dataset {selectedDatasetId}</div>
   );
 }

--- a/app/scripts/components/sandbox/layer-info/index.js
+++ b/app/scripts/components/sandbox/layer-info/index.js
@@ -12,20 +12,30 @@ export default function SandboxMDXPage() {
   const openModal = useCallback(() => setRevealed(true), []);
   const closeModal = useCallback(() => setRevealed(false), []);
 
-  const layer = datasets[selectedDatasetId]?.data.layers[0];
+  const datasetData = datasets[selectedDatasetId]?.data;
+  const layerData = datasetData.layers[0];
 
-  return layer && layer.info ? (
+  const modalData = {
+    name: layerData.name,
+    info: layerData.info,
+    parentData: {
+      id: datasetData.id,
+      infoDescription: datasetData.infoDescription
+    }
+  };
+
+  return datasetData && datasetData.infoDescription && layerData.info ? (
     <>
       <Block>
         <ContentBlockProse>
           <button type='button' onClick={openModal}>
-            Open {layer.name} Layer Information Modal
+            Open {datasetData.name} Layer Information Modal
           </button>
           {revealed && (
             <LayerInfoModal
               revealed={revealed}
               close={closeModal}
-              datasetLayer={layer}
+              layerData={modalData}
             />
           )}
         </ContentBlockProse>
@@ -33,8 +43,8 @@ export default function SandboxMDXPage() {
       <Block>
         <ContentBlockProse>
           <h4> Templated layer info</h4>
-          {Object.keys(layer.info.template).map((key, idx, arr) => {
-            const currentValue = layer.info.template[key];
+          {Object.keys(layerData.info).map((key, idx, arr) => {
+            const currentValue = layerData.info[key];
             return idx !== arr.length - 1 ? (
               <span>{currentValue} · </span>
             ) : (
@@ -45,6 +55,6 @@ export default function SandboxMDXPage() {
       </Block>
     </>
   ) : (
-    <div> Cannot find layer info from dataset {selectedDatasetId}</div>
+    <div> Cannot find dataset info from {selectedDatasetId}</div>
   );
 }

--- a/app/scripts/components/sandbox/layer-info/index.js
+++ b/app/scripts/components/sandbox/layer-info/index.js
@@ -7,11 +7,22 @@ import { ContentBlockProse } from '$styles/content-block';
 export default function SandboxMDXPage() {
   const data = datasets['no2'].data.layers[0];
   const layerInfoMdxContent = data.info?.description;
+  const layerInfoTable = data.info.table;
+
   return layerInfoMdxContent ? (
     <Block>
       <ContentBlockProse>
         <h2>{data.name} Layer Info</h2>
         <div dangerouslySetInnerHTML={{ __html: layerInfoMdxContent }} />
+        <ul>
+          {Object.keys(layerInfoTable).map((key) => {
+            return (
+              <li key={key}>
+                <b>{key} : </b> <span>{layerInfoTable[key]}</span>
+              </li>
+            );
+          })}
+        </ul>
       </ContentBlockProse>
     </Block>
   ) : (

--- a/app/scripts/components/sandbox/layer-info/index.js
+++ b/app/scripts/components/sandbox/layer-info/index.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { datasets } from 'veda';
+import Block from '$components/common/blocks';
+
+import { ContentBlockProse } from '$styles/content-block';
+
+export default function SandboxMDXPage() {
+  const data = datasets['no2'].data.layers[0];
+  const layerInfoMdxContent = data.info?.description;
+  return layerInfoMdxContent ? (
+    <Block>
+      <ContentBlockProse>
+        <h2>{data.name} Layer Info</h2>
+        <div dangerouslySetInnerHTML={{ __html: layerInfoMdxContent }} />
+      </ContentBlockProse>
+    </Block>
+  ) : (
+    <div> Cannot find layer info fron dataset no2</div>
+  );
+}

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -55,6 +55,20 @@ layers:
       id: polarNorth
     bounds: [-10, 36, -5, 42]
     description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
+    info:
+      description: |
+        ::markdown 
+        ### Title
+
+        - list item 1
+        - lis item 2
+
+        [A tag test](https://developmentseed.org)
+      table:
+        source: NASA
+        spatialExtent: Global
+        latency: Monthly
+        unit: unit
     zoomExtent:
       - 0
       - 20

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -56,19 +56,24 @@ layers:
     bounds: [-10, 36, -5, 42]
     description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     info:
-      description: |
-        ::markdown 
-        ### Title
-
-        - list item 1
-        - lis item 2
-
-        [A tag test](https://developmentseed.org)
-      table:
+      modal:
+        subtitle: |
+          ::markdown
+          Global, monthly 1 km resolution dataset of fossil fuel carbon dioxide emissions, version 2022
+        contents: |
+          ::markdown
+          - Temporal Extent: January 2000 - December 2021
+          - Temporal Resolution: Monthly
+          - Spatial Extent: Global
+          - Spatial Resolution: 1 km x 1 km
+          - Data Units: Tons of carbon per 1 km x 1 km cell (monthly total)
+          - Data Type: Research
+          - Data Latency: Updated annually, following the release of an updated [BP Statistical Review of World Energy report](https://www.bp.com/en/global/corporate/energy-economics.html)
+      template:
         source: NASA
         spatialExtent: Global
         latency: Monthly
-        unit: unit
+        unit: 10¹⁵ molecules cm⁻²
     zoomExtent:
       - 0
       - 20

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -46,6 +46,15 @@ taxonomy:
   - name: Source
     values:
       - Mock
+infoDescription: |
+  ::markdown
+    - Temporal Extent: January 2000 - December 2021
+    - Temporal Resolution: Monthly
+    - Spatial Extent: Global
+    - Spatial Resolution: 1 km x 1 km
+    - Data Units: Tons of carbon per 1 km x 1 km cell (monthly total)
+    - Data Type: Research
+    - Data Latency: Updated annually, following the release of an updated [BP Statistical Review of World Energy report](https://www.bp.com/en/global/corporate/energy-economics.html)
 layers:
   - id: no2-monthly
     stacCol: no2-monthly
@@ -55,25 +64,6 @@ layers:
       id: polarNorth
     bounds: [-10, 36, -5, 42]
     description: Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    info:
-      modal:
-        subtitle: |
-          ::markdown
-          Global, monthly 1 km resolution dataset of fossil fuel carbon dioxide emissions, version 2022
-        contents: |
-          ::markdown
-          - Temporal Extent: January 2000 - December 2021
-          - Temporal Resolution: Monthly
-          - Spatial Extent: Global
-          - Spatial Resolution: 1 km x 1 km
-          - Data Units: Tons of carbon per 1 km x 1 km cell (monthly total)
-          - Data Type: Research
-          - Data Latency: Updated annually, following the release of an updated [BP Statistical Review of World Energy report](https://www.bp.com/en/global/corporate/energy-economics.html)
-      template:
-        source: NASA
-        spatialExtent: Global
-        latency: Monthly
-        unit: 10¹⁵ molecules cm⁻²
     zoomExtent:
       - 0
       - 20
@@ -111,6 +101,11 @@ layers:
         - max
         # dummy value to make sure non existent values are sagfely discarded
         - non-existent
+    info:
+      source: NASA
+      spatialExtent: Global
+      latency: Monthly
+      unit: 10¹⁵ molecules cm⁻²
   - id: no2-monthly-2
     stacCol: no2-monthly
     name: No2 US

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "mapbox-gl": "^2.15.0",
     "mapbox-gl-compare": "^0.4.0",
     "mapbox-gl-draw-rectangle-mode": "^1.0.4",
+    "markdown-it": "^14.0.0",
     "optics-ts": "^2.4.1",
     "papaparse": "^5.3.2",
     "polished": "^4.1.3",

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -56,11 +56,23 @@ declare module 'veda' {
     MONTH = 'month',
     DAY = 'day'
   }
+  export interface LayerFrontmatterInfo {
+    info: {
+      description: string;
+      table: {
+        source: string;
+        spatialExtent: string;
+        latency: string;
+        unit: string;
+      };
+    };
+  }
   export interface DatasetLayer extends DatasetLayerCommonProps {
     id: string;
     stacCol: string;
     stacApiEndpoint?: string;
     tileApiEndpoint?: string;
+    info?: LayerFrontmatterInfo;
     name: string;
     description: string;
     initialDatetime?: 'newest' | 'oldest' | string;

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -56,24 +56,17 @@ declare module 'veda' {
     MONTH = 'month',
     DAY = 'day'
   }
-  export interface LayerFrontmatterInfo {
-    modal: {
-      subtitle: string;
-      contents: string;
-    },
-    template: {
-      source: string;
-      spatialExtent: string;
-      latency: string;
-      unit: string;
-    };
-  }
+export interface LayerInfo {
+  source: string;
+  spatialExtent: string;
+  latency: string;
+  unit: string;
+}
   export interface DatasetLayer extends DatasetLayerCommonProps {
     id: string;
     stacCol: string;
     stacApiEndpoint?: string;
     tileApiEndpoint?: string;
-    info?: LayerFrontmatterInfo;
     name: string;
     description: string;
     initialDatetime?: 'newest' | 'oldest' | string;
@@ -92,6 +85,7 @@ declare module 'veda' {
       to: string;
     },
     time_density?: TimeDensity;
+    info?: LayerInfo;
   }
   // A normalized compare layer is the result after the compare definition is
   // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The
@@ -185,6 +179,7 @@ declare module 'veda' {
     featured?: boolean;
     id: string;
     name: string;
+    infoDescription?: string;
     taxonomy: Taxonomy[];
     description: string;
     usage?: DatasetUsage[];

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -57,14 +57,15 @@ declare module 'veda' {
     DAY = 'day'
   }
   export interface LayerFrontmatterInfo {
-    info: {
-      description: string;
-      table: {
-        source: string;
-        spatialExtent: string;
-        latency: string;
-        unit: string;
-      };
+    modal: {
+      subtitle: string;
+      contents: string;
+    },
+    template: {
+      source: string;
+      spatialExtent: string;
+      latency: string;
+      unit: string;
     };
   }
   export interface DatasetLayer extends DatasetLayerCommonProps {

--- a/parcel-resolver-veda/stringify-yml-func.js
+++ b/parcel-resolver-veda/stringify-yml-func.js
@@ -1,7 +1,9 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const markdownit = require('markdown-it');
-const md = markdownit();
+const md = markdownit({
+  html: true
+});
 
 /**
  * Stringify the given object so that it can be used in the veda module.

--- a/parcel-resolver-veda/stringify-yml-func.js
+++ b/parcel-resolver-veda/stringify-yml-func.js
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 const markdownit = require('markdown-it');
-const md = markdownit({
-  html: true
-});
+const md = markdownit();
 
 /**
  * Stringify the given object so that it can be used in the veda module.

--- a/parcel-resolver-veda/stringify-yml-func.js
+++ b/parcel-resolver-veda/stringify-yml-func.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
+const marked = require('marked');
 
 /**
  * Stringify the given object so that it can be used in the veda module.
@@ -40,6 +41,16 @@ function stringifyYmlWithFns(data, filePath) {
     if (typeof v === 'string') {
       if (v.match(/^(\r|\n\s)*::js/gim)) {
         return `${v} ::js`;
+      }
+
+      // Handle markdown string
+      if (v.startsWith('::markdown')) {
+        // Detach the prefix
+        const p = v.replace(/^::markdown ?/, '');
+        // Conver the string to HTML
+        const parsedVal = marked.parse(p);
+        // Get rid of any empty line
+        return parsedVal.replace(/(\r\n|\n|\r)/gm, '');
       }
 
       // Handle file requires

--- a/parcel-resolver-veda/stringify-yml-func.js
+++ b/parcel-resolver-veda/stringify-yml-func.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
-const marked = require('marked');
+const markdownit = require('markdown-it');
+const md = markdownit();
 
 /**
  * Stringify the given object so that it can be used in the veda module.
@@ -48,7 +49,7 @@ function stringifyYmlWithFns(data, filePath) {
         // Detach the prefix
         const p = v.replace(/^::markdown ?/, '');
         // Conver the string to HTML
-        const parsedVal = marked.parse(p);
+        const parsedVal = md.render(p);
         // Get rid of any empty line
         return parsedVal.replace(/(\r\n|\n|\r)/gm, '');
       }

--- a/parcel-resolver-veda/stringify-yml-func.js
+++ b/parcel-resolver-veda/stringify-yml-func.js
@@ -45,6 +45,9 @@ function stringifyYmlWithFns(data, filePath) {
       }
 
       // Handle markdown string
+      // @NOTE: MDX render that VEDA uses to render stories, dataset overview expects a loader to render the contents
+      // (not straightforward to implement in frontmatter)
+      // Therefore, we convert markdown to HTML so it can be rendered without the MDX renderer
       if (v.startsWith('::markdown')) {
         // Detach the prefix
         const p = v.replace(/^::markdown ?/, '');

--- a/yarn.lock
+++ b/yarn.lock
@@ -6357,6 +6357,11 @@ entities@^3.0.1:
   resolved "http://verdaccio.ds.io:4873/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
   integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
+entities@^4.4.0:
+  version "4.5.0"
+  resolved "http://verdaccio.ds.io:4873/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
 error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "http://verdaccio.ds.io:4873/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
@@ -9209,6 +9214,13 @@ lines-and-columns@^1.1.6:
   resolved "http://verdaccio.ds.io:4873/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+linkify-it@^5.0.0:
+  version "5.0.0"
+  resolved "http://verdaccio.ds.io:4873/linkify-it/-/linkify-it-5.0.0.tgz#9ef238bfa6dc70bd8e7f9572b52d369af569b421"
+  integrity sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==
+  dependencies:
+    uc.micro "^2.0.0"
+
 lint-staged@14.0.1:
   version "14.0.1"
   resolved "http://verdaccio.ds.io:4873/lint-staged/-/lint-staged-14.0.1.tgz#57dfa3013a3d60762d9af5d9c83bdb51291a6232"
@@ -9489,6 +9501,18 @@ markdown-extensions@^1.0.0:
   resolved "http://verdaccio.ds.io:4873/markdown-extensions/-/markdown-extensions-1.1.1.tgz#fea03b539faeaee9b4ef02a3769b455b189f7fc3"
   integrity sha512-WWC0ZuMzCyDHYCasEGs4IPvLyTGftYwh6wIEOULOF0HXcqZlhwRzrK0w2VUlxWA98xnvb/jszw4ZSkJ6ADpM6Q==
 
+markdown-it@^14.0.0:
+  version "14.0.0"
+  resolved "http://verdaccio.ds.io:4873/markdown-it/-/markdown-it-14.0.0.tgz#b4b2ddeb0f925e88d981f84c183b59bac9e3741b"
+  integrity sha512-seFjF0FIcPt4P9U39Bq1JYblX0KZCjDLFFQPHpL5AzHpqPEKtosxmdq/LTVZnjfH7tjt9BxStm+wXcDBNuYmzw==
+  dependencies:
+    argparse "^2.0.1"
+    entities "^4.4.0"
+    linkify-it "^5.0.0"
+    mdurl "^2.0.0"
+    punycode.js "^2.3.1"
+    uc.micro "^2.0.0"
+
 markdown-table@^3.0.0:
   version "3.0.2"
   resolved "http://verdaccio.ds.io:4873/markdown-table/-/markdown-table-3.0.2.tgz#9b59eb2c1b22fe71954a65ff512887065a7bb57c"
@@ -9749,6 +9773,11 @@ mdurl@^1.0.0:
   version "1.0.1"
   resolved "http://verdaccio.ds.io:4873/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
   integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+
+mdurl@^2.0.0:
+  version "2.0.0"
+  resolved "http://verdaccio.ds.io:4873/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
+  integrity sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==
 
 meow@^6.1.1:
   version "6.1.1"
@@ -11304,6 +11333,11 @@ pumpify@^1.3.5:
     duplexify "^3.6.0"
     inherits "^2.0.3"
     pump "^2.0.0"
+
+punycode.js@^2.3.1:
+  version "2.3.1"
+  resolved "http://verdaccio.ds.io:4873/punycode.js/-/punycode.js-2.3.1.tgz#6b53e56ad75588234e79f4affa90972c7dd8cdb7"
+  integrity sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==
 
 punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
@@ -13277,6 +13311,11 @@ typewise@^1.0.3:
   integrity sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==
   dependencies:
     typewise-core "^1.2.0"
+
+uc.micro@^2.0.0:
+  version "2.0.0"
+  resolved "http://verdaccio.ds.io:4873/uc.micro/-/uc.micro-2.0.0.tgz#84b3c335c12b1497fd9e80fcd3bfa7634c363ff1"
+  integrity sha512-DffL94LsNOccVn4hyfRe5rdKa273swqeA5DJpMOeFmEn1wCDc7nAbbB0gXlgBCL7TNzeTv6G7XVWzan7iJtfig==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Part of #823 

**Heavily edited after the last time I opened this PR**

With this pr, layer can include `info` attribute. `info` consists of
```
info:
  modal: 
    subtitle: |
      ::markdown subtitle in markdown
    contents: |
      ::markdown contents in markdown
  template:
        source: string
        spatialExtent: string
        latency: string
        unit: string
``` 

I added a sandbox page to trigger the modal.   https://deploy-preview-843--veda-ui.netlify.app/sandbox/sandboxLayerInfo 

@faustoperez Currently, there is no easy way to determine if the link the user uses is an external or an internal link. (The link is just part of the HTML that a user passes as a part of Layerdata.) So I think we might have to skip the external link icons. :[ 


I am not implementing the link on top of the header, since I can pick that component up from the other branch currently working on (https://github.com/NASA-IMPACT/veda-ui/pull/829) 
![Screen Shot 2024-02-14 at 10 48 14 AM](https://github.com/NASA-IMPACT/veda-ui/assets/4583806/f0928050-bc3a-4391-aed8-ddd1c57fd5d4)


**Details of technical implementation**: This PR required an Implementation of processing markdown in frontmatter in `stringfy-yml-func`.
- I thought about passing Markdown as it is and delegating the rendering of it to the front-end, but it will increase the load of front-end work at this point. (Integrating it with our current MDX system for rendering stories and datasets seems challenging.) 
- Initially considered using our system's markdown parsers ([remark](https://github.com/remarkjs/remark) and [rehype](https://github.com/rehypejs/rehype)), but they are pure ES modules requiring rewiring in the pipeline, which I wanted to avoid in this PR. Therefore, I chose a different markdown parser.
- It's important to note that `info.modal.subtitle` and `info.modal.contents` should only contain markdown, not MDX, to exclude custom components.
