### PR TITLE
828 layer select modal

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -27,13 +27,15 @@ import { useMediaQuery } from '$utils/use-media-query';
 const BrowseControlsWrapper = styled.div`
   display: flex;
   flex-flow: column;
-  gap: ${variableGlsp(0.5)};
+  gap: ${variableGlsp(0.25)};
   padding-top: ${variableGlsp(0.5)};
 `;
 
 const SearchWrapper = styled.div`
   display: flex;
   gap: ${variableGlsp(0.5)};
+  width: 100%;
+  max-width: 70rem;
 `;
 
 const TaxonomyWrapper = styled.div`
@@ -58,10 +60,12 @@ const DropButton = styled(Button)`
 `;
 const MainDropButton = styled(DropButton)`
   width: 15rem;
+  max-width: 15rem;
 `;
 
 const ShowMorebutton = styled(Button)`
   width: 10rem;
+  max-width: 10rem;
 `;
 
 const ButtonPrefix = styled(Overline).attrs({ as: 'small' })`

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Taxonomy } from 'veda';
 import { Overline } from '@devseed-ui/typography';
@@ -28,6 +28,7 @@ const BrowseControlsWrapper = styled.div`
   display: flex;
   flex-flow: column;
   gap: ${variableGlsp(0.5)};
+  padding-top: ${variableGlsp(0.5)};
 `;
 
 const SearchWrapper = styled.div`
@@ -46,8 +47,7 @@ const TaxonomyWrapper = styled.div`
 `;
 
 const DropButton = styled(Button)`
-  max-width: 14rem;
-
+  max-width: 12rem;
   > span {
     ${truncated()}
   }
@@ -55,6 +55,13 @@ const DropButton = styled(Button)`
   > svg {
     flex-shrink: 0;
   }
+`;
+const MainDropButton = styled(DropButton)`
+  width: 15rem;
+`;
+
+const ShowMorebutton = styled(Button)`
+  width: 10rem;
 `;
 
 const ButtonPrefix = styled(Overline).attrs({ as: 'small' })`
@@ -68,6 +75,7 @@ interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
 }
 
 function BrowseControls(props: BrowseControlsProps) {
+  const [ showMoreFilters, setShowMoreFilters ] = useState(false);
   const {
     taxonomiesOptions,
     taxonomies,
@@ -85,20 +93,6 @@ function BrowseControls(props: BrowseControlsProps) {
 
   return (
     <BrowseControlsWrapper {...rest}>
-      <TaxonomyWrapper>
-        {taxonomiesOptions.map(({ name, values }) => (
-          <DropdownOptions
-            key={name}
-            prefix={name}
-            items={[optionAll].concat(values)}
-            currentId={taxonomies?.[name] ?? 'all'}
-            onChange={(v) => {
-              onAction(Actions.TAXONOMY, { key: name, value: v });
-            }}
-            size={isLargeUp ? 'large' : 'medium'}
-          />
-        ))}
-      </TaxonomyWrapper>
       <SearchWrapper>
         <SearchField
           size={isLargeUp ? 'large' : 'medium'}
@@ -111,7 +105,7 @@ function BrowseControls(props: BrowseControlsProps) {
           alignment='left'
           // eslint-disable-next-line @typescript-eslint/no-unused-vars
           triggerElement={({ active, className, ...rest }) => (
-            <DropButton
+            <MainDropButton
               variation='base-outline'
               size={isLargeUp ? 'large' : 'medium'}
               active={active}
@@ -124,7 +118,7 @@ function BrowseControls(props: BrowseControlsProps) {
               ) : (
                 <CollecticonChevronDownSmall />
               )}
-            </DropButton>
+            </MainDropButton>
           )}
         >
           <DropTitle>Options</DropTitle>
@@ -155,7 +149,30 @@ function BrowseControls(props: BrowseControlsProps) {
             ))}
           </DropMenu>
         </DropdownScrollable>
+        <ShowMorebutton
+          variation='base-text'
+          size={isLargeUp ? 'large' : 'medium'}
+          fitting='skinny'
+          onClick={() => {setShowMoreFilters(value => !value);}}
+        >
+          {showMoreFilters? 'Show less' : 'Show more'}
+        </ShowMorebutton>
       </SearchWrapper>
+      {showMoreFilters && 
+        <TaxonomyWrapper>
+          {taxonomiesOptions.map(({ name, values }) => (
+            <DropdownOptions
+              key={name}
+              prefix={name}
+              items={[optionAll].concat(values)}
+              currentId={taxonomies?.[name] ?? 'all'}
+              onChange={(v) => {
+                onAction(Actions.TAXONOMY, { key: name, value: v });
+              }}
+              size={isLargeUp ? 'large' : 'medium'}
+            />
+          ))}
+        </TaxonomyWrapper>}
     </BrowseControlsWrapper>
   );
 }

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -66,6 +66,7 @@ const MainDropButton = styled(DropButton)`
 const ShowMorebutton = styled(Button)`
   width: 10rem;
   max-width: 10rem;
+  text-decoration: underline;
 `;
 
 const ButtonPrefix = styled(Overline).attrs({ as: 'small' })`
@@ -79,7 +80,7 @@ interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
 }
 
 function BrowseControls(props: BrowseControlsProps) {
-  const [ showMoreFilters, setShowMoreFilters ] = useState(false);
+  const [ showFilters, setShowFilters ] = useState(false);
   const {
     taxonomiesOptions,
     taxonomies,
@@ -157,12 +158,12 @@ function BrowseControls(props: BrowseControlsProps) {
           variation='base-text'
           size={isLargeUp ? 'large' : 'medium'}
           fitting='skinny'
-          onClick={() => {setShowMoreFilters(value => !value);}}
+          onClick={() => {setShowFilters(value => !value);}}
         >
-          {showMoreFilters? 'Hide filters' : 'Show filters'}
+          {showFilters? 'Hide filters' : 'Show filters'}
         </ShowMorebutton>
       </SearchWrapper>
-      {showMoreFilters && 
+      {showFilters && 
         <TaxonomyWrapper>
           {taxonomiesOptions.map(({ name, values }) => (
             <DropdownOptions

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -159,7 +159,7 @@ function BrowseControls(props: BrowseControlsProps) {
           fitting='skinny'
           onClick={() => {setShowMoreFilters(value => !value);}}
         >
-          {showMoreFilters? 'Show less' : 'Show more'}
+          {showMoreFilters? 'Hide filters' : 'Show filters'}
         </ShowMorebutton>
       </SearchWrapper>
       {showMoreFilters && 

--- a/app/scripts/components/common/search-field.tsx
+++ b/app/scripts/components/common/search-field.tsx
@@ -59,6 +59,12 @@ const SearchFieldContainer = styled.div`
     border-radius: ${themeVal('shape.rounded')};
     box-shadow: inset 0 0 0 1px ${themeVal('color.base')};
   }
+  &:focus-within {
+    border-radius: ${themeVal('shape.rounded')};
+    outline-width: 0.25rem;
+    outline-color: ${themeVal('color.primary-200a')};
+    outline-style: solid;
+  }
 `;
 
 const SearchFieldClearable = styled.div<{ isOpen: boolean }>`

