### PR TITLE
Update styles for long collection and layer names on dataset cards

### DIFF
--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -77,13 +77,20 @@ export const ParentDatasetTitle = styled.h2<{size?: string}>`
   text-align: left;
   font-size: ${(props => props.size=='small'? '0.75rem': '1rem')};
   line-height: 0.75rem;
-  font-weight: normal;
+  font-weight: normal; ${(props => props.size=='small'? '400': 'normal')};
   display: flex;
+  min-width: 0;
   align-items: center;
   justify-content: center;
   gap: 0.1rem;
+  p {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   > svg {
     fill: ${themeVal('color.primary')};
+    min-width: ${(props => props.size=='small' ? '1rem': 'auto')};
   }
 `;
 

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -49,7 +49,7 @@ const DatasetInfo = styled.div`
   flex-flow: column;
   gap: 0.5rem;
   background-color: ${themeVal('color.surface')};
-  padding: ${glsp(0.5)} ${glsp(1)};
+  padding: ${glsp(1)} ${glsp(1)};
   border-radius: ${themeVal('shape.rounded')};
   border: 1px solid ${themeVal('color.base-200')};
 
@@ -73,7 +73,11 @@ const DatasetInfo = styled.div`
 const DatasetHeadline = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  padding-top: 4px;
+`;
+
+const DatasetToolbar = styled(Toolbar)`
+  align-items: flex-start;
 `;
 
 const DatasetTitle = styled(Heading)`
@@ -96,14 +100,14 @@ export default function DataLayerCard(props: CardProps) {
         <DatasetCardInfo>
           <Header>
           <ParentDatasetTitle size='small'>
-            <CollecticonDatasetLayers /> {dataset.data.parentDataset.name}
+            <CollecticonDatasetLayers /> <p>{dataset.data.parentDataset.name}</p>
           </ParentDatasetTitle>
           </Header>
           <DatasetHeadline>
             <DatasetTitle as='h3' size='xxsmall'>
               {dataset.data.name}
             </DatasetTitle>
-            <Toolbar size='small'>
+            <DatasetToolbar size='small'>
               <TipButton
                 tipContent='Layer info'
                 // Using a button instead of a toolbar button because the
@@ -140,7 +144,7 @@ export default function DataLayerCard(props: CardProps) {
               )}
               </TipButton>
               <LayerMenuOptions datasetAtom={datasetAtom} />
-            </Toolbar>
+            </DatasetToolbar>
           </DatasetHeadline>
           
           <DatasetMetricInfo>


### PR DESCRIPTION
Closes Ticket https://github.com/NASA-IMPACT/veda-ui/issues/864

![Screenshot 2024-03-08 at 11 17 24 AM](https://github.com/NASA-IMPACT/veda-ui/assets/30272083/7e1df257-c939-405e-a50b-f4efe252570a)

**Changes**
* Updates the dataset layer cards parent collection name to truncate after one line
* Updates the toolbar menu on cards to stay top aligned to layer name
* Padding updated to 16px all around

**Validation**
* Validate that dataset cards look correct with a long title
* Validate that the parent dataset titles in the **layer selection modal** are not affected by these changes and look as they are supposed too