### PR TITLE
[#856] A&E Fast Follow Tweaks

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -96,7 +96,7 @@ function BrowseControls(props: BrowseControlsProps) {
 
   const { isLargeUp } = useMediaQuery();
 
-  return (
+  return (  
     <BrowseControlsWrapper {...rest}>
       <SearchWrapper>
         <SearchField
@@ -128,7 +128,8 @@ function BrowseControls(props: BrowseControlsProps) {
         >
           <DropTitle>Options</DropTitle>
           <DropMenu>
-            {sortOptions.map((t) => (
+            {/* { @NOTE: Display the sort option labels only when there is more than one otherwise it already defaults to the button title} */}
+            {sortOptions.length > 1 && sortOptions.map((t) => (
               <li key={t.id}>
                 <DropMenuItemButton
                   active={t.id === sortField}

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -73,7 +73,7 @@ const DatasetIntro = styled.div`
 `;
 
 export const ParentDatasetTitle = styled.h2<{size?: string}>`
-  color: ${themeVal('color.base-500')};
+  color: ${themeVal('color.primary')};
   text-align: left;
   font-size: ${(props => props.size=='small'? '0.75rem': '1rem')};
   line-height: 0.75rem;
@@ -83,7 +83,7 @@ export const ParentDatasetTitle = styled.h2<{size?: string}>`
   justify-content: center;
   gap: 0.1rem;
   > svg {
-    fill: ${themeVal('color.base-500')};
+    fill: ${themeVal('color.primary')};
   }
 `;
 

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -17,9 +17,9 @@ import {
   CardMeta,
   CardTopicsList
 } from '$components/common/card';
-import ParentDatasetLink from '$components/exploration/components/parent-dataset-link';
 import TextHighlight from '$components/common/text-highlight';
 import { CardSourcesList } from '$components/common/card-sources';
+import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 import { getDatasetPath } from '$utils/routes';
 import {
   getTaxonomy,
@@ -27,6 +27,7 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { Pill } from '$styles/pill';
+
 const DatasetContainer = styled.div`
   height: auto;
   display: flex;
@@ -71,6 +72,21 @@ const DatasetIntro = styled.div`
   padding: ${glsp(1)} 0;
 `;
 
+const ParentDatasetTitle = styled.h2`
+  color: ${themeVal('color.base-500')};
+  text-align: left;
+  font-size: 1rem;
+  line-height: 0.75rem;
+  font-weight: normal;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.1rem;
+  > svg {
+    fill: ${themeVal('color.base-500')};
+  }
+`;
+
 interface ModalContentComponentProps {
   search: string;
   selectedIds: string[];
@@ -90,7 +106,9 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
         <SingleDataset key={currentDataset.id}>
           <DatasetIntro>
             <DatasetHeadline>
-            <ParentDatasetLink parentDataset={currentDataset} size='medium' />
+            <ParentDatasetTitle>
+              <CollecticonDatasetLayers /> {currentDataset.name}
+            </ParentDatasetTitle>
             {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
             <DatasetDescription>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -72,10 +72,10 @@ const DatasetIntro = styled.div`
   padding: ${glsp(1)} 0;
 `;
 
-const ParentDatasetTitle = styled.h2`
+export const ParentDatasetTitle = styled.h2<{size?: string}>`
   color: ${themeVal('color.base-500')};
   text-align: left;
-  font-size: 1rem;
+  font-size: ${(props => props.size=='small'? '0.75rem': '1rem')};
   line-height: 0.75rem;
   font-weight: normal;
   display: flex;

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -9,6 +9,7 @@ import {
 import { Toolbar } from '@devseed-ui/toolbar';
 import { Heading } from '@devseed-ui/typography';
 import { LayerInfoLiner } from '../layer-info-modal';
+import { ParentDatasetTitle } from '../dataset-selector-modal/content';
 import LayerMenuOptions from './layer-options-menu';
 import { TipButton } from '$components/common/tip-button';
 import {
@@ -17,7 +18,8 @@ import {
 } from '$components/common/mapbox/layer-legend';
 
 import { TimelineDataset } from '$components/exploration/types.d.ts';
-import ParentDatasetLink from '$components/exploration/components/parent-dataset-link';
+import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
+
 interface CardProps {
   dataset: TimelineDataset;
   datasetAtom: PrimitiveAtom<TimelineDataset>;
@@ -88,7 +90,9 @@ export default function DataLayerCard(props: CardProps) {
       <DatasetInfo className='dataset-info'>
         <DatasetCardInfo>
           <Header>
-          <ParentDatasetLink parentDataset={dataset.data.parentDataset} size='small' />
+          <ParentDatasetTitle size='small'>
+            <CollecticonDatasetLayers /> {dataset.data.parentDataset.name}
+          </ParentDatasetTitle>
           </Header>
           <DatasetHeadline>
             <DatasetTitle as='h3' size='xxsmall'>

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -120,7 +120,7 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
       }
       footerContent={
         <ButtonStyleLink to={dataCatalogPage} onClick={close} variation='primary-fill' size='medium'>
-          Learn more
+          Open in Data Catalog
         </ButtonStyleLink>
       }
     />

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -48,6 +48,7 @@ const DatasetModal = styled(Modal)`
     z-index: 100;
   }
 `;
+
 const ParentDatasetHeading = styled.h2`
   padding: ${glsp(0.5)} 0;
 `;

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -12,9 +12,10 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { createButtonStyles } from '@devseed-ui/button';
 import { LayerInfo } from 'veda';
 
-import ParentDatasetLink from './parent-dataset-link';
+import { ParentDatasetTitle } from './dataset-selector-modal/content';
 import SmartLink from '$components/common/smart-link';
 import { getDatasetPath } from '$utils/routes';
+import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 
 const DatasetModal = styled(Modal)`
   z-index: ${themeVal('zIndices.modal')};
@@ -105,7 +106,9 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
       renderHeadline={() => {
         return (
           <ModalHeadline>
-            <ParentDatasetLink parentDataset={layerData.parentData} size='small' />
+            <ParentDatasetTitle>
+              <CollecticonDatasetLayers /> {layerData.parentData.name}
+            </ParentDatasetTitle>
             <ParentDatasetHeading> {layerData.name} </ParentDatasetHeading>
             <p>
               {


### PR DESCRIPTION
This PR completes the following tasks in #856 

- [x] select modal - update filter to remove redundant "Name" option
- [x] card - remove link from collection title
- [x] select modal - remove link from collection title on top of the modal
- [x] info modal - change button text to "Open in Data Catalog"

@faustoperez Removed the linking in the selector modal and data layer card for the collection title and made the font color `base-500`. (color themes [here](https://ui.ds.io/latest/?path=/docs/components-theme-provider--colors)). Let me know if this should change


![Screenshot 2024-02-26 at 4 09 12 PM](https://github.com/NASA-IMPACT/veda-ui/assets/30272083/767478ac-49dc-44c2-8020-a420412f3da7)

![Screenshot 2024-02-26 at 4 09 21 PM](https://github.com/NASA-IMPACT/veda-ui/assets/30272083/35d32d3c-a5fa-4a48-804c-f141a479e6b1)

![Screenshot 2024-02-26 at 4 09 44 PM](https://github.com/NASA-IMPACT/veda-ui/assets/30272083/ee9d27e4-8117-49fe-9a14-09969b72cbe9)


