### PR TITLE
Zoom in AOI when analysis is run

### DIFF
--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -1,25 +1,11 @@
 import { useCallback } from 'react';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 
-import { useControl } from 'react-map-gl';
 
-export function getZoomFromBbox(bbox: [number, number, number, number]): number {
-  const latMax = Math.max(bbox[3], bbox[1]);
-  const lngMax = Math.max(bbox[2], bbox[0]);
-  const latMin = Math.min(bbox[3], bbox[1]);
-  const lngMin = Math.min(bbox[2], bbox[0]);
-  const maxDiff = Math.max(latMax - latMin, lngMax - lngMin);
-  if (maxDiff < 360 / Math.pow(2, 20)) {
-    return 21;
-} else {
-    const zoomLevel = Math.floor(-1*( (Math.log(maxDiff)/Math.log(2)) - (Math.log(360)/Math.log(2))));
-    if (zoomLevel < 1) return 1;
-    else return zoomLevel;
-  }
-}
+import { useControl } from 'react-map-gl';
+import { getZoomFromBbox } from '$components/common/map/utils';
 
 export default function GeocoderControl() {
-
   const handleGeocoderResult = useCallback((map, geocoder) => ({ result }) => {
     geocoder.clear();
     geocoder._inputEl.blur();

--- a/app/scripts/components/common/map/utils.ts
+++ b/app/scripts/components/common/map/utils.ts
@@ -3,6 +3,7 @@ import { Map as MapboxMap } from 'mapbox-gl';
 import { MapRef } from 'react-map-gl';
 import { endOfDay, startOfDay } from 'date-fns';
 import { Feature, MultiPolygon, Polygon } from 'geojson';
+import { BBox } from "@turf/helpers";
 import {
   DatasetDatumFn,
   DatasetDatumFnResolverBag,
@@ -232,3 +233,19 @@ export function multiPolygonToPolygons(feature: Feature<MultiPolygon>) {
 
   return polygons;
 }
+
+export function getZoomFromBbox(bbox: BBox): number {
+  const latMax = Math.max(bbox[3], bbox[1]);
+  const lngMax = Math.max(bbox[2], bbox[0]);
+  const latMin = Math.min(bbox[3], bbox[1]);
+  const lngMin = Math.min(bbox[2], bbox[0]);
+  const maxDiff = Math.max(latMax - latMin, lngMax - lngMin);
+  if (maxDiff < 360 / Math.pow(2, 20)) {
+    return 21;
+} else {
+    const zoomLevel = Math.floor(-1*( (Math.log(maxDiff)/Math.log(2)) - (Math.log(360)/Math.log(2))));
+    if (zoomLevel < 1) return 1;
+    else return zoomLevel;
+  }
+}
+

--- a/app/scripts/components/common/mapbox/map.tsx
+++ b/app/scripts/components/common/mapbox/map.tsx
@@ -28,7 +28,7 @@ import MapCoords from './map-coords';
 
 import { useMapStyle } from './layers/styles';
 import { BasemapId, Option } from './map-options/basemaps';
-import { getZoomFromBbox } from '$components/common/map/controls/geocoder';
+import { getZoomFromBbox } from '$components/common/map/utils';
 import { round } from '$utils/format';
 
 mapboxgl.accessToken = process.env.MAPBOX_TOKEN ?? '';

--- a/app/scripts/components/exploration/atoms/timeline.ts
+++ b/app/scripts/components/exploration/atoms/timeline.ts
@@ -12,6 +12,11 @@ export const zoomTransformAtom = atom<ZoomTransformPlain>({
   k: 1
 });
 
+
+// Atom to zoom TOI when analysis is run
+type ZoomTOIFunction = (newX: number, newK: number) => void;
+export const onTOIZoomAtom = atom<ZoomTOIFunction | null>(null);
+
 // Width of the whole timeline item. Set via a size observer and then used to
 // compute the different element sizes.
 export const timelineWidthAtom = atom<number | undefined>(undefined);

--- a/app/scripts/components/exploration/components/map/tour-control.tsx
+++ b/app/scripts/components/exploration/components/map/tour-control.tsx
@@ -27,7 +27,6 @@ export function ShowTourControl() {
   const { setIsOpen, setCurrentStep, setSteps } = useTour();
   const datasets = useAtomValue(timelineDatasetsAtom);
   const disabled = datasets.length === 0;
-
   const reopenTour = useCallback(() => {
     setCurrentStep(0);
     setSteps?.(introTourSteps);

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -56,6 +56,7 @@ import {
   useScaleFactors,
   useScales
 } from '$components/exploration/hooks/scales-hooks';
+import { useOnTOIZoom } from '$components/exploration/hooks/use-toi-zoom';
 import {
   TimelineDatasetStatus,
   TimelineDatasetSuccess,
@@ -200,7 +201,7 @@ export default function Timeline(props: TimelineProps) {
   const [selectedInterval, setSelectedInterval] = useAtom(selectedIntervalAtom);
 
   const { setObsolete, runAnalysis, isAnalyzing } = useAnalysisController();
-
+  const [zoomTransform, setZoomTransform] = useAtom(zoomTransformAtom);
   const { features } = useAois();
 
   useEffect(() => {
@@ -215,8 +216,6 @@ export default function Timeline(props: TimelineProps) {
     ],
     [width]
   );
-
-  const [zoomTransform, setZoomTransform] = useAtom(zoomTransformAtom);
 
   // Calculate min and max scale factors, such has each day has a minimum of 2px
   // and a maximum of 100px.
@@ -371,7 +370,17 @@ export default function Timeline(props: TimelineProps) {
     applyTransform(zoomBehavior, select(interactionRef.current), 0, 0, k0);
   }, [prevSuccessDatasetsCount, successDatasetsCount, k0, zoomBehavior]);
 
-  const onControlsZoom = useCallback(
+  const { initializeTOIZoom } = useOnTOIZoom();
+
+  useEffect(() => {
+    // Set TOIZoom functionality in atom so it can be used in analysis component
+    // Ensure zoomBehavior and interactionRef are defined before initializing
+    if (zoomBehavior && interactionRef.current) {
+      initializeTOIZoom(zoomBehavior, interactionRef);
+    }
+  }, [initializeTOIZoom, zoomBehavior, interactionRef]);
+
+    const onControlsZoom = useCallback(
     (zoomV) => {
       if (!interactionRef.current || !xMain || !xScaled || !selectedDay) return;
 

--- a/app/scripts/components/exploration/hooks/use-toi-zoom.ts
+++ b/app/scripts/components/exploration/hooks/use-toi-zoom.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useAtom } from 'jotai';
+import { select, ZoomBehavior } from 'd3';
+import { onTOIZoomAtom } from '../atoms/timeline';
+import { applyTransform } from '$components/exploration/components/timeline/timeline-utils';
+
+export function useOnTOIZoom() {
+  const [onTOIZoom, setOnTOIZoom] = useAtom(onTOIZoomAtom);
+
+  const initialize = useCallback((zoomBehavior:  ZoomBehavior<Element, unknown>, interactionRef: React.RefObject<HTMLElement>) => {
+    setOnTOIZoom(() => (newX: number, newK: number) => {
+      if (!newX || !newK) return;
+      const { current: interactionElement } = interactionRef;
+      if (!interactionElement) return;
+      
+      applyTransform(
+        zoomBehavior,
+        select(interactionElement),
+        newX,
+        0,
+        newK
+      );
+    });
+  }, [setOnTOIZoom]);
+
+  const safeOnTOIZoom = (newX: number, newK: number) => {
+    if (onTOIZoom) {
+      onTOIZoom(newX, newK);
+    }
+  };
+
+  return { initializeTOIZoom: initialize, onTOIZoom: safeOnTOIZoom };
+}


### PR DESCRIPTION
**Related Ticket:** #857 
### Description of Changes
Zoom aoi when analysis gets run  (note that this PR only handles AOI, not TOI)

### Notes & Questions About Changes

Mapbox has fitBonds problem with some projections: https://github.com/mapbox/mapbox-gl-js/issues/12565 Because of this issue, we have to do manual centering which might not look very smooth.

### Validation / Testing
Run Analysis on this page:
https://deploy-preview-906--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22casa-gfed-co2-flux-fuel%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22min%22%2C%22label%22%3A%22Min%22%2C%22chartLabel%22%3A%22Min%22%2C%22themeColor%22%3A%22infographicA%22%7D%2C%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Avg%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22max%22%2C%22label%22%3A%22Max%22%2C%22chartLabel%22%3A%22Max%22%2C%22themeColor%22%3A%22infographicC%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22STD%22%2C%22themeColor%22%3A%22infographicD%22%7D%2C%7B%22id%22%3A%22median%22%2C%22label%22%3A%22Median%22%2C%22chartLabel%22%3A%22Median%22%2C%22themeColor%22%3A%22infographicE%22%7D%5D%7D%7D%5D&date=2017-11-30T15%3A00%3A00.000Z&aois=%5B%22kpoaX%7BdjwCozrlC%3F%3FnwdmFpnkuDzs_N%22%2C%22ef9c32%22%2Ctrue%5D&dateRange=2017-09-30T15%3A00%3A00.000Z%7C2017-12-31T15%3A00%3A00.000Z

