### PR TITLE
Some datasets can only be analyzed with layers from the same source

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -13,7 +13,6 @@ import { DropMenu, DropTitle } from '@devseed-ui/dropdown';
 import {
   Actions,
   FilterOption,
-  TaxonomyFilterOption,
   optionAll,
   useBrowserControls
 } from './use-browse-controls';

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -43,7 +43,7 @@ const FilterOptionsWrapper = styled.div`
   > * {
     flex-shrink: 0;
   }
-`
+`;
 
 const DropButton = styled(Button)`
   max-width: 12rem;
@@ -69,20 +69,14 @@ const ButtonPrefix = styled(Overline).attrs({ as: 'small' })`
 
 interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
   taxonomiesOptions: Taxonomy[];
-  sortOptions: FilterOption[];
-  defaultSelect?: TaxonomyFilterOption;
 }
 
 function BrowseControls(props: BrowseControlsProps) {
   const {
     taxonomiesOptions,
     taxonomies,
-    sortOptions,
     search,
-    sortField,
-    sortDir,
     onAction,
-    defaultSelect,
     ...rest
   } = props;
 

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -96,7 +96,7 @@ function BrowseControls(props: BrowseControlsProps) {
         key={name}
         prefix={name}
         items={[optionAll].concat(values)}
-        currentId={filterList?.[name] ?? 'all'}
+        currentId={taxonomies?.[name] ?? 'all'}
         onChange={(v) => {
           onAction(Actions.TAXONOMY, { key: name, value: v });
         }}
@@ -122,7 +122,7 @@ function BrowseControls(props: BrowseControlsProps) {
       {
         wrapTaxonomies && (
           <FilterOptionsWrapper>
-            {createFilterList(taxonomiesOptions.slice(0, filterWrapConstant))}
+            {createFilterList(taxonomiesOptions.slice(filterWrapConstant, taxonomiesOptions.length))}
           </FilterOptionsWrapper>
         )
       }
@@ -146,7 +146,7 @@ function DropdownOptions(props: DropdownOptionsProps) {
   const { size, items, currentId, onChange, prefix } = props;
 
   const currentItem = items.find((d) => d.id === currentId);
-
+  
   return (
     <DropdownScrollable
       alignment='left'

--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { Taxonomy } from 'veda';
+import { Taxonomy, TaxonomyItem } from 'veda';
 import { Overline } from '@devseed-ui/typography';
 import { Button, ButtonProps } from '@devseed-ui/button';
 import {
@@ -13,6 +13,7 @@ import { DropMenu, DropTitle } from '@devseed-ui/dropdown';
 import {
   Actions,
   FilterOption,
+  TaxonomyFilterOption,
   optionAll,
   sortDirOptions,
   useBrowserControls
@@ -78,6 +79,7 @@ interface BrowseControlsProps extends ReturnType<typeof useBrowserControls> {
   taxonomiesOptions: Taxonomy[];
   sortOptions: FilterOption[];
   showMoreButtonOpt?: boolean;
+  defaultSelect?: TaxonomyFilterOption;
 }
 
 function BrowseControls(props: BrowseControlsProps) {
@@ -90,6 +92,7 @@ function BrowseControls(props: BrowseControlsProps) {
     sortField,
     sortDir,
     onAction,
+    defaultSelect,
     ...rest
   } = props;
 

--- a/app/scripts/components/common/browse-controls/use-browse-controls.ts
+++ b/app/scripts/components/common/browse-controls/use-browse-controls.ts
@@ -18,6 +18,12 @@ export interface FilterOption {
   name: string;
 }
 
+export interface TaxonomyFilterOption {
+  taxonomyType: string;
+  value: string;
+  exclusion?: string;
+}
+
 interface BrowseControlsHookParams {
   sortOptions: FilterOption[];
 }

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -201,7 +201,6 @@ function DataCatalog() {
           <BrowseControls
             {...controlVars}
             taxonomiesOptions={datasetTaxonomies}
-            sortOptions={sortOptions}
           />
         </BrowseFoldHeader>
 

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { glsp, themeVal, media } from '@devseed-ui/theme-provider';
 import {
@@ -27,7 +28,6 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { Pill } from '$styles/pill';
-import { Link } from 'react-router-dom';
 
 const DatasetContainer = styled.div`
   height: auto;
