### PR TITLE
Add move up and down functionality, other touch-ups

### DIFF
--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -90,7 +90,6 @@ const DatasetMetricInfo = styled.div`
   color: ${themeVal('color.base-500')}
 `;
 
-
 export default function DataLayerCard(props: CardProps) {
   const {dataset, datasetAtom, isVisible, setVisible, datasetLegend, parent} = props;
 

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -183,7 +183,7 @@ export function DatasetListItem(props: DatasetListItemProps) {
       <DatasetItem>
         <DatasetHeader>
           <DatasetHeaderInner>
-            <div onPointerDown={(e) => controls.start(e)}>
+            <div style={{width: '100%'}} onPointerDown={(e) => controls.start(e)}>
               <DataLayerCard dataset={dataset} datasetAtom={datasetAtom} isVisible={isVisible} setVisible={setVisible} datasetLegend={datasetLegend} parent={parent} />
             </div>
           </DatasetHeaderInner>

--- a/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
+++ b/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { PrimitiveAtom, useAtomValue, useAtom } from 'jotai';
 import styled from 'styled-components';
-import { Dropdown, DropMenu } from '@devseed-ui/dropdown';
+import { Dropdown, DropMenu, DropMenuItem } from '@devseed-ui/dropdown';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
-import { Button } from '@devseed-ui/button';
 import {
   CollecticonEllipsisVertical,
   CollecticonDrop,
@@ -18,7 +17,7 @@ import { TileUrlModal } from './tile-link-modal';
 import { TipButton } from '$components/common/tip-button';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
 import { useTimelineDatasetSettings } from '$components/exploration/atoms/hooks';
-import { SliderInput, SliderInputProps } from '$styles/range-slider';
+import { NativeSliderInput, SliderInputProps } from '$styles/range-slider';
 import { TimelineDataset } from '$components/exploration/types.d.ts';
 
 
@@ -35,12 +34,16 @@ const StyledDropdown = styled(Dropdown)`
   padding: ${glsp(1.5)};
 
   li {
-    padding: ${glsp(0.5)};
+    padding: ${glsp(0.25)};
     border-bottom: 1px solid ${themeVal('color.base-200')};
+    ${DropMenuItem} {
+      cursor:pointer;
+    }
   }
 
   li:last-child {
     border-bottom: 0;
+    padding-bottom: 0;
   }
   li:first-child {
     padding-top: 0;
@@ -58,16 +61,6 @@ const StyledDropdown = styled(Dropdown)`
       gap: 0.25rem;
     }
   }
-
-  & .${classNamePrefix}-remove-layer {
-    button {
-      color: #CF3F02 !important;
-    }
-  }
-`;
-
-const LayerMenuButton = styled(Button)`
-  justify-content: flex-start;
 `;
 
 export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
@@ -141,10 +134,7 @@ export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
             />
           </li>
           <li>
-            <LayerMenuButton 
-              variation='base-text'
-              size='small'
-              fitting='baggy'
+            <DropMenuItem 
               onClick={() => setVisible((v) => !v)}
             >
               {isVisible ? (
@@ -159,54 +149,45 @@ export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
                 />
               )}
               {isVisible ? 'Hide layer' : 'Show layer'}
-            </LayerMenuButton>
+            </DropMenuItem>
           </li>
           <li>
-            {/* // @TODO: Implement moving up action */}
-              <LayerMenuButton
-                variation='base-text'
-                size='small'
-                fitting='baggy'
-                onClick={moveUp}
-              >
-                <CollecticonArrowUp />
-                Move up
-              </LayerMenuButton>
+            <DropMenuItem
+              disabled={currentIndex === 0}
+              aria-disabled={currentIndex === 0}
+              onClick={moveUp}
+              data-dropdown='click.close'
+            >
+              <CollecticonArrowUp />
+              Move up
+            </DropMenuItem>
           </li>
           <li>
-            {/* // @TODO: Implement moving down action */}
-            <LayerMenuButton
-              variation='base-text'
-              size='small'
-              fitting='baggy'
+            <DropMenuItem
+              disabled={currentIndex === datasets.length -1}
+              aria-disabled={currentIndex === 0}
               onClick={moveDown}
+              data-dropdown='click.close'
             >
               <CollecticonArrowDown />
                 Move down
-            </LayerMenuButton>
-
+            </DropMenuItem>
           </li>
           <li>
-            <LayerMenuButton
-              variation='base-text'
-              size='small'
-              fitting='baggy'
+            <DropMenuItem
               onClick={handleLoadIntoGIS}
             >
               <CollecticonShare />
               Load into GIS
-            </LayerMenuButton>
+            </DropMenuItem>
           </li>
           <li className={`${classNamePrefix}-remove-layer`}>
-            <LayerMenuButton
-              variation='base-text'
-              size='small'
-              fitting='baggy'
+            <DropMenuItem
               onClick={handleRemove}
             >
               <CollecticonXmarkSmall />
               Remove layer
-            </LayerMenuButton>
+            </DropMenuItem>
           </li>
         </DropMenu>
       </StyledDropdown>
@@ -247,7 +228,7 @@ function OpacityControl(props: SliderInputProps) {
   return (
     <OpacityControlWrapper>
       <OpacityControlElements>
-        <SliderInput value={value} onInput={onInput} />
+        <NativeSliderInput value={value} onInput={onInput} />
         <OpacityValue>{value}</OpacityValue>
       </OpacityControlElements>
     </OpacityControlWrapper>

--- a/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
+++ b/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
@@ -21,6 +21,7 @@ import { useTimelineDatasetSettings } from '$components/exploration/atoms/hooks'
 import { SliderInput, SliderInputProps } from '$styles/range-slider';
 import { TimelineDataset } from '$components/exploration/types.d.ts';
 
+
 interface LayerMenuOptionsProps {
   datasetAtom: PrimitiveAtom<TimelineDataset>;
   isVisible: boolean;
@@ -72,17 +73,39 @@ const LayerMenuButton = styled(Button)`
 export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
   const { datasetAtom, isVisible, setVisible } = props;
 
-  const [, setDatasets] = useAtom(timelineDatasetsAtom);
+  const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
   const dataset = useAtomValue(datasetAtom);
   const [getSettings, setSetting] = useTimelineDatasetSettings(datasetAtom);
   const opacity = (getSettings('opacity') ?? 100) as number;
 
   const [tileModalRevealed, setTileModalRevealed] = useState(false);
 
+  const currentIndex = datasets.findIndex(d => d.data.id === dataset.data.id);
+
   const handleRemove = () => {
-      setDatasets((datasets) =>
-      datasets.filter((d) => d.data.id !== dataset.data.id)
+      setDatasets((prevDatasets) =>
+      prevDatasets.filter((d) => d.data.id !== dataset.data.id)
     );
+  };
+
+  const moveUp = () => {
+    if (currentIndex > 0 ) {
+      setDatasets((prevDatasets) => {
+        const arr = [...prevDatasets];
+        [arr[currentIndex], arr[currentIndex - 1]] = [arr[currentIndex - 1], arr[currentIndex]];
+        return arr;
+      });
+    }
+  };
+
+  const moveDown = () => {
+    if (currentIndex < datasets.length - 1) {
+      setDatasets((prevDatasets) => {
+        const arr = [...prevDatasets];
+        [arr[currentIndex], arr[currentIndex + 1]] = [arr[currentIndex + 1], arr[currentIndex]];
+        return arr;
+      });
+    }
   };
 
   const handleLoadIntoGIS = () => {
@@ -144,7 +167,7 @@ export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
                 variation='base-text'
                 size='small'
                 fitting='baggy'
-                onClick={() => true}
+                onClick={moveUp}
               >
                 <CollecticonArrowUp />
                 Move up
@@ -156,7 +179,7 @@ export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
               variation='base-text'
               size='small'
               fitting='baggy'
-              onClick={() => true}
+              onClick={moveDown}
             >
               <CollecticonArrowDown />
                 Move down

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -515,7 +515,7 @@ export default function Timeline(props: TimelineProps) {
           Data layers
         </Heading>
         <Button
-          variation='base-text'
+          variation='primary-fill'
           size='small'
           onClick={onDatasetAddClick}
         >

--- a/app/scripts/styles/range-slider.tsx
+++ b/app/scripts/styles/range-slider.tsx
@@ -69,3 +69,20 @@ export function SliderInput(props: SliderInputProps) {
     />
   );
 }
+
+
+// @TECH-DEBT: We need to pass 'onPointerDownCapture' to HTML element to prevent dragging event from propagating.
+// But existing input element uses Third party library, which makes it impossible to pass this even to HTML element level
+// This element was created to provide a fast solution for this problem. In the future, we have to deprecate the one from the top
+export function NativeSliderInput(props: SliderInputProps) {
+  const { value, onInput, ...rest } = props;
+  return (
+    <input 
+      type='range'
+      {...rest}
+      value={value}
+      onPointerDownCapture={e => e.stopPropagation()}
+      onChange={e => onInput(parseInt(e.target.value))}
+      defaultValue={100}
+    />);
+}


### PR DESCRIPTION
This PR handles
- Move up & Down functionality from dropdown
- Dragging propagation problem from opacity control (Refer to the attached screen recording): This fix changes the look of the range slider though. Left a tech-debt comment
- use DropMenuItem instead of Button 
- Misc style fixes


https://github.com/NASA-IMPACT/veda-ui/assets/4583806/328933ca-b747-4d90-9cb6-89f3cca90665

