### PR TITLE
Update Data Catalog Links for A&E to open in new tab 

### DIFF
--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -30,7 +30,7 @@ export default function RenderModalHeader () {
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
       <ModalIntro>
-          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH}>Data Catalog</Link>.
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH} target='_blank'>Data Catalog</Link>.
           </p>
       </ModalIntro>
       <BrowseControls

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -123,7 +123,7 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
         <div dangerouslySetInnerHTML={{__html: parentData.infoDescription?? 'Currently, we are unable to display the layer information, but you can find it in the data catalog.' }} />
       }
       footerContent={
-        <ButtonStyleLink to={dataCatalogPage} onClick={close} variation='primary-fill' size='medium'>
+        <ButtonStyleLink to={dataCatalogPage} onClick={close} variation='primary-fill' size='medium' target='_blank'>
           Open in Data Catalog
         </ButtonStyleLink>
       }


### PR DESCRIPTION
This PR updates the data catalog links for A&E to open in a new tab instead of the exiting current screen.

Closes https://github.com/NASA-IMPACT/veda-ui/issues/861
Addresses https://github.com/NASA-IMPACT/veda-ui/issues/856