### PR TITLE
Add documentation about infoDescription, info, layer level media

### DIFF
--- a/docs/content/CONTENT.md
+++ b/docs/content/CONTENT.md
@@ -61,6 +61,7 @@ usage: Usage[]
   - url: string
     label: string
     title: string
+infoDescription: markdown 
 ---
 
 <Block>
@@ -172,7 +173,22 @@ usage:
     label: Run example notebook
     title: 'Interactive session in VEDA 2i2c JupyterHub (requires account)'
 ```
+**infoDescription**
 
+The infoDescription attribute provides detailed metadata about a dataset in Markdown format. Prefix `::markdown` is required.
+
+Example: 
+```yaml
+infoDescription: |
+  ::markdown
+    - Temporal Extent: January 2000 - December 2021
+    - Temporal Resolution: Monthly
+    - Spatial Extent: Global
+    - Spatial Resolution: 1 km x 1 km
+    - Data Units: Tons of carbon per 1 km x 1 km cell (monthly total)
+    - Data Type: Research
+    - Data Latency: Updated annually, following the release of an updated [BP Statistical Review of World Energy report](https://www.bp.com/en/global/corporate/energy-economics.html)
+```
 ---
 
 ## Stories

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -256,7 +256,7 @@ Controls whether this layer should be excluded from the analysis page. If set to
 
 **media**  
 `Media`  
-Image to identify this layer. If not defined, the layer will use dataset level Medida. See [media.md](./frontmatter/media.md) for details.
+Image to identify this layer. If not defined, the layer will use dataset level Media. See [media.md](./frontmatter/media.md) for details.
 
 ### Info
 

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -26,6 +26,8 @@ sourceParams:
 compare: Compare
 legend: Legend
 analysis: Analysis
+media: Media
+info: Info
 ```
 
 ## Properties
@@ -251,6 +253,42 @@ Parameters to be appended to the `/statistics` endpoint as query parameters. Che
 **analysis.exclude**  
 `boolean`  
 Controls whether this layer should be excluded from the analysis page. If set to `true` the layer will not be available for analysis.
+
+**media**  
+`Media`  
+Image to identify this layer. If not defined, the layer will use dataset level Medida. See [media.md](./frontmatter/media.md) for details.
+
+### Info
+
+**info**
+List of key-value pair to describe layer level information. 
+
+Example: 
+```yaml
+info:
+  source: NASA
+  spatialExtent: Global
+  latency: Monthly
+  unit: 10¹⁵ molecules cm⁻²
+```
+
+**info.source**
+`string`
+This key indicates the origin or the provider of the data. 
+
+**info.spatialExtent**
+`string`
+This key describes s the geographic coverage of the data.
+
+**info.latency**
+`string`
+This key refers to the frequency with which the data is updated or made available. 
+
+**info.unit**
+`string`
+The unit key specifies the measurement unit in which the data values are expressed. 
+
+
 
 ### Compare
 


### PR DESCRIPTION
Close #842 

In case it helps, no2.data.mdx file has all three new attributes: https://github.com/NASA-IMPACT/veda-ui/blob/main/mock/datasets/no2.data.mdx

infoDescription: https://github.com/NASA-IMPACT/veda-ui/blob/main/mock/datasets/no2.data.mdx#L49
layer level info: https://github.com/NASA-IMPACT/veda-ui/blob/main/mock/datasets/no2.data.mdx#L107
layer level media: https://github.com/NASA-IMPACT/veda-ui/blob/main/mock/datasets/no2.data.mdx#L62


Feel free to edit as you see fit. I opened this pr mainly to help https://github.com/orgs/nasa-IMPACT/projects/17/views/6?pane=issue&itemId=53396097