### PR TITLE
Make filters button optional for datasets

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -77,6 +77,7 @@ const ButtonPrefix = styled(Overline).attrs({ as: 'small' })`
 interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
   taxonomiesOptions: Taxonomy[];
   sortOptions: FilterOption[];
+  showMoreButtonOpt?: boolean;
 }
 
 function BrowseControls(props: BrowseControlsProps) {
@@ -86,6 +87,7 @@ function BrowseControls(props: BrowseControlsProps) {
     taxonomies,
     sortOptions,
     search,
+    showMoreButtonOpt,
     sortField,
     sortDir,
     onAction,
@@ -155,14 +157,18 @@ function BrowseControls(props: BrowseControlsProps) {
             ))}
           </DropMenu>
         </DropdownScrollable>
-        <ShowMorebutton
-          variation='base-text'
-          size={isLargeUp ? 'large' : 'medium'}
-          fitting='skinny'
-          onClick={() => {setShowFilters(value => !value);}}
-        >
-          {showFilters? 'Hide filters' : 'Show filters'}
-        </ShowMorebutton>
+        {
+          showMoreButtonOpt && (
+            <ShowMorebutton
+              variation='base-text'
+              size={isLargeUp ? 'large' : 'medium'}
+              fitting='skinny'
+              onClick={() => {setShowFilters(value => !value);}}
+            >
+              {showFilters? 'Hide filters' : 'Show filters'}
+            </ShowMorebutton>
+          )
+        }
       </SearchWrapper>
       {showFilters && 
         <TaxonomyWrapper>

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -81,7 +81,6 @@ interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
 }
 
 function BrowseControls(props: BrowseControlsProps) {
-  const [ showFilters, setShowFilters ] = useState(false);
   const {
     taxonomiesOptions,
     taxonomies,
@@ -93,6 +92,8 @@ function BrowseControls(props: BrowseControlsProps) {
     onAction,
     ...rest
   } = props;
+
+  const [ showFilters, setShowFilters ] = useState(showMoreButtonOpt ? false : true);
 
   const currentSortField = sortOptions.find((s) => s.id === sortField)!;
 
@@ -165,7 +166,7 @@ function BrowseControls(props: BrowseControlsProps) {
               fitting='skinny'
               onClick={() => {setShowFilters(value => !value);}}
             >
-              {showFilters? 'Hide filters' : 'Show filters'}
+              {showFilters ? 'Hide filters' : 'Show filters'}
             </ShowMorebutton>
           )
         }

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -37,6 +37,7 @@ export default function RenderModalHeader () {
           {...controlVars}
           taxonomiesOptions={datasetTaxonomies}
           sortOptions={sortOptions}
+          showMoreButtonOpt={true}
       />
     </StyledModalHeadline>
   );


### PR DESCRIPTION
This is to remediate the issue discussed from this slack thread [here](https://developmentseed.slack.com/archives/C03LGTM2SSH/p1709050497517369)

This PR makes the filters button in the browser controls which currently lives in the `Data Catalog` and Datasets Selector Modal for A&E optional.

**Validation:**
* Make sure the Filters button does not appear on the `Data Catalog` Page
* Make sure the Filters button does appear for the Datasets Selector Modal for A&E