### PR TITLE
Include dataset id to filter layers

### DIFF
--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -7,7 +7,6 @@ import { Subtitle } from '@devseed-ui/typography';
 import { Button } from '@devseed-ui/button';
 import { CollecticonXmarkSmall } from '@devseed-ui/collecticons';
 import { VerticalDivider } from '@devseed-ui/toolbar';
-import { datasets } from 'veda';
 
 import DatasetMenu from './dataset-menu';
 
@@ -42,14 +41,13 @@ import Pluralize from '$utils/pluralize';
 import { Pill } from '$styles/pill';
 import { FeaturedDatasets } from '$components/common/featured-slider-section';
 import { CardSourcesList } from '$components/common/card-sources';
+import { allDatasetsWithEnhancedLayers } from '$components/exploration/data-utils';
 import {
   getTaxonomy,
   TAXONOMY_SOURCE,
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { DatasetClassification } from '$components/common/dataset-classification';
-
-const allDatasetsForCatalog = Object.values(datasets).map((d) => d!.data);
 
 const DatasetCount = styled(Subtitle)`
   grid-column: 1 / -1;
@@ -92,6 +90,8 @@ export const prepareDatasets = (
     const layerMatchesSearch = (layer) => 
       includesSearchLower(layer.stacCol) ||
       includesSearchLower(layer.name) ||
+      includesSearchLower(layer.parentDataset.name) ||
+      includesSearchLower(layer.parentDataset.id) ||
       includesSearchLower(layer.description);
 
     filtered = filtered
@@ -101,7 +101,6 @@ export const prepareDatasets = (
         const nameLower = d.name.toLowerCase();
         const descriptionLower = d.description.toLowerCase();
         const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
-
         // Check if any of the conditions for including the item are met
         return (
           idLower.includes(searchLower) ||
@@ -157,7 +156,7 @@ function DataCatalog() {
 
   const displayDatasets = useMemo(
     () =>
-      prepareDatasets(allDatasetsForCatalog, {
+      prepareDatasets(allDatasetsWithEnhancedLayers, {
         search,
         taxonomies,
         sortField,
@@ -214,7 +213,7 @@ function DataCatalog() {
               count={displayDatasets.length}
               showCount={true}
             />{' '}
-            out of {allDatasetsForCatalog.length}.
+            out of {allDatasetsWithEnhancedLayers.length}.
           </span>
           {isFiltering && (
             <Button forwardedAs={Link} to={DATASETS_PATH} size='small'>

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -6,7 +6,7 @@ import {
   startOfMonth,
   startOfYear
 } from 'date-fns';
-import { DatasetLayer, datasets } from 'veda';
+import { DatasetLayer, DatasetData, datasets } from 'veda';
 import {
   EnhancedDatasetLayer,
   StacDatasetData,
@@ -38,7 +38,11 @@ export const allDatasets = Object.values(datasets)
   .map((d) => d!.data)
   .filter((d) => !d.disableExplore);
 
-export const allDatasetsWithEnhancedLayers = allDatasets.map(currentDataset => {
+export interface DatasetDataWithEnhancedLayers extends DatasetData {
+  layers: EnhancedDatasetLayer[];
+}
+
+export const allDatasetsWithEnhancedLayers: DatasetDataWithEnhancedLayers[]  = allDatasets.map(currentDataset => {
   return {
     ...currentDataset,
     layers: currentDataset.layers.map(l => ({


### PR DESCRIPTION
**Related Ticket:** #876 

### Description of Changes
Include dataset id & name for search criteria

### Notes & Questions About Changes
I am kind of surprised that dataset id & name were not search criteria yet? Anyway, this will go well with our new approach in A&E to group layers with dataset.

### Validation / Testing
Check LPJ dataset link from veda-config-ghg