--- a/app/scripts/components/common/search-field.tsx
+++ b/app/scripts/components/common/search-field.tsx
@@ -16,6 +16,7 @@ const SearchFieldWrapper = styled.div`
   display: flex;
   flex-flow: column;
   align-items: flex-end;
+  width: 100%;
 `;
 
 interface SearchFieldMessageProps {
@@ -33,7 +34,8 @@ const SearchFieldMessage = styled(FormHelperMessage)<SearchFieldMessageProps>`
   ${({ isOpen }) =>
     isOpen &&
     css`
-      max-width: 15rem;
+      width: 100%;
+      max-width: 100%;
     `}
 
   ${({ isFocused }) =>
@@ -46,7 +48,8 @@ const SearchFieldMessage = styled(FormHelperMessage)<SearchFieldMessageProps>`
 const SearchFieldContainer = styled.div`
   position: relative;
   display: flex;
-
+  width: 100%;
+  background-color: ${themeVal('color.surface')};
   ::before {
     position: absolute;
     inset: 0;
@@ -63,11 +66,11 @@ const SearchFieldClearable = styled.div<{ isOpen: boolean }>`
   overflow: hidden;
   transition: max-width 320ms ease-in-out;
   max-width: 0;
-
   ${({ isOpen }) =>
     isOpen &&
     css`
-      max-width: 15rem;
+      width: 100%;
+      max-width: 100%;
     `}
 `;
 
@@ -75,7 +78,7 @@ const FormInputSearch = styled(FormInput)`
   border: 0;
   padding-left: 0;
   padding-right: 0;
-  width: 15rem;
+  width: 100%;
 `;
 
 interface SearchFieldProps

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -76,30 +76,49 @@ export const prepareDatasets = (
     taxonomies: Record<string, string> | null;
     sortField: string | null;
     sortDir: string | null;
+    filterLayers: boolean | null;
   }
 ) => {
-  const { sortField, sortDir, search, taxonomies } = options;
+  const { sortField, sortDir, search, taxonomies, filterLayers } = options;
 
   let filtered = [...data];
 
   // Does the free text search appear in specific fields?
   if (search.length >= 3) {
     const searchLower = search.toLowerCase();
-    filtered = filtered.filter((d) => {
-      const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
-      return (
-        d.id.toLowerCase().includes(searchLower) ||
-        d.name.toLowerCase().includes(searchLower) ||
-        d.description.toLowerCase().includes(searchLower) ||
-        d.layers.some((l) => l.stacCol.toLowerCase().includes(searchLower)) ||
-        d.layers.some((l) => l.name.toLowerCase().includes(searchLower)) ||
-        d.layers.some((l) => l.description.toLowerCase().includes(searchLower)) ||
-        topicsTaxonomy?.values.some((t) =>
-          t.name.toLowerCase().includes(searchLower)
-        )
-      );
-    });
+    // Function to check if searchLower is included in any of the string fields
+    const includesSearchLower = (str) => str.toLowerCase().includes(searchLower);
+    // Function to determine if a layer matches the search criteria
+    const layerMatchesSearch = (layer) => 
+      includesSearchLower(layer.stacCol) ||
+      includesSearchLower(layer.name) ||
+      includesSearchLower(layer.description);
+
+    filtered = filtered
+      .filter((d) => {
+        // Pre-calculate lowercased versions to use in comparisons
+        const idLower = d.id.toLowerCase();
+        const nameLower = d.name.toLowerCase();
+        const descriptionLower = d.description.toLowerCase();
+        const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
+
+        // Check if any of the conditions for including the item are met
+        return (
+          idLower.includes(searchLower) ||
+          nameLower.includes(searchLower) ||
+          descriptionLower.includes(searchLower) ||
+          d.layers.some(layerMatchesSearch) ||
+          topicsTaxonomy?.values.some((t) => includesSearchLower(t.name))
+        );
+      });
+
+      if (filterLayers)
+        filtered = filtered.map((d) => ({
+          ...d,
+          layers: d.layers.filter(layerMatchesSearch),
+        }));
   }
+
 
   taxonomies &&
     Object.entries(taxonomies).forEach(([name, value]) => {
@@ -142,7 +161,8 @@ function DataCatalog() {
         search,
         taxonomies,
         sortField,
-        sortDir
+        sortDir,
+        filterLayers: false
       }),
     [search, taxonomies, sortField, sortDir]
   );

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -93,6 +93,7 @@ export const prepareDatasets = (
         d.description.toLowerCase().includes(searchLower) ||
         d.layers.some((l) => l.stacCol.toLowerCase().includes(searchLower)) ||
         d.layers.some((l) => l.name.toLowerCase().includes(searchLower)) ||
+        d.layers.some((l) => l.description.toLowerCase().includes(searchLower)) ||
         topicsTaxonomy?.values.some((t) =>
           t.name.toLowerCase().includes(searchLower)
         )

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -6,6 +6,7 @@ import {
   CollecticonTickSmall,
   iconDataURI
 } from '@devseed-ui/collecticons';
+import { DatasetData } from 'veda';
 import { DatasetLayerCardProps } from './';
 
 import { DatasetClassification } from '$components/common/dataset-classification';
@@ -25,7 +26,6 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { Pill } from '$styles/pill';
-
 const DatasetContainer = styled.div`
   height: auto;
   display: flex;
@@ -72,8 +72,10 @@ const DatasetIntro = styled.div`
 interface ModalContentComponentProps {
   search: string;
   selectedIds: string[];
-  displayDatasets: any[];
-  onCheck:  (id:any) => void;
+  displayDatasets: (DatasetData & {
+    countSelectedLayers: number;
+  })[];
+  onCheck: (id: string) => void;
 }
 
 export default function ModalContentComponent(props:ModalContentComponentProps) {
@@ -236,7 +238,6 @@ function DatasetLayerCard(props: DatasetLayerCardProps) {
               ))}
             </CardTopicsList>
           ) : null}
-          {/* <DatasetMenu dataset={parent} /> */}
         </>
       }
     />

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -59,14 +59,14 @@ const DatasetHeadline = styled.div`
   gap: ${glsp(1)};
   margin-bottom: ${glsp(1)};
 `;
-const DatasetDescription = styled.p``;
+const DatasetDescription = styled.p`
+  ${media.largeUp`
+    width: 66%;
+  `}
+`;
+
 const DatasetIntro = styled.div`
   padding: ${glsp(1)} 0;
-  ${DatasetDescription} {
-    ${media.largeUp`
-      width: 66%;
-    `}
-  }
 `;
 
 interface ModalContentComponentProps {
@@ -78,7 +78,7 @@ interface ModalContentComponentProps {
 
 export default function ModalContentComponent(props:ModalContentComponentProps) {
   const { search, selectedIds, displayDatasets, onCheck } = props;
-  return(<>
+  return(
   <DatasetContainer>
     {displayDatasets.length ? (
       <div>
@@ -87,7 +87,7 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
           <DatasetIntro>
             <DatasetHeadline>
             <h4>{currentDataset.name}</h4>
-            {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
+            {currentDataset.countSelectedLayers && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
             <DatasetDescription>
               <TextHighlight
@@ -122,7 +122,7 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
       </EmptyHub>
     )}
   </DatasetContainer>
-         </>);
+        );
 }
 
 const LayerCard = styled(Card)<{ checked: boolean }>`

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -51,7 +51,7 @@ const DatasetSelectedLayer = styled.div`
   background-color: ${themeVal('color.primary')};
   border-radius: 40px;
   padding: 0 ${glsp(0.5)};
-  color: ${themeVal('color.surface')}
+  color: ${themeVal('color.surface')};
 `;
 
 const DatasetHeadline = styled.div`

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -49,7 +49,7 @@ const SingleDataset = styled.div`
 
 const DatasetSelectedLayer = styled.div`
   background-color: ${themeVal('color.primary')};
-  border-radius: 40px;
+  border-radius: ${themeVal('shape.ellipsoid')};
   padding: 0 ${glsp(0.5)};
   color: ${themeVal('color.surface')};
 `;

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
-import { glsp, themeVal } from '@devseed-ui/theme-provider';
+import { glsp, themeVal, media } from '@devseed-ui/theme-provider';
 import {
   CollecticonPlus,
   CollecticonTickSmall,
@@ -59,8 +59,14 @@ const DatasetHeadline = styled.div`
   gap: ${glsp(1)};
   margin-bottom: ${glsp(1)};
 `;
+const DatasetDescription = styled.p``;
 const DatasetIntro = styled.div`
   padding: ${glsp(1)} 0;
+  ${DatasetDescription} {
+    ${media.largeUp`
+      width: 66%;
+    `}
+  }
 `;
 
 interface ModalContentComponentProps {
@@ -84,7 +90,7 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
             {/* <Subtitle><LayerInfoLiner info={currentDataset.subtitle}/></Subtitle> */}
             {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
-            <p>{currentDataset.description}</p>
+            <DatasetDescription>{currentDataset.description}</DatasetDescription>
           </DatasetIntro>
         <CardList key={currentDataset.id}>
         {currentDataset.layers.map((datasetLayer) => {
@@ -158,6 +164,7 @@ const LayerCard = styled(Card)<{ checked: boolean }>`
     css`
       &:before {
         opacity: 1;
+        z-index: 10;
         content: 'Selected';
         color: ${themeVal('color.surface')};
         padding-left: 2.75rem;

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -90,7 +90,14 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
             {/* <Subtitle><LayerInfoLiner info={currentDataset.subtitle}/></Subtitle> */}
             {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
-            <DatasetDescription>{currentDataset.description}</DatasetDescription>
+            <DatasetDescription>
+              <TextHighlight
+                value={search}
+                disabled={search.length < 3}
+              >
+                {currentDataset.description}
+              </TextHighlight>
+            </DatasetDescription>
           </DatasetIntro>
         <CardList key={currentDataset.id}>
         {currentDataset.layers.map((datasetLayer) => {
@@ -208,7 +215,7 @@ function DatasetLayerCard(props: DatasetLayerCardProps) {
           {layer.name}
         </TextHighlight>
       }
-      description={layer.description}
+      description={<TextHighlight value={searchTerm} disabled={searchTerm.length < 3}>{layer.description}</TextHighlight>}
       imgSrc={layer.media?.src ?? parent.media?.src}
       imgAlt={layer.media?.alt ?? parent.media?.alt}
       footerContent={

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -87,7 +87,6 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
           <DatasetIntro>
             <DatasetHeadline>
             <h4>{currentDataset.name}</h4>
-            {/* <Subtitle><LayerInfoLiner info={currentDataset.subtitle}/></Subtitle> */}
             {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
             <DatasetDescription>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -87,7 +87,7 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
           <DatasetIntro>
             <DatasetHeadline>
             <h4>{currentDataset.name}</h4>
-            {currentDataset.countSelectedLayers && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
+            {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
             <DatasetDescription>
               <TextHighlight

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -1,0 +1,232 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import styled, { css } from 'styled-components';
+import { useAtom } from 'jotai';
+
+import { DatasetData, DatasetLayer } from 'veda';
+import {
+  Modal,
+  ModalBody,
+  ModalFooter,
+  ModalHeader
+} from '@devseed-ui/modal';
+import { glsp, themeVal } from '@devseed-ui/theme-provider';
+import { Button } from '@devseed-ui/button';
+import { Subtitle } from '@devseed-ui/typography';
+import {
+  CollecticonPlus,
+  CollecticonTickSmall,
+  CollecticonXmarkSmall,
+  iconDataURI
+} from '@devseed-ui/collecticons';
+
+import { timelineDatasetsAtom } from '../../atoms/datasets';
+import {
+  allDatasets,
+  datasetLayers,
+  findParentDataset,
+  reconcileDatasets
+} from '../../data-utils';
+
+import RenderModalHeader from './header';
+
+import EmptyHub from '$components/common/empty-hub';
+import {
+  Card,
+  CardList,
+  CardMeta,
+  CardTopicsList
+} from '$components/common/card';
+import { DatasetClassification } from '$components/common/dataset-classification';
+import { CardSourcesList } from '$components/common/card-sources';
+import DatasetMenu from '$components/data-catalog/dataset-menu';
+import { getDatasetPath } from '$utils/routes';
+import {
+  getTaxonomy,
+  TAXONOMY_SOURCE,
+  TAXONOMY_TOPICS
+} from '$utils/veda-data';
+import { Pill } from '$styles/pill';
+import {
+  Actions,
+  useBrowserControls
+} from '$components/common/browse-controls/use-browse-controls';
+import { prepareDatasets, sortOptions } from '$components/data-catalog';
+import Pluralize from '$utils/pluralize';
+import TextHighlight from '$components/common/text-highlight';
+
+const DatasetContainer = styled.div`
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  margin-bottom: ${glsp(2)};
+
+  ${CardList} {
+    width: 100%;
+  }
+
+  ${EmptyHub} {
+    flex-grow: 1;
+  }
+`;
+
+const LayerCard = styled(Card)<{ checked: boolean }>`
+  outline: 4px solid transparent;
+  ${({ checked }) =>
+    checked &&
+    css`
+      outline-color: ${themeVal('color.primary')};
+    `}
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    height: 3rem;
+    min-width: 3rem;
+    transform: translate(-50%, -50%);
+    padding: ${glsp(0.5, 1, 0.5, 1)};
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: ${themeVal('color.primary')};
+    border-radius: ${themeVal('shape.ellipsoid')};
+    font-weight: ${themeVal('type.base.bold')};
+    line-height: 1rem;
+    background-image: url(${({ theme }) =>
+      iconDataURI(CollecticonPlus, {
+        color: theme.color?.surface,
+        size: 'large'
+      })});
+    background-repeat: no-repeat;
+    background-position: 0.75rem center;
+    pointer-events: none;
+    transition: all 0.16s ease-in-out;
+    opacity: 0;
+  }
+
+  &:hover ::before {
+    opacity: 1;
+  }
+
+  ${({ checked }) =>
+    checked &&
+    css`
+      &:before {
+        opacity: 1;
+        content: 'Selected';
+        padding-left: 2.75rem;
+        background-image: url(${({ theme }) =>
+          iconDataURI(CollecticonTickSmall, {
+            color: theme.color?.surface,
+            size: 'large'
+          })});
+        background-color: ${themeVal('color.base')};
+      }
+      &:hover ::before {
+        background-color: ${themeVal('color.primary')};
+      }
+    `}
+`;
+
+function DatasetLayerCard(props: DatasetLayerProps) {
+  const { parent, layer, onDatasetClick, selected, searchTerm } = props;
+
+  const topics = getTaxonomy(parent, TAXONOMY_TOPICS)?.values;
+
+  return (
+    <LayerCard
+      cardType='cover'
+      checked={selected}
+      overline={
+        <CardMeta>
+          <DatasetClassification dataset={parent} />
+          <CardSourcesList
+            sources={getTaxonomy(parent, TAXONOMY_SOURCE)?.values}
+          />
+        </CardMeta>
+      }
+      linkTo={getDatasetPath(parent)}
+      linkLabel='View dataset'
+      onLinkClick={(e) => {
+        e.preventDefault();
+        onDatasetClick();
+      }}
+      title={
+        <TextHighlight value={searchTerm} disabled={searchTerm.length < 3}>
+          {layer.name}
+        </TextHighlight>
+      }
+      description={
+        <>
+          From:{' '}
+          <TextHighlight value={searchTerm} disabled={searchTerm.length < 3}>
+            {parent.name}
+          </TextHighlight>
+        </>
+      }
+      imgSrc={layer.media?.src ?? parent.media?.src}
+      imgAlt={layer.media?.alt ?? parent.media?.alt}
+      footerContent={
+        <>
+          {topics?.length ? (
+            <CardTopicsList>
+              <dt>Topics</dt>
+              {topics.map((t) => (
+                <dd key={t.id}>
+                  <Pill variation='achromic'>
+                    <TextHighlight
+                      value={searchTerm}
+                      disabled={searchTerm.length < 3}
+                    >
+                      {t.name}
+                    </TextHighlight>
+                  </Pill>
+                </dd>
+              ))}
+            </CardTopicsList>
+          ) : null}
+          <DatasetMenu dataset={parent} />
+        </>
+      }
+    />
+  );
+}
+
+export default function ModalContentRender(props) {
+  const { search, selectedIds, displayDatasets, onCheck } = props;
+  return(<>
+  <DatasetContainer>
+    {displayDatasets.length ? (
+      <div>
+      {displayDatasets.map(currentDataset => (
+        <>
+        <h4>{currentDataset.name}</h4>
+        <span>{currentDataset.countSelectedLayers}</span>
+        <p>{currentDataset.description}</p>
+        <CardList key={currentDataset.id}>
+        {currentDataset.layers.map((datasetLayer) => {
+          return (
+            <li key={datasetLayer.id}>
+              <DatasetLayerCard
+                searchTerm={search}
+                layer={datasetLayer}
+                parent={currentDataset}
+                selected={selectedIds.includes(datasetLayer.id)}
+                onDatasetClick={() => onCheck(datasetLayer.id)}
+              />
+            </li>
+          );
+        })}
+        </CardList>
+        </>
+      ))}
+      </div>
+    ) : (
+      <EmptyHub>
+        There are no datasets to show with the selected filters.
+      </EmptyHub>
+    )}
+  </DatasetContainer>
+         </>);
+}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { Button } from '@devseed-ui/button';
+import { pluralize } from '$utils/pluralize';
+
+interface ModalFooterComponentProps {
+  selectedIds: string[]; 
+  onConfirm: () => void; 
+  isFirstSelection: boolean;
+}
+
+export default function ModalFooterRender (props:ModalFooterComponentProps) {
+  const { selectedIds, onConfirm, isFirstSelection } = props;
+  return (
+    <>
+      <p className='selection-info'>
+        {selectedIds.length
+          ? `${selectedIds.length} ${pluralize({ singular: 'layer', plural: 'layers', count: selectedIds.length})} selected`
+          : 'No data layers selected'}
+      </p>
+      {!isFirstSelection && (
+        <Button variation='base-text' onClick={close}>
+          Cancel
+        </Button>
+      )}
+      <Button
+        variation='primary-fill'
+        disabled={!selectedIds.length}
+        onClick={onConfirm}
+      >
+        Add to map
+      </Button>
+    </>
+  );
+
+}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -13,7 +13,7 @@ export default function ModalFooterRender (props:ModalFooterComponentProps) {
   const { selectedIds, onConfirm, isFirstSelection } = props;
   return (
     <>
-      <p className='selection-info'>
+      <p aria-live='polite' className='selection-info'>
         {selectedIds.length
           ? `${selectedIds.length} ${pluralize({ singular: 'layer', plural: 'layers', count: selectedIds.length})} selected`
           : 'No data layers selected'}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import styled from 'styled-components';
+
+import { themeVal, glsp } from '@devseed-ui/theme-provider';
 
 import { Button } from '@devseed-ui/button';
 import { pluralize } from '$utils/pluralize';
@@ -8,16 +11,32 @@ interface ModalFooterComponentProps {
   onConfirm: () => void; 
   isFirstSelection: boolean;
 }
+const LayerNumberHighlight = styled.div`
+  border-radius: 100%;
+  background-color: ${themeVal('color.primary')};
+  color: ${themeVal('color.surface')};
+  font-weight: bold;
+  width: 25px;
+  height: 25px;
+  display: flex;
+  justify-content: center;
+  align-content: center;
+`;
+
+const LayerResult = styled.div`
+  display: flex;
+  gap: ${glsp(0.5)};
+`;
 
 export default function ModalFooterRender (props:ModalFooterComponentProps) {
   const { selectedIds, onConfirm, isFirstSelection } = props;
   return (
     <>
-      <p aria-live='polite' className='selection-info'>
+      <LayerResult aria-live='polite' className='selection-info'>
         {selectedIds.length
-          ? `${selectedIds.length} ${pluralize({ singular: 'layer', plural: 'layers', count: selectedIds.length})} selected`
+          ? <><LayerNumberHighlight>{selectedIds.length} </LayerNumberHighlight> <div>{pluralize({ singular: 'layer', plural: 'layers', count: selectedIds.length})} selected</div></>
           : 'No data layers selected'}
-      </p>
+      </LayerResult>
       {!isFirstSelection && (
         <Button variation='base-text' onClick={close}>
           Cancel

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -7,9 +7,9 @@ import { Button } from '@devseed-ui/button';
 import { pluralize } from '$utils/pluralize';
 
 interface ModalFooterComponentProps {
-  selectedIds: string[]; 
-  onConfirm: () => void; 
-  isFirstSelection: boolean;
+  selectedIds: string[];
+  onConfirm: () => void;
+  close: () => void;
 }
 const LayerNumberHighlight = styled.div`
   border-radius: 100%;
@@ -29,7 +29,7 @@ const LayerResult = styled.div`
 `;
 
 export default function ModalFooterRender (props:ModalFooterComponentProps) {
-  const { selectedIds, onConfirm, isFirstSelection } = props;
+  const { selectedIds, close, onConfirm } = props;
   return (
     <>
       <LayerResult aria-live='polite' className='selection-info'>
@@ -37,11 +37,9 @@ export default function ModalFooterRender (props:ModalFooterComponentProps) {
           ? <><LayerNumberHighlight>{selectedIds.length} </LayerNumberHighlight> <div>{pluralize({ singular: 'layer', plural: 'layers', count: selectedIds.length})} selected</div></>
           : 'No data layers selected'}
       </LayerResult>
-      {!isFirstSelection && (
         <Button variation='base-text' onClick={close}>
           Cancel
         </Button>
-      )}
       <Button
         variation='primary-fill'
         disabled={!selectedIds.length}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -25,9 +25,7 @@ export default function RenderModalHeader () {
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
       <ModalIntro>
-          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the 
-            <Link to={DATASETS_PATH}>Data Catalog</Link>
-          .
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH}>Data Catalog</Link>.
           </p>
       </ModalIntro>
       <BrowseControls

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 import { datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
 } from '@devseed-ui/modal';
 import { Heading } from '@devseed-ui/typography';
 
-import SmartLink from '$components/common/smart-link';
 import BrowseControls from '$components/common/browse-controls';
 import {
   useBrowserControls
@@ -25,7 +25,10 @@ export default function RenderModalHeader () {
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
       <ModalIntro>
-          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <SmartLink to={DATASETS_PATH}>Data Catalog</SmartLink>.</p>
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the 
+            <Link to={DATASETS_PATH}>Data Catalog</Link>
+          .
+          </p>
       </ModalIntro>
       <BrowseControls
           {...controlVars}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+import { datasetTaxonomies } from 'veda';
+import {
+  ModalHeadline
+} from '@devseed-ui/modal';
+
+import { Heading } from '@devseed-ui/typography';
+import BrowseControls from '$components/common/browse-controls';
+import {
+  useBrowserControls
+} from '$components/common/browse-controls/use-browse-controls';
+import { sortOptions } from '$components/data-catalog';
+
+const StyledModalHeadline = styled(ModalHeadline)``;
+const ModalIntro = styled.div``;
+
+export default function RenderModalHeader () {
+  const controlVars = useBrowserControls({
+    sortOptions
+  });
+  
+  return(
+    <StyledModalHeadline>
+      <Heading size='small'>Data layers</Heading>
+      <ModalIntro>
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the Data Catalog.</p>
+      </ModalIntro>
+      <BrowseControls
+            {...controlVars}
+            taxonomiesOptions={datasetTaxonomies}
+            sortOptions={sortOptions}
+      />
+    </StyledModalHeadline>
+  );
+}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { media } from '@devseed-ui/theme-provider';
 import { datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
@@ -15,7 +16,11 @@ import { sortOptions } from '$components/data-catalog';
 import { DATASETS_PATH } from '$utils/routes';
 
 const StyledModalHeadline = styled(ModalHeadline)``;
-const ModalIntro = styled.div``;
+const ModalIntro = styled.div`
+  ${media.largeUp`
+    width: 66%;
+  `}
+`;
 
 export default function RenderModalHeader () {
   const controlVars = useBrowserControls({

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -4,13 +4,15 @@ import { datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
 } from '@devseed-ui/modal';
-
 import { Heading } from '@devseed-ui/typography';
+
+import SmartLink from '$components/common/smart-link';
 import BrowseControls from '$components/common/browse-controls';
 import {
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
 import { sortOptions } from '$components/data-catalog';
+import { DATASETS_PATH } from '$utils/routes';
 
 const StyledModalHeadline = styled(ModalHeadline)``;
 const ModalIntro = styled.div``;
@@ -19,17 +21,16 @@ export default function RenderModalHeader () {
   const controlVars = useBrowserControls({
     sortOptions
   });
-  
   return(
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
       <ModalIntro>
-          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the Data Catalog.</p>
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <SmartLink to={DATASETS_PATH}>Data Catalog</SmartLink>.</p>
       </ModalIntro>
       <BrowseControls
-            {...controlVars}
-            taxonomiesOptions={datasetTaxonomies}
-            sortOptions={sortOptions}
+          {...controlVars}
+          taxonomiesOptions={datasetTaxonomies}
+          sortOptions={sortOptions}
       />
     </StyledModalHeadline>
   );

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -50,7 +50,7 @@ const DatasetModal = styled(Modal)`
 
   ${ModalBody} {
     height: 100%;
-    min-height: 0;
+    min-height: 100%;
     overflow-y: auto;
     display: flex;
     flex-flow: column;
@@ -150,9 +150,8 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
     }
   }, [revealed]);
 
-  // Filters are applies to the veda datasets, but then we want to display the
-  // dataset layers since those are shown on the map.
-  const displayDatasets = useMemo(
+  // Filtered datasets for modal display
+  const displayDatasets = useMemo<(DatasetData & {countSelectedLayers: number})[]>(
     () =>
       // TODO: Move function from data-catalog once that page is removed.
       prepareDatasets(allDatasets, {
@@ -168,13 +167,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       })),
     [search, taxonomies, sortField, sortDir, selectedIds]
   );
-
-  // const isFiltering = !!(
-  //   (taxonomies && Object.keys(taxonomies).length) ||
-  //   search
-  // );
-
-  const isFirstSelection = timelineDatasets.length === 0;
 
   return (
     <DatasetModal
@@ -198,7 +190,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       footerContent={
         <ModalFooterRender 
           selectedIds={selectedIds} 
-          isFirstSelection={isFirstSelection} 
+          close={close}
           onConfirm={onConfirm} 
         />
       }

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -100,7 +100,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
     setSelectedIds(timelineDatasets.map((dataset) => dataset.data.id));
   }, [timelineDatasets]);
 
-  const onCheck = useCallback((id) => {
+  const onCheck = useCallback((id: string) => {
     setSelectedIds((ids) =>
       ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
     );

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -172,7 +172,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
   //   (taxonomies && Object.keys(taxonomies).length) ||
   //   search
   // );
-  // console.log(selectedIds);
+
   const isFirstSelection = timelineDatasets.length === 0;
 
   return (

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -2,17 +2,16 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import styled, { css } from 'styled-components';
 import { useAtom } from 'jotai';
 
-import { DatasetData, DatasetLayer, datasetTaxonomies } from 'veda';
+import { DatasetData, DatasetLayer } from 'veda';
 import {
   Modal,
   ModalBody,
   ModalFooter,
-  ModalHeader,
-  ModalHeadline
+  ModalHeader
 } from '@devseed-ui/modal';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Button } from '@devseed-ui/button';
-import { Heading, Subtitle } from '@devseed-ui/typography';
+import { Subtitle } from '@devseed-ui/typography';
 import {
   CollecticonPlus,
   CollecticonTickSmall,
@@ -20,13 +19,15 @@ import {
   iconDataURI
 } from '@devseed-ui/collecticons';
 
-import { timelineDatasetsAtom } from '../atoms/datasets';
+import { timelineDatasetsAtom } from '../../atoms/datasets';
 import {
   allDatasets,
   datasetLayers,
   findParentDataset,
   reconcileDatasets
-} from '../data-utils';
+} from '../../data-utils';
+
+import RenderModalHeader from './header';
 
 import EmptyHub from '$components/common/empty-hub';
 import {
@@ -45,7 +46,6 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { Pill } from '$styles/pill';
-import BrowseControls from '$components/common/browse-controls';
 import {
   Actions,
   useBrowserControls
@@ -67,8 +67,9 @@ const DatasetModal = styled(Modal)`
     position: sticky;
     top: ${glsp(-2)};
     z-index: 100;
-    box-shadow: 0 1px 0 0 ${themeVal('color.base-100a')};
     margin-bottom: ${glsp(2)};
+    background-color: ${themeVal('color.base-50')};
+    align-items: start;
   }
 
   ${ModalBody} {
@@ -93,8 +94,6 @@ const DatasetModal = styled(Modal)`
     }
   }
 `;
-
-const ModalIntro = styled.div``;
 
 const DatasetCount = styled(Subtitle)`
   display: flex;
@@ -186,6 +185,10 @@ interface DatasetSelectorModalProps {
   close: () => void;
 }
 
+
+
+
+
 export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
   const { revealed, close } = props;
 
@@ -263,24 +266,10 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       revealed={revealed}
       onCloseClick={close}
       renderHeadline={() => (
-        <ModalHeadline>
-          <Heading size='small'>Select data layers</Heading>
-          <ModalIntro>
-            {isFirstSelection ? (
-              <p>Select data layers to start the exploration.</p>
-            ) : (
-              <p>Add or remove data layers to the exploration.</p>
-            )}
-          </ModalIntro>
-        </ModalHeadline>
+        <RenderModalHeader />
       )}
       content={
         <>
-          <BrowseControls
-            {...controlVars}
-            taxonomiesOptions={datasetTaxonomies}
-            sortOptions={sortOptions}
-          />
           <DatasetCount>
             <span>
               Showing{' '}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -14,7 +14,7 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
 import { timelineDatasetsAtom } from '../../atoms/datasets';
 import {
-  allDatasets as rawAllDatasets,
+  allDatasetsWithEnhancedLayers as allDatasets,
   reconcileDatasets
 } from '../../data-utils';
 import RenderModalHeader from './header';
@@ -77,20 +77,6 @@ interface DatasetSelectorModalProps {
   revealed: boolean;
   close: () => void;
 }
-
-const allDatasets = rawAllDatasets.map(currentDataset => {
-  return {
-    ...currentDataset,
-    layers: currentDataset.layers.map(l => ({
-      ...l,
-      parentDataset: {
-        id: currentDataset.id,
-        name: currentDataset.name
-        // infoDescription: currentDataset.infoDescription,
-      }
-    }))
-  };
-});
 
 const datasetLayers = allDatasets
   .flatMap((dataset) => dataset.layers)

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -87,9 +87,8 @@ const allDatasets = rawAllDatasets.map(currentDataset => {
       ...l,
       parentDataset: {
         id: currentDataset.id,
-        name: currentDataset.name,
-        taxonomy: currentDataset.taxonomy,
-        infoDescription: currentDataset.infoDescription,
+        name: currentDataset.name
+        // infoDescription: currentDataset.infoDescription,
       }
     }))
   };
@@ -142,6 +141,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
 
   // Clear filters when the modal is revealed.
   const firstRevealRef = React.useRef(true);
+
   useEffect(() => {
     if (revealed) {
       if (firstRevealRef.current) {

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -49,8 +49,8 @@ const DatasetModal = styled(Modal)`
   }
 
   ${ModalBody} {
-    max-height: 100%;
-    height: 400px;
+    height: 100%;
+    min-height: 0;
     overflow-y: auto;
     display: flex;
     flex-flow: column;
@@ -65,8 +65,6 @@ const DatasetModal = styled(Modal)`
     position: sticky;
     bottom: ${glsp(-2)};
     z-index: 100;
-    padding-top: ${glsp(1)};
-    padding-bottom: ${glsp(1)};
     background-color: ${themeVal('color.base-50')};
     box-shadow: 0 -1px 0 0 ${themeVal('color.base-200a')};
     > .selection-info {

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -15,7 +15,8 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { timelineDatasetsAtom } from '../../atoms/datasets';
 import {
   allDatasetsWithEnhancedLayers as allDatasets,
-  reconcileDatasets
+  reconcileDatasets,
+  datasetLayers
 } from '../../data-utils';
 import RenderModalHeader from './header';
 import ModalContentRender from './content';
@@ -78,11 +79,7 @@ interface DatasetSelectorModalProps {
   close: () => void;
 }
 
-const datasetLayers = allDatasets
-  .flatMap((dataset) => dataset.layers)
-  .filter((d) => !d.analysis?.exclude);
-
-  // Filter elements in arr1 that are also included in arr2
+// Filter elements in arr1 that are also included in arr2
 function countOverlap(arr1, arr2) {
   const commonElements = arr1.filter(element => arr2.includes(element));
   return commonElements.length;

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -166,7 +166,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
           search={search} 
           selectedIds={selectedIds} 
           displayDatasets={displayDatasets} 
-          // isFiltering={isFiltering}
           onCheck={onCheck}
         /> 
       }

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -159,7 +159,8 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
         search,
         taxonomies,
         sortField,
-        sortDir
+        sortDir,
+        filterLayers: true
       })
       .map(dataset => ({
         ...dataset,

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { useAtom } from 'jotai';
 
 import { DatasetData, DatasetLayer } from 'veda';
@@ -10,50 +10,23 @@ import {
   ModalHeader
 } from '@devseed-ui/modal';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
-import { Button } from '@devseed-ui/button';
-import { Subtitle } from '@devseed-ui/typography';
-import {
-  CollecticonPlus,
-  CollecticonTickSmall,
-  CollecticonXmarkSmall,
-  iconDataURI
-} from '@devseed-ui/collecticons';
+
 
 import { timelineDatasetsAtom } from '../../atoms/datasets';
 import {
   allDatasets as rawAllDatasets,
-  findParentDataset,
   reconcileDatasets
 } from '../../data-utils';
-
 import RenderModalHeader from './header';
 import ModalContentRender from './content';
+import ModalFooterRender from './footer';
 
-import EmptyHub from '$components/common/empty-hub';
-import {
-  Card,
-  CardList,
-  CardMeta,
-  CardTopicsList
-} from '$components/common/card';
-import { DatasetClassification } from '$components/common/dataset-classification';
-import { CardSourcesList } from '$components/common/card-sources';
-import DatasetMenu from '$components/data-catalog/dataset-menu';
-import { getDatasetPath } from '$utils/routes';
-import {
-  getTaxonomy,
-  TAXONOMY_SOURCE,
-  TAXONOMY_TOPICS
-} from '$utils/veda-data';
-import { Pill } from '$styles/pill';
 import {
   Actions,
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
 import { prepareDatasets, sortOptions } from '$components/data-catalog';
-import Pluralize from '$utils/pluralize';
-import TextHighlight from '$components/common/text-highlight';
-import { select } from 'd3';
+
 
 const DatasetModal = styled(Modal)`
   z-index: ${themeVal('zIndices.modal')};
@@ -68,16 +41,20 @@ const DatasetModal = styled(Modal)`
     position: sticky;
     top: ${glsp(-2)};
     z-index: 100;
-    margin-bottom: ${glsp(2)};
     background-color: ${themeVal('color.base-50')};
     align-items: start;
+    padding-top: ${glsp(2)};
+    padding-bottom: ${glsp(1)};
+    box-shadow: 0 -1px 0 0 ${themeVal('color.base-200a')};
   }
 
   ${ModalBody} {
-    height: 100%;
-    min-height: 0;
+    max-height: 100%;
+    height: 400px;
+    overflow-y: auto;
     display: flex;
     flex-flow: column;
+    padding-top: ${glsp(2)};
     gap: ${glsp(1)};
   }
 
@@ -88,97 +65,14 @@ const DatasetModal = styled(Modal)`
     position: sticky;
     bottom: ${glsp(-2)};
     z-index: 100;
-    box-shadow: 0 -1px 0 0 ${themeVal('color.base-100a')};
-
+    padding-top: ${glsp(1)};
+    padding-bottom: ${glsp(1)};
+    background-color: ${themeVal('color.base-50')};
+    box-shadow: 0 -1px 0 0 ${themeVal('color.base-200a')};
     > .selection-info {
       margin-right: auto;
     }
   }
-`;
-
-const DatasetCount = styled(Subtitle)`
-  display: flex;
-  gap: ${glsp(0.5)};
-
-  span {
-    text-transform: uppercase;
-    line-height: 1.5rem;
-  }
-`;
-
-const DatasetContainer = styled.div`
-  height: 100%;
-  min-height: 0;
-  display: flex;
-  margin-bottom: ${glsp(2)};
-
-  ${CardList} {
-    width: 100%;
-  }
-
-  ${EmptyHub} {
-    flex-grow: 1;
-  }
-`;
-
-const LayerCard = styled(Card)<{ checked: boolean }>`
-  outline: 4px solid transparent;
-  ${({ checked }) =>
-    checked &&
-    css`
-      outline-color: ${themeVal('color.primary')};
-    `}
-
-  &::before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    height: 3rem;
-    min-width: 3rem;
-    transform: translate(-50%, -50%);
-    padding: ${glsp(0.5, 1, 0.5, 1)};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: ${themeVal('color.primary')};
-    border-radius: ${themeVal('shape.ellipsoid')};
-    font-weight: ${themeVal('type.base.bold')};
-    line-height: 1rem;
-    background-image: url(${({ theme }) =>
-      iconDataURI(CollecticonPlus, {
-        color: theme.color?.surface,
-        size: 'large'
-      })});
-    background-repeat: no-repeat;
-    background-position: 0.75rem center;
-    pointer-events: none;
-    transition: all 0.16s ease-in-out;
-    opacity: 0;
-  }
-
-  &:hover ::before {
-    opacity: 1;
-  }
-
-  ${({ checked }) =>
-    checked &&
-    css`
-      &:before {
-        opacity: 1;
-        content: 'Selected';
-        padding-left: 2.75rem;
-        background-image: url(${({ theme }) =>
-          iconDataURI(CollecticonTickSmall, {
-            color: theme.color?.surface,
-            size: 'large'
-          })});
-        background-color: ${themeVal('color.base')};
-      }
-      &:hover ::before {
-        background-color: ${themeVal('color.primary')};
-      }
-    `}
 `;
 
 interface DatasetSelectorModalProps {
@@ -193,7 +87,9 @@ const allDatasets = rawAllDatasets.map(currentDataset => {
       ...l,
       parentDataset: {
         id: currentDataset.id,
-        name: currentDataset.name
+        name: currentDataset.name,
+        taxonomy: currentDataset.taxonomy,
+        infoDescription: currentDataset.infoDescription,
       }
     }))
   };
@@ -203,11 +99,9 @@ const datasetLayers = allDatasets
   .flatMap((dataset) => dataset.layers)
   .filter((d) => !d.analysis?.exclude);
 
-function countOverlap(arr1, arr2) {
   // Filter elements in arr1 that are also included in arr2
+function countOverlap(arr1, arr2) {
   const commonElements = arr1.filter(element => arr2.includes(element));
-  console.log(commonElements)
-  // The length of commonElements array represents the number of overlapping elements
   return commonElements.length;
 }
   
@@ -275,14 +169,12 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       })),
     [search, taxonomies, sortField, sortDir, selectedIds]
   );
-  console.log(selectedIds)
-  
-  console.log(displayDatasets);
-  const isFiltering = !!(
-    (taxonomies && Object.keys(taxonomies).length) ||
-    search
-  );
 
+  // const isFiltering = !!(
+  //   (taxonomies && Object.keys(taxonomies).length) ||
+  //   search
+  // );
+  // console.log(selectedIds);
   const isFirstSelection = timelineDatasets.length === 0;
 
   return (
@@ -295,90 +187,29 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       renderHeadline={() => (
         <RenderModalHeader />
       )}
-      content={<ModalContentRender 
-        search={search} 
-        selectedIds={selectedIds} 
-        displayDatasets={displayDatasets} 
-        onCheck={onCheck}
-               />}
-        
-          // <DatasetCount>
-          //   <span>
-          //     Showing{' '}
-          //     <Pluralize
-          //       singular='data layer'
-          //       plural='data layers'
-          //       count={displayDatasets.length}
-          //       showCount={true}
-          //     />{' '}
-          //     out of {datasetLayers.length}.
-          //   </span>
-          //   {isFiltering && (
-          //     <Button size='small' onClick={() => onAction(Actions.CLEAR)}>
-          //       Clear filters <CollecticonXmarkSmall />
-          //     </Button>
-          //   )}
-          // </DatasetCount> 
-
-          // <DatasetContainer>
-          //   {displayDatasets.length ? (
-          //     <CardList>
-          //       {displayDatasetLayers.map((datasetLayer) => {
-          //         const parent = findParentDataset(datasetLayer.id);
-          //         if (!parent) return null;
-
-          //         return (
-          //           <li key={datasetLayer.id}>
-          //             <DatasetLayerCard
-          //               searchTerm={search}
-          //               layer={datasetLayer}
-          //               parent={parent}
-          //               selected={selectedIds.includes(datasetLayer.id)}
-          //               onDatasetClick={() => onCheck(datasetLayer.id)}
-          //             />
-          //           </li>
-          //         );
-          //       })}
-          //     </CardList>
-          //   ) : (
-          //     <EmptyHub>
-          //       There are no datasets to show with the selected filters.
-          //     </EmptyHub>
-          //   )}
-          // </DatasetContainer> 
-        
-      
+      content={
+        <ModalContentRender 
+          search={search} 
+          selectedIds={selectedIds} 
+          displayDatasets={displayDatasets} 
+          // isFiltering={isFiltering}
+          onCheck={onCheck}
+        /> 
+      }
       footerContent={
-        <>
-          <p className='selection-info'>
-            {selectedIds.length
-              ? `${selectedIds.length} out of ${datasetLayers.length} data layers selected.`
-              : 'No data layers selected.'}
-          </p>
-          {!isFirstSelection && (
-            <Button variation='base-text' onClick={close}>
-              Cancel
-            </Button>
-          )}
-          <Button
-            variation='primary-fill'
-            disabled={!selectedIds.length}
-            onClick={onConfirm}
-          >
-            Add to map
-          </Button>
-        </>
+        <ModalFooterRender 
+          selectedIds={selectedIds} 
+          isFirstSelection={isFirstSelection} 
+          onConfirm={onConfirm} 
+        />
       }
     />
   );
 }
-
-interface DatasetLayerProps {
+export interface DatasetLayerCardProps {
   parent: DatasetData;
   layer: DatasetLayer;
   searchTerm: string;
   selected: boolean;
   onDatasetClick: () => void;
 }
-
-

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -62,6 +62,22 @@ interface LayerInfoModalProps {
   }
 }
 
+export function LayerInfoLiner(props: { info: LayerInfo }) {
+  const { info } = props;
+  return (
+    <span>
+    {Object.keys(info).map((key, idx, arr) => {
+      const currentValue = info[key];
+      return idx !== arr.length - 1 ? (
+        <span>{currentValue} · </span>
+      ) : (
+        <span>{currentValue} </span>
+      );
+    })}
+    </span>
+  );
+}
+
 export default function LayerInfoModal(props: LayerInfoModalProps) {
   const { revealed, close, layerData } = props;
   const { parentData } = layerData;
@@ -78,14 +94,7 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
           <ModalHeadline>
             <Heading size='medium'>{layerData.name}</Heading>
             <p>
-              {Object.keys(layerData.info).map((key, idx, arr) => {
-                const currentValue = layerData.info[key];
-                return idx !== arr.length - 1 ? (
-                  <span>{currentValue} · </span>
-                ) : (
-                  <span>{currentValue} </span>
-                );
-              })}
+            <LayerInfoLiner info={layerData.info} />
             </p>
           </ModalHeadline>);
       }}

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -35,6 +35,19 @@ export const allDatasets = Object.values(datasets)
   .map((d) => d!.data)
   .filter((d) => !d.disableExplore);
 
+export const allDatasetsWithEnhancedLayers = allDatasets.map(currentDataset => {
+  return {
+    ...currentDataset,
+    layers: currentDataset.layers.map(l => ({
+      ...l,
+      parentDataset: {
+        id: currentDataset.id,
+        name: currentDataset.name
+      }
+    }))
+  };
+});
+
 export const datasetLayers = Object.values(datasets)
   .flatMap((dataset) => dataset!.data.layers)
   .filter((d) => !d.analysis?.exclude);

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -8,6 +8,7 @@ import {
 } from 'date-fns';
 import { DatasetLayer, datasets } from 'veda';
 import {
+  EnhancedDatasetLayer,
   StacDatasetData,
   TimeDensity,
   TimelineDataset,
@@ -49,8 +50,15 @@ export const allDatasetsWithEnhancedLayers = allDatasets.map(currentDataset => {
 });
 
 export const datasetLayers = Object.values(datasets)
-  .flatMap((dataset) => dataset!.data.layers)
-  .filter((d) => !d.analysis?.exclude);
+  .flatMap((dataset) => {
+    return dataset!.data.layers.map(l => ({
+      ...l,
+      parentDataset: {
+        id: dataset!.data.id,
+        name: dataset!.data.name
+      }
+    }));
+  });
 
 /**
  * Returns an array of metrics based on the given Dataset Layer configuration.
@@ -86,7 +94,7 @@ function getInitialMetrics(data: DatasetLayer): DataMetric[] {
  */
 export function reconcileDatasets(
   ids: string[],
-  datasetsList: DatasetLayer[],
+  datasetsList: EnhancedDatasetLayer[],
   reconciledDatasets: TimelineDataset[]
 ): TimelineDataset[] {
   return ids.map((id) => {

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -27,6 +27,10 @@ export const findParentDataset = (layerId: string) => {
   return parentDataset?.data;
 };
 
+export const findParentDatasetAttribute = ({ datasetId, attr }) => {
+  return datasets[datasetId]?.data[attr];
+};
+
 export const allDatasets = Object.values(datasets)
   .map((d) => d!.data)
   .filter((d) => !d.disableExplore);

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -27,7 +27,7 @@ export const findParentDataset = (layerId: string) => {
   return parentDataset?.data;
 };
 
-export const findParentDatasetAttribute = ({ datasetId, attr }) => {
+export const findDatasetAttribute = ({ datasetId, attr }: {datasetId: string, attr: string}) => {
   return datasets[datasetId]?.data[attr];
 };
 

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -45,7 +45,6 @@ function reconcileQueryDataWithDataset(
 
     if (queryData.status === TimelineDatasetStatus.SUCCESS) {
       const domain = resolveLayerTemporalExtent(base.data.id, queryData.data);
-
       base = {
         ...base,
         data: {

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -80,8 +80,14 @@ export type TimelineDatasetAnalysis =
   | TimelineDatasetAnalysisSuccess;
 
 // END TimelineDatasetAnalysis type discriminants
+export interface EnhancedDatasetLayer extends DatasetLayer {
+  parentDataset: {
+    id: string;
+    name: string;
+  }
+}
 
-export interface TimelineDatasetData extends DatasetLayer {
+export interface TimelineDatasetData extends EnhancedDatasetLayer {
   isPeriodic: boolean;
   timeDensity: TimeDensity;
   domain: Date[];
@@ -103,7 +109,7 @@ type TimelineDatasetMeta = Record<string, any>;
 // TimelineDataset type discriminants
 export interface TimelineDatasetIdle {
   status: TimelineDatasetStatus.IDLE;
-  data: DatasetLayer;
+  data: EnhancedDatasetLayer;
   error: null;
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
@@ -112,7 +118,7 @@ export interface TimelineDatasetIdle {
 }
 export interface TimelineDatasetLoading {
   status: TimelineDatasetStatus.LOADING;
-  data: DatasetLayer;
+  data: EnhancedDatasetLayer;
   error: null;
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;
@@ -121,7 +127,7 @@ export interface TimelineDatasetLoading {
 }
 export interface TimelineDatasetError {
   status: TimelineDatasetStatus.ERROR;
-  data: DatasetLayer;
+  data: EnhancedDatasetLayer;
   error: unknown;
   // User controlled settings like visibility, opacity.
   settings: TimelineDatasetSettings;

--- a/mock/datasets/sandbox.data.mdx
+++ b/mock/datasets/sandbox.data.mdx
@@ -157,6 +157,7 @@ layers:
   - id: dev-fail
     stacCol: dev-fail
     name: Failing layer
+    description: failing
     type: raster
   - id: geoglam
     stacCol: geoglam


### PR DESCRIPTION
@faustoperez 

1. This component lives on the other branch right now. I will do proper styling once everything is merged on main branch.
2. I removed this section because the one-liner information belongs to the layer level (not the collection level)

![Screen Shot 2024-02-15 at 3 44 24 PM](https://github.com/NASA-IMPACT/veda-ui/assets/4583806/e3f2ab3c-bd0b-4111-a021-70addc7bd965)

TODO:
- [x] Text highlight on the description of the collection
- [x] Show more button styling
- [x] Modal height - needs to be close to max

- [x]  2/3 length for layer selection modal main description
- [x] the number (layer selected) showing up on 0

Preview link: https://deploy-preview-845--veda-ui.netlify.app/exploration 
(@faustoperez , let me know if you want to see it in GHG instance context)