### PR TITLE
Add a work around for Safari scroll problem

### DIFF
--- a/app/scripts/components/common/map/maps.tsx
+++ b/app/scripts/components/common/map/maps.tsx
@@ -37,7 +37,7 @@ const chevronLeftURI = () =>
 const MapsContainer = styled.div`
   ${MapboxStyleOverride}
   height: 100%;
-
+  flex: 1; /* Necessary for Safari */
   .mapboxgl-map {
     position: absolute !important;
     inset: 0;
@@ -135,7 +135,6 @@ function Maps({ children, projection, onStyleUpdate }: MapsProps) {
   });
 
   const { containerId } = useMapsContext();
-
   return (
     <MapsContainer id={containerId} ref={observe}>
       <Styles onStyleUpdate={onStyleUpdate}>

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -131,6 +131,11 @@ const EmptyTimelineContentInner = styled.div`
 
 const TimelineContentInner = styled(EmptyTimelineContentInner)`
   overflow-y: scroll;
+  /* @TECH-DEBT: A hack to target only Safari
+     Safari needs a specific height to make the contents  scrollable */
+  @supports (font: -apple-system-body) and (-webkit-appearance: none) {
+    height: 250px; 
+  }
 `;
 
 const LayerActionBox = styled.div`

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -129,12 +129,12 @@ const EmptyTimelineContentInner = styled.div`
   position: relative;
 `;
 
-const TimelineContentInner = styled(EmptyTimelineContentInner)`
+const TimelineContentInner = styled(EmptyTimelineContentInner)<{panelHeight: number}>`
   overflow-y: scroll;
   /* @TECH-DEBT: A hack to target only Safari
      Safari needs a specific height to make the contents  scrollable */
   @supports (font: -apple-system-body) and (-webkit-appearance: none) {
-    height: 250px; 
+    height: calc(${(props)=> 100 - props.panelHeight}vh - 130px);
   }
 `;
 
@@ -158,6 +158,7 @@ const TimelineHeading = styled(Heading)`
 
 interface TimelineProps {
   onDatasetAddClick: () => void;
+  panelHeight: number;
 }
 
 const getIntervalFromDate = (selectedDay: Date, dataDomain: [Date, Date]) => {
@@ -173,7 +174,7 @@ const getIntervalFromDate = (selectedDay: Date, dataDomain: [Date, Date]) => {
 };
 
 export default function Timeline(props: TimelineProps) {
-  const { onDatasetAddClick } = props;
+  const { onDatasetAddClick, panelHeight } = props;
 
   // Refs for non react based interactions.
   // The interaction rect is used to capture the different d3 events for the
@@ -658,7 +659,7 @@ export default function Timeline(props: TimelineProps) {
           </>
         )}
 
-        <TimelineContentInner ref={datasetsContainerRef}>
+        <TimelineContentInner ref={datasetsContainerRef} panelHeight={panelHeight}>
           <DatasetList width={width} xScaled={xScaled} />
         </TimelineContentInner>
       </TimelineContent>

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -73,6 +73,8 @@ function Exploration() {
   const [datasetModalRevealed, setDatasetModalRevealed] = useState(
     !datasets.length
   );
+  // @TECH-DEBT: panelHeight  needs to be passed to work around Safari CSS 
+  const [panelHeight, setPanelHeight] = useState(0);
 
   const openModal = useCallback(() => setDatasetModalRevealed(true), []);
   const closeModal = useCallback(() => setDatasetModalRevealed(false), []);
@@ -104,12 +106,16 @@ function Exploration() {
         <PageHero title='Exploration' isHidden />
         <Container>
           <PanelGroup direction='vertical' className='panel-wrapper'>
-            <Panel maxSize={75} className='panel'>
+            <Panel
+            maxSize={75}
+            className='panel'
+            onResize={(size:number)=> {setPanelHeight(size);}}
+            >
               <ExplorationMap />
             </Panel>
             <PanelResizeHandle className='resize-handle' />
             <Panel maxSize={75} className='panel panel-timeline'>
-              <Timeline onDatasetAddClick={openModal} />
+              <Timeline onDatasetAddClick={openModal} panelHeight={panelHeight} />
             </Panel>
           </PanelGroup>
         </Container>

--- a/app/scripts/styles/range-slider.tsx
+++ b/app/scripts/styles/range-slider.tsx
@@ -51,7 +51,7 @@ export const RangeSliderInput = styled(RangeSlider)<RangeSliderInputProps>`
 `;
 
 export interface SliderInputProps
-  extends Omit<RangeSliderInputProps, 'value' | 'onInput'> {
+  extends Omit<RangeSliderInputProps, 'value' | 'onInput' | 'defaultValue'> {
   value: number;
   onInput: (v: number) => void;
 }
@@ -83,6 +83,5 @@ export function NativeSliderInput(props: SliderInputProps) {
       value={value}
       onPointerDownCapture={e => e.stopPropagation()}
       onChange={e => onInput(parseInt(e.target.value))}
-      defaultValue={100}
     />);
 }


### PR DESCRIPTION
**Related Ticket:** #878 

### Description of Changes
Add Safari targeting CSS to work around the problem of #878 

### Notes & Questions About Changes
- It seems Safari is generally bad at not-explicit height. As far as I can see, the scroll was not attached because the container didn't have the explicit height to overflow the contents. (Other browsers fit the container as 100% automatically.) I am giving dynamic heights based on dataset number only to Safari in this PR.
- I ended up using the panel's height to give proper height to the basket in Safari. In theory, it will decrease the performance of rendering of the basket(Things didn't need to be re-rendered on React side with panel resizing before, but now they have to.)  but hopefully it is not noticable.

### Validation / Testing

Open https://deploy-preview-909--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22casa-gfed-co2-flux%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%2C%7B%22id%22%3A%22casa-gfed-co2-flux-hr%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%2C%7B%22id%22%3A%22casa-gfed-co2-flux-nee%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&date=2017-11-30T15%3A00%3A00.000Z in Safari
