### PR TITLE
Replace latency with temporalResolution in layer info

### DIFF
--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -268,7 +268,7 @@ Example:
 info:
   source: NASA
   spatialExtent: Global
-  latency: Monthly
+  temporalResolution: Monthly
   unit: 10¹⁵ molecules cm⁻²
 ```
 
@@ -280,9 +280,9 @@ This key indicates the origin or the provider of the data.
 `string`
 This key describes s the geographic coverage of the data.
 
-**info.latency**
+**info.temporalResolution**
 `string`
-This key refers to the frequency with which the data is updated or made available. 
+This key describes the periodicity of the data. 
 
 **info.unit**
 `string`

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -90,7 +90,7 @@ layers:
     info:
       source: NASA
       spatialExtent: Global
-      latency: Monthly
+      temporalResolution: Monthly
       unit: 10¹⁵ molecules cm⁻²
   - id: casa-gfed-co2-flux-hr
     stacApiEndpoint: https://ghg.center/api/stac

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -107,7 +107,7 @@ layers:
     info:
       source: NASA
       spatialExtent: Global
-      latency: Monthly
+      temporalResolution: Monthly
       unit: 10¹⁵ molecules cm⁻²
   - id: no2-monthly-2
     stacCol: no2-monthly

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -59,7 +59,7 @@ declare module 'veda' {
 export interface LayerInfo {
   source: string;
   spatialExtent: string;
-  latency: string;
+  temporalResolution: string;
   unit: string;
 }
   export interface DatasetLayer extends DatasetLayerCommonProps {


### PR DESCRIPTION
**Related Ticket:**

Closes #897 

### Description of Changes

Temporal resolution (data periodicity) is more relevant to show in the short layer info than latency (data publication frequency).

This PR swaps the two in the LayerInfo object and updates the docs.

### Validation / Testing

Check out the Exploration and Analysis interface (`/exploration`) and see the temporalResolution information on the layer cards as well as in the header of the layer info modal.
