### PR TITLE
Adding custom javascript tag as a temporary fix for implementing DAP  script block for GHG

### DIFF
--- a/app/scripts/components/common/meta-tags.js
+++ b/app/scripts/components/common/meta-tags.js
@@ -47,7 +47,7 @@ function MetaTags({ title, description, thumbnail, children }) {
 
       {/* Additional javascript */}
       {process.env.CUSTOM_SCRIPT_SRC ? (
-      <script async type='text/javascript' src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: 'custom_script_id'} \>
+      <script async type='text/javascript' src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: 'custom_script_id'} ></script>
       ) : null}
     </Helmet>
   );

--- a/app/scripts/components/common/meta-tags.js
+++ b/app/scripts/components/common/meta-tags.js
@@ -9,8 +9,6 @@ const baseUrl = window.location.origin;
 
 const defaultMetaImage = `${process.env.PUBLIC_URL ?? '/'}/meta/meta-image.png`;
 
-const includeGSAScript = process.env.includeGSAScript;
-
 function MetaTags({ title, description, thumbnail, children }) {
   const theme = useTheme();
   const location = useLocation();
@@ -46,9 +44,10 @@ function MetaTags({ title, description, thumbnail, children }) {
       {/* Additional children */}
       {children}
 
+
       {/* Additional javascript */}
       {process.env.CUSTOM_SCRIPT_SRC ? (
-       <script async type="text/javascript" src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: "custom_script_id" } ></script>
+      <script async type='text/javascript' src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: 'custom_script_id'} \>
       ) : null}
     </Helmet>
   );

--- a/app/scripts/components/common/meta-tags.js
+++ b/app/scripts/components/common/meta-tags.js
@@ -9,6 +9,8 @@ const baseUrl = window.location.origin;
 
 const defaultMetaImage = `${process.env.PUBLIC_URL ?? '/'}/meta/meta-image.png`;
 
+const includeGSAScript = process.env.includeGSAScript;
+
 function MetaTags({ title, description, thumbnail, children }) {
   const theme = useTheme();
   const location = useLocation();
@@ -43,6 +45,11 @@ function MetaTags({ title, description, thumbnail, children }) {
 
       {/* Additional children */}
       {children}
+
+      {/* Additional javascript */}
+      {process.env.CUSTOM_SCRIPT_SRC ? (
+       <script async type="text/javascript" src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: "custom_script_id" } ></script>
+      ) : null}
     </Helmet>
   );
 }

--- a/app/scripts/components/common/meta-tags.js
+++ b/app/scripts/components/common/meta-tags.js
@@ -44,10 +44,19 @@ function MetaTags({ title, description, thumbnail, children }) {
       {/* Additional children */}
       {children}
 
-
       {/* Additional javascript */}
+      {/* @NOTE https://github.com/NASA-IMPACT/veda-ui/pull/846 */}
       {process.env.CUSTOM_SCRIPT_SRC ? (
-      <script async type='text/javascript' src={process.env.CUSTOM_SCRIPT_SRC} id={process.env.CUSTOM_SCRIPT_ID ? process.env.CUSTOM_SCRIPT_ID: 'custom_script_id'} ></script>
+        <script
+          async
+          type='text/javascript'
+          src={process.env.CUSTOM_SCRIPT_SRC}
+          id={
+            process.env.CUSTOM_SCRIPT_ID
+              ? process.env.CUSTOM_SCRIPT_ID
+              : 'custom_script_id'
+          }
+        />
       ) : null}
     </Helmet>
   );


### PR DESCRIPTION
In response to a memo directing agencies to ensure that GSA’s [Digital Analytics Program (DAP)](https://nasa.sharepoint.com/sites/webservices/SitePages/Google%20Analytics%20DAP.aspx) tracking code is installed on all public-facing sites to enable reporting of web traffic metrics, we need to add a custom script tag to the header. This PR allows us to do so by defining two environment variables in the .env file:

CUSTOM_SCRIPT_SRC=<DAP_SRC>
CUSTOM_SCRIPT_ID=<DAP_ID>

Also allows other users to include a custom analytics script.