### PR TITLE
Implement updated hidden dataset card style

### DIFF
--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -5,6 +5,8 @@ import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { LayerLegendCategorical, LayerLegendGradient } from 'veda';
 import {
   CollecticonCircleInformation,
+  CollecticonEyeDisabled,
+  CollecticonEye,
 } from '@devseed-ui/collecticons';
 import { Toolbar } from '@devseed-ui/toolbar';
 import { Heading } from '@devseed-ui/typography';
@@ -113,7 +115,28 @@ export default function DataLayerCard(props: CardProps) {
                   title='View dataset page'
                 />
               </TipButton>
-              <LayerMenuOptions datasetAtom={datasetAtom} isVisible={!!isVisible} setVisible={setVisible} />
+              <TipButton
+                tipContent={isVisible ? 'Hide layer' : 'Show layer'}
+                // Using a button instead of a toolbar button because the
+                // latter doesn't support the `forwardedAs` prop.
+                size='small'
+                fitting='skinny'
+                onPointerDownCapture={e => e.stopPropagation()}
+                onClick={() => setVisible((v) => !v)}
+              >
+              {isVisible ? (
+                <CollecticonEyeDisabled
+                  meaningful
+                  title='Toggle dataset visibility'
+                />
+              ) : (
+                <CollecticonEye
+                  meaningful
+                  title='Toggle dataset visibility'
+                />
+              )}
+              </TipButton>
+              <LayerMenuOptions datasetAtom={datasetAtom} />
             </Toolbar>
           </DatasetHeadline>
           

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -65,6 +65,9 @@ const DatasetInfo = styled.div`
   ${DatasetCardInfo} {
     gap: 0rem;
   }
+  &.layerHidden {
+    opacity: 0.5;
+  }
 `;
 
 const DatasetHeadline = styled.div`
@@ -89,7 +92,7 @@ export default function DataLayerCard(props: CardProps) {
 
   return (
     <>
-      <DatasetInfo className='dataset-info'>
+      <DatasetInfo className={isVisible ? 'layerShown' : 'layerHidden'}>
         <DatasetCardInfo>
           <Header>
           <ParentDatasetTitle size='small'>
@@ -125,12 +128,12 @@ export default function DataLayerCard(props: CardProps) {
                 onClick={() => setVisible((v) => !v)}
               >
               {isVisible ? (
-                <CollecticonEyeDisabled
+                <CollecticonEye
                   meaningful
                   title='Toggle dataset visibility'
                 />
               ) : (
-                <CollecticonEye
+                <CollecticonEyeDisabled
                   meaningful
                   title='Toggle dataset visibility'
                 />

--- a/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
+++ b/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
@@ -7,8 +7,6 @@ import {
   CollecticonEllipsisVertical,
   CollecticonDrop,
   CollecticonXmarkSmall,
-  CollecticonEyeDisabled,
-  CollecticonEye,
   CollecticonArrowDown,
   CollecticonArrowUp,
   CollecticonShare,
@@ -23,8 +21,6 @@ import { TimelineDataset } from '$components/exploration/types.d.ts';
 
 interface LayerMenuOptionsProps {
   datasetAtom: PrimitiveAtom<TimelineDataset>;
-  isVisible: boolean;
-  setVisible: (v: any) => void;
 }
 
 // @NOTE: Class Name prefix is named after file name
@@ -64,7 +60,7 @@ const StyledDropdown = styled(Dropdown)`
 `;
 
 export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
-  const { datasetAtom, isVisible, setVisible } = props;
+  const { datasetAtom } = props;
 
   const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
   const dataset = useAtomValue(datasetAtom);
@@ -132,24 +128,6 @@ export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
               value={opacity}
               onInput={(v) => setSetting('opacity', v)}
             />
-          </li>
-          <li>
-            <DropMenuItem 
-              onClick={() => setVisible((v) => !v)}
-            >
-              {isVisible ? (
-                <CollecticonEyeDisabled
-                  meaningful
-                  title='Toggle dataset visibility'
-                />
-              ) : (
-                <CollecticonEye
-                  meaningful
-                  title='Toggle dataset visibility'
-                />
-              )}
-              {isVisible ? 'Hide layer' : 'Show layer'}
-            </DropMenuItem>
           </li>
           <li>
             <DropMenuItem


### PR DESCRIPTION
This PR addresses ticket https://github.com/NASA-IMPACT/veda-ui/issues/848 and updates the E&A data layer card styling for hiding and displaying a layer

Closes https://github.com/NASA-IMPACT/veda-ui/issues/848