@@ -102,7 +102,7 @@ export const ParentDatasetTitle = styled.h2<{size?: string}>`
 
 const WarningPill = styled(Pill)`
   margin-left: 8px;
-`
+`;
 
 interface ModalContentComponentProps {
   search: string;
@@ -167,7 +167,7 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
     ) : (
       <EmptyHub>
         <EmptyInfoDiv>
-          <p>There are no datasets to show with the selected filters.</p><br/>
+          <p>There are no datasets to show with the selected filters.</p><br />
           <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH} target='_blank'>Data Catalog</Link>.</p>
         </EmptyInfoDiv>
       </EmptyHub>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -6,7 +6,7 @@ import {
   CollecticonTickSmall,
   iconDataURI
 } from '@devseed-ui/collecticons';
-import { DatasetData, DatasetLayer, TaxonomyItem } from 'veda';
+import { DatasetData } from 'veda';
 import { DatasetLayerCardProps } from './';
 
 import { DatasetClassification } from '$components/common/dataset-classification';
@@ -20,13 +20,14 @@ import {
 import TextHighlight from '$components/common/text-highlight';
 import { CardSourcesList } from '$components/common/card-sources';
 import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
-import { getDatasetPath } from '$utils/routes';
+import { DATASETS_PATH, getDatasetPath } from '$utils/routes';
 import {
   getTaxonomy,
   TAXONOMY_SOURCE,
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
 import { Pill } from '$styles/pill';
+import { Link } from 'react-router-dom';
 
 const DatasetContainer = styled.div`
   height: auto;
@@ -72,6 +73,11 @@ const DatasetIntro = styled.div`
   padding: ${glsp(1)} 0;
 `;
 
+const EmptyInfoDiv = styled.div`
+  width: 70%;
+  text-align: center;
+`;
+
 export const ParentDatasetTitle = styled.h2<{size?: string}>`
   color: ${themeVal('color.primary')};
   text-align: left;
@@ -94,18 +100,23 @@ export const ParentDatasetTitle = styled.h2<{size?: string}>`
   }
 `;
 
+const WarningPill = styled(Pill)`
+  margin-left: 8px;
+`
+
 interface ModalContentComponentProps {
   search: string;
   selectedIds: string[];
   displayDatasets?: (DatasetData & {
     countSelectedLayers: number;
   })[];
-  // onCheck: (id: string, sources?: TaxonomyItem[], currentDataset?: any) => void;
   onCheck: (id: string, currentDataset?: DatasetData & {countSelectedLayers: number}) => void;
 }
 
 export default function ModalContentComponent(props:ModalContentComponentProps) {
   const { search, selectedIds, displayDatasets, onCheck } = props;
+  const exclusiveSourceWarning = "Can only be analyzed with layers from the same source";
+
   return(
   <DatasetContainer>
     {displayDatasets?.length ? (
@@ -116,6 +127,13 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
             <DatasetHeadline>
             <ParentDatasetTitle>
               <CollecticonDatasetLayers /> {currentDataset.name}
+              {
+                currentDataset.sourceExclusive && (
+                  <WarningPill variation='warning'>
+                    {exclusiveSourceWarning}
+                  </WarningPill>
+                )
+              }
             </ParentDatasetTitle>
             {currentDataset.countSelectedLayers > 0 && <DatasetSelectedLayer><span>{currentDataset.countSelectedLayers} selected </span> </DatasetSelectedLayer>}
             </DatasetHeadline>
@@ -137,7 +155,6 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
                 layer={datasetLayer}
                 parent={currentDataset}
                 selected={selectedIds.includes(datasetLayer.id)}
-                // onDatasetClick={() => onCheck(datasetLayer.id, getTaxonomy(currentDataset, TAXONOMY_SOURCE)?.values, currentDataset)}
                 onDatasetClick={() => onCheck(datasetLayer.id, currentDataset)}
               />
             </li>
@@ -149,7 +166,10 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
       </div>
     ) : (
       <EmptyHub>
-        There are no datasets to show with the selected filters.
+        <EmptyInfoDiv>
+          <p>There are no datasets to show with the selected filters.</p><br/>
+          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH} target='_blank'>Data Catalog</Link>.</p>
+        </EmptyInfoDiv>
       </EmptyHub>
     )}
   </DatasetContainer>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/content.tsx
@@ -6,7 +6,7 @@ import {
   CollecticonTickSmall,
   iconDataURI
 } from '@devseed-ui/collecticons';
-import { DatasetData } from 'veda';
+import { DatasetData, DatasetLayer, TaxonomyItem } from 'veda';
 import { DatasetLayerCardProps } from './';
 
 import { DatasetClassification } from '$components/common/dataset-classification';
@@ -97,17 +97,18 @@ export const ParentDatasetTitle = styled.h2<{size?: string}>`
 interface ModalContentComponentProps {
   search: string;
   selectedIds: string[];
-  displayDatasets: (DatasetData & {
+  displayDatasets?: (DatasetData & {
     countSelectedLayers: number;
   })[];
-  onCheck: (id: string) => void;
+  // onCheck: (id: string, sources?: TaxonomyItem[], currentDataset?: any) => void;
+  onCheck: (id: string, currentDataset?: DatasetData & {countSelectedLayers: number}) => void;
 }
 
 export default function ModalContentComponent(props:ModalContentComponentProps) {
   const { search, selectedIds, displayDatasets, onCheck } = props;
   return(
   <DatasetContainer>
-    {displayDatasets.length ? (
+    {displayDatasets?.length ? (
       <div>
       {displayDatasets.map(currentDataset => (
         <SingleDataset key={currentDataset.id}>
@@ -136,7 +137,8 @@ export default function ModalContentComponent(props:ModalContentComponentProps) 
                 layer={datasetLayer}
                 parent={currentDataset}
                 selected={selectedIds.includes(datasetLayer.id)}
-                onDatasetClick={() => onCheck(datasetLayer.id)}
+                // onDatasetClick={() => onCheck(datasetLayer.id, getTaxonomy(currentDataset, TAXONOMY_SOURCE)?.values, currentDataset)}
+                onDatasetClick={() => onCheck(datasetLayer.id, currentDataset)}
               />
             </li>
           );
@@ -220,6 +222,7 @@ function DatasetLayerCard(props: DatasetLayerCardProps) {
   const { parent, layer, onDatasetClick, selected, searchTerm } = props;
 
   const topics = getTaxonomy(parent, TAXONOMY_TOPICS)?.values;
+  const sources = getTaxonomy(parent, TAXONOMY_SOURCE)?.values;
   return (
     <LayerCard
       cardType='classic'
@@ -228,7 +231,7 @@ function DatasetLayerCard(props: DatasetLayerCardProps) {
         <CardMeta>
           <DatasetClassification dataset={parent} />
           <CardSourcesList
-            sources={getTaxonomy(parent, TAXONOMY_SOURCE)?.values}
+            sources={sources}
           />
         </CardMeta>
       }

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -30,6 +30,7 @@ const LayerResult = styled.div`
 
 export default function ModalFooterRender (props:ModalFooterComponentProps) {
   const { selectedIds, close, onConfirm } = props;
+  console.log(`footer_selectedIds: `, selectedIds)
   return (
     <>
       <LayerResult aria-live='polite' className='selection-info'>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/footer.tsx
@@ -30,7 +30,7 @@ const LayerResult = styled.div`
 
 export default function ModalFooterRender (props:ModalFooterComponentProps) {
   const { selectedIds, close, onConfirm } = props;
-  console.log(`footer_selectedIds: `, selectedIds)
+
   return (
     <>
       <LayerResult aria-live='polite' className='selection-info'>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import { media } from '@devseed-ui/theme-provider';
-import { Taxonomy, TaxonomyItem, datasetTaxonomies } from 'veda';
+import { datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
 } from '@devseed-ui/modal';
@@ -15,13 +13,9 @@ import {
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
 import { sortOptions } from '$components/data-catalog';
-import { DATASETS_PATH } from '$utils/routes';
 
-const StyledModalHeadline = styled(ModalHeadline)``;
-const ModalIntro = styled.div`
-  ${media.largeUp`
-    width: 66%;
-  `}
+const StyledModalHeadline = styled(ModalHeadline)`
+  width: 100%;
 `;
 
 export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: TaxonomyFilterOption}) {
@@ -39,15 +33,10 @@ export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: Tax
   return(
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
-      <ModalIntro>
-          <p>This tool allows the exploration and analysis of time-series datasets in raster format. For a comprehensive list of available datasets, please visit the <Link to={DATASETS_PATH} target='_blank'>Data Catalog</Link>.
-          </p>
-      </ModalIntro>
       <BrowseControls
           {...controlVars}
           taxonomiesOptions={datasetTaxonomies}
           sortOptions={sortOptions}
-          showMoreButtonOpt={true}
           defaultSelect={defaultSelect}
       />
     </StyledModalHeadline>

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -27,7 +27,7 @@ export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: Tax
     if(defaultSelect) {
       controlVars.onAction(Actions.TAXONOMY, { key: defaultSelect.taxonomyType, value: defaultSelect.value });
     }
-  }, [defaultSelect])
+  }, [defaultSelect]);
 
   return(
     <StyledModalHeadline>
@@ -35,8 +35,6 @@ export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: Tax
       <BrowseControls
           {...controlVars}
           taxonomiesOptions={datasetTaxonomies}
-          sortOptions={sortOptions}
-          defaultSelect={defaultSelect}
       />
     </StyledModalHeadline>
   );

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
 import { media } from '@devseed-ui/theme-provider';
-import { datasetTaxonomies } from 'veda';
+import { Taxonomy, TaxonomyItem, datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
 } from '@devseed-ui/modal';
@@ -10,6 +10,8 @@ import { Heading } from '@devseed-ui/typography';
 
 import BrowseControls from '$components/common/browse-controls';
 import {
+  Actions,
+  TaxonomyFilterOption,
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
 import { sortOptions } from '$components/data-catalog';
@@ -22,10 +24,18 @@ const ModalIntro = styled.div`
   `}
 `;
 
-export default function RenderModalHeader () {
+export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: TaxonomyFilterOption}) {
   const controlVars = useBrowserControls({
     sortOptions
   });
+
+  React.useEffect(() => {
+    if(defaultSelect) {
+      controlVars.onAction(Actions.TAXONOMY, { key: defaultSelect.taxonomyType, value: defaultSelect.value });
+      console.log(`only ${defaultSelect.taxonomyType} ${defaultSelect.value} should be available now`)
+    }
+  }, [defaultSelect])
+
   return(
     <StyledModalHeadline>
       <Heading size='small'>Data layers</Heading>
@@ -38,6 +48,7 @@ export default function RenderModalHeader () {
           taxonomiesOptions={datasetTaxonomies}
           sortOptions={sortOptions}
           showMoreButtonOpt={true}
+          defaultSelect={defaultSelect}
       />
     </StyledModalHeadline>
   );

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -26,7 +26,6 @@ export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: Tax
   React.useEffect(() => {
     if(defaultSelect) {
       controlVars.onAction(Actions.TAXONOMY, { key: defaultSelect.taxonomyType, value: defaultSelect.value });
-      console.log(`only ${defaultSelect.taxonomyType} ${defaultSelect.value} should be available now`)
     }
   }, [defaultSelect])
 

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { useAtom } from 'jotai';
 
-import { DatasetData, DatasetLayer, Taxonomy, TaxonomyItem } from 'veda';
+import { DatasetData, DatasetLayer } from 'veda';
 import {
   Modal,
   ModalBody,
@@ -106,8 +106,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
 
   const prevSelectedIds = usePreviousValue(selectedIds);
 
-  const [relevantIds, setReleventIds] = useState<string[] | undefined>();
-
   const [exclusionSelected, setExclusionSelected] = useState<boolean>(false);
   
   useEffect(() => {
@@ -115,7 +113,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
   }, [timelineDatasets]);
 
   const onCheck = useCallback((id: string, currentDataset?: DatasetData & {countSelectedLayers: number}) => {
-    console.log(`checked_currentDataset: `, currentDataset)
     if (currentDataset) {
       // This layer is part of a dataset that is exclusive
       const exclusiveSource = currentDataset.sourceExclusive;
@@ -123,17 +120,12 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       const sourceIds = sources?.map(source => source.id);
       console.log(`sourceIds: `, sourceIds)
     
-      // if (sourceIds?.includes('epa')) {
+
       if (exclusiveSource && sourceIds?.includes(exclusiveSource.toLowerCase())) {
-        console.log(`epa source chosen, remove all others, `, sources)
-        // setDefaultSelectFilter({taxonomyType: TAXONOMY_SOURCE, value: 'epa'});
         setDefaultSelectFilter({taxonomyType: TAXONOMY_SOURCE, value: exclusiveSource.toLowerCase()});
         setExclusionSelected(true);
-        // setSelectedIds([]);
       }
-      // if (exclusiveSource && !sourceIds?.includes(exclusiveSource.toLowerCase())) {
-        if (!exclusiveSource) {
-        console.log(`non epa source chosen, remove epa choices`)
+      if (!exclusiveSource) {
         setDefaultSelectFilter(undefined);
         setExclusionSelected(false);
       }
@@ -181,8 +173,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
         relevantIds = selectedIdsWithParentData.filter((x) => !x.values?.includes(x.sourceExclusive)).map((x) => x.id)
       }
 
-      console.log(`relevantIds: `, relevantIds)
-
       setSelectedIds((ids) =>
         ids.filter((id) => relevantIds?.includes(id))
       );
@@ -200,24 +190,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       onAction(Actions.CLEAR);
     }
   }, [revealed]);
-
-  // // Filtered datasets for modal display
-  // const displayDatasets = useMemo<(DatasetData & {countSelectedLayers: number})[]>(
-  //   () =>
-  //     // @TODO: Move function from data-catalog once that page is removed.
-  //     prepareDatasets(allDatasets, {
-  //       search,
-  //       taxonomies,
-  //       sortField,
-  //       sortDir,
-  //       filterLayers: true
-  //     })
-  //     .map(dataset => ({
-  //       ...dataset,
-  //       countSelectedLayers: countOverlap(dataset.layers.map(l => l.id), selectedIds)
-  //     })),
-  //   [search, taxonomies, sortField, sortDir, selectedIds]
-  // );
 
   useEffect(() => {
     const datasets = prepareDatasets(allDatasets, {
@@ -249,7 +221,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
         <ModalContentRender 
           search={search} 
           selectedIds={selectedIds} 
-          // displayDatasets={displayDatasets}
           displayDatasets={datasetsToDisplay} 
           onCheck={onCheck}
         /> 

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -115,15 +115,14 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
   const onCheck = useCallback((id: string, currentDataset?: DatasetData & {countSelectedLayers: number}) => {
     if (currentDataset) {
       // This layer is part of a dataset that is exclusive
-      const exclusiveSource = currentDataset.sourceExclusive;
+      const exclusiveSource = currentDataset.sourceExclusive?.toLowerCase();
       const sources = getTaxonomy(currentDataset, TAXONOMY_SOURCE)?.values;
       const sourceIds = sources?.map(source => source.id);
 
-      if (exclusiveSource && sourceIds?.includes(exclusiveSource.toLowerCase())) {
-        setDefaultSelectFilter({taxonomyType: TAXONOMY_SOURCE, value: exclusiveSource.toLowerCase()});
+      if (exclusiveSource && sourceIds?.includes(exclusiveSource)) {
+        setDefaultSelectFilter({taxonomyType: TAXONOMY_SOURCE, value: exclusiveSource});
         setExclusionSelected(true);
-      }
-      if (!exclusiveSource) {
+      } else {
         setDefaultSelectFilter(undefined);
         setExclusionSelected(false);
       }
@@ -159,15 +158,12 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
         const parentData = findParentDataset(selectedId);
         const exclusiveSource = parentData?.sourceExclusive;
         const parentDataSourceValues = parentData?.taxonomy.filter((x) => x.name === 'Source')?.[0]?.values?.map((value) => value.id);
-        return {id: selectedId, values: parentDataSourceValues, sourceExclusive: exclusiveSource?.toLowerCase() || ''}
+        return {id: selectedId, values: parentDataSourceValues, sourceExclusive: exclusiveSource?.toLowerCase() || ''};
       });
       
-      if(exclusionSelected) {
-        // Dataset with exclusions selected
+      if (exclusionSelected) {
         relevantIds = selectedIdsWithParentData.filter((x) => x.values?.includes(x.sourceExclusive)).map((x) => x.id)
-      } 
-      if(!exclusionSelected) {
-        // Dataset with no exclusions selected
+      } else {
         relevantIds = selectedIdsWithParentData.filter((x) => !x.values?.includes(x.sourceExclusive)).map((x) => x.id)
       }
 
@@ -213,7 +209,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       revealed={revealed}
       onCloseClick={close}
       renderHeadline={() => (
-        <RenderModalHeader defaultSelect={defaultSelectFilter}/>
+        <RenderModalHeader defaultSelect={defaultSelectFilter} />
       )}
       content={
         <ModalContentRender 

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -118,8 +118,6 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       const exclusiveSource = currentDataset.sourceExclusive;
       const sources = getTaxonomy(currentDataset, TAXONOMY_SOURCE)?.values;
       const sourceIds = sources?.map(source => source.id);
-      console.log(`sourceIds: `, sourceIds)
-    
 
       if (exclusiveSource && sourceIds?.includes(exclusiveSource.toLowerCase())) {
         setDefaultSelectFilter({taxonomyType: TAXONOMY_SOURCE, value: exclusiveSource.toLowerCase()});

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -162,18 +162,16 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       });
       
       if (exclusionSelected) {
-        relevantIds = selectedIdsWithParentData.filter((x) => x.values?.includes(x.sourceExclusive)).map((x) => x.id)
+        relevantIds = selectedIdsWithParentData.filter((x) => x.values?.includes(x.sourceExclusive)).map((x) => x.id);
       } else {
-        relevantIds = selectedIdsWithParentData.filter((x) => !x.values?.includes(x.sourceExclusive)).map((x) => x.id)
+        relevantIds = selectedIdsWithParentData.filter((x) => !x.values?.includes(x.sourceExclusive)).map((x) => x.id);
       }
 
       setSelectedIds((ids) =>
         ids.filter((id) => relevantIds?.includes(id))
       );
     }
-    
-
-  }, [exclusionSelected])
+  }, [exclusionSelected]);
 
   useEffect(() => {
     if (revealed) {
@@ -196,10 +194,10 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
     .map(dataset => ({
       ...dataset,
       countSelectedLayers: countOverlap(dataset.layers.map(l => l.id), selectedIds)
-    }))
+    }));
 
     setDatasetsToDisplay(datasets);
-  }, [search, taxonomies, sortField, sortDir, selectedIds])
+  }, [search, taxonomies, sortField, sortDir, selectedIds]);
   
   return (
     <DatasetModal

--- a/app/scripts/components/stories/hub/index.tsx
+++ b/app/scripts/components/stories/hub/index.tsx
@@ -188,7 +188,6 @@ function StoriesHub() {
             <BrowseControls
               {...controlVars}
               taxonomiesOptions={storyTaxonomies}
-              sortOptions={sortOptions}
             />
           </BrowseFoldHeader>
 

--- a/app/scripts/styles/pill.tsx
+++ b/app/scripts/styles/pill.tsx
@@ -2,7 +2,6 @@ import styled, { css } from 'styled-components';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
 const renderPillVariation = ({ variation }: PillProps) => {
-  console.log(`variation: `, variation)
   switch (variation) {
     case 'achromic':
       return css`

--- a/app/scripts/styles/pill.tsx
+++ b/app/scripts/styles/pill.tsx
@@ -2,13 +2,18 @@ import styled, { css } from 'styled-components';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
 const renderPillVariation = ({ variation }: PillProps) => {
+  console.log(`variation: `, variation)
   switch (variation) {
     case 'achromic':
       return css`
         color: ${themeVal('color.surface')};
         background: ${themeVal('color.surface-100a')};
       `;
-
+    case 'warning':
+      return css`
+        color: ${themeVal('color.danger-500')};
+        background: ${themeVal('color.danger-200a')};
+      `;
     case 'primary':
     default:
       return css`
@@ -19,7 +24,7 @@ const renderPillVariation = ({ variation }: PillProps) => {
 };
 
 interface PillProps {
-  variation?: 'primary' | 'achromic';
+  variation?: 'primary' | 'achromic' | 'warning';
 }
 export const Pill = styled.span<PillProps>`
   display: inline-flex;

--- a/docs/content/CONTENT.md
+++ b/docs/content/CONTENT.md
@@ -51,6 +51,7 @@ thematics: string[]
 sources: string[]
 featured: boolean
 disableExplore: boolean
+sourceExclusive: string
 
 layers: Layer[]
 related: Related[]
@@ -114,6 +115,10 @@ Whether this dataset is featured
 **disableExplore**  
 `boolean`  
 When set to true, the 'explore data' section won't be available for this dataset.
+
+**sourceExclusive**  
+`string`  
+When a source value is provided, this marks the dataset layers as can only be analyzed with layers from the same source
 
 
 **layers**  

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -2,6 +2,7 @@
 id: no2
 name: 'Nitrogen Dioxide'
 featured: true
+sourceExclusive: Mock
 description: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
 usage:
   - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
@@ -210,7 +211,7 @@ NASA has observed subsequent rebounds in nitrogen dioxide levels as the lockdown
 ## Scientific research
 [Ongoing research](https://airquality.gsfc.nasa.gov/) by scientists in the Atmospheric Chemistry and Dynamics Laboratory at NASA’s Goddard Space Flight Center and [new research](https://science.nasa.gov/earth-science/rrnes-awards) funded by NASA's Rapid Response and Novel research in the Earth Sciences (RRNES) program element seek to better understand the atmospheric effects of the COVID-19 shutdowns.
 
-For nitrogen dioxide levels related to COVID-19, NASA uses data collected by the joint NASA-Royal Netherlands Meteorological Institute (KNMI) [Ozone Monitoring Instrument (OMI)](https://aura.gsfc.nasa.gov/omi.html) aboard the Aura satellite, as well as data collected by the Tropospheric Monitoring Instrument (TROPOMI) aboard the European Commission’s Copernicus Sentinel-5P satellite, built by the European Space Agency.
+For nitrogen dioxide levels related to COVID-19, NASA uses data collected by the joint NASA-Royal Netherlands Meteorological Institute (KNMI) [Ozone Monitoring Instrument (OMI)](https://aura.gsfc.nasa.gov/omi.html) aboard the Aura satellite, as well as data collected by the Tropospheric Monitoring Instrument (TROPOMI) aboard the European Commission’s Copernicus Sentinel-5P satellite, built by the European Space Agency.
 
 OMI, which launched in 2004, preceded TROPOMI, which launched in 2017. While TROPOMI provides higher resolution information, the longer OMI data record provides context for the TROPOMI observations.
 

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -178,6 +178,7 @@ export interface LayerInfo {
    */
   export interface DatasetData {
     featured?: boolean;
+    sourceExclusive?: string;
     id: string;
     name: string;
     infoDescription?: string;


### PR DESCRIPTION
**Related Ticket:**

Closes https://github.com/NASA-IMPACT/veda-ui/issues/882#issuecomment-2037327990

### Description of Changes
* New dataset markdown attribute `sourceExclusive` added
* When sourceExclusive, dataset can only be selected to be analyzed with other layers from the same dataset/source
* Updates data layer selector modal
   * Remove show/hide filters
   * Allow only 4 filters with the search bar and then wrap all other filters below
   * Remove SortBy filter
   * Remove heading description to only appear in empty/not found state
   * Move note about limited selection of available datasets from top bar to the message that is shown when search and/or filters do not return any layers.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
