### PR TITLE
Handle empty result

### DIFF
--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -235,6 +235,18 @@ export async function requestDatasetTimeseriesData({
       )
     );
 
+    if (layerStatistics.filter(e => e.mean).length === 0) {
+      return {
+        ...datasetAnalysis,
+        status: TimelineDatasetStatus.ERROR,
+        error: new ExtendedError(
+          'No valid statistics in the given time range and area of interest',
+          'ANALYSIS_NO_DATA'
+        ),
+        data: null
+      };
+    }
+
     onProgress({
       status: TimelineDatasetStatus.SUCCESS,
       meta: {

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -240,7 +240,7 @@ export async function requestDatasetTimeseriesData({
         ...datasetAnalysis,
         status: TimelineDatasetStatus.ERROR,
         error: new ExtendedError(
-          'No valid statistics in the given time range and area of interest',
+          'The selected time and area of interest contains no valid data. Please adjust your selection.',
           'ANALYSIS_NO_DATA'
         ),
         data: null


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/904

### Description of Changes
Handle the case when there is no actual value to display from statistics requests.

### Notes & Questions About Changes

- I am not sure the wording is clear. Please feel free to change. It will look like this

<img width="368" alt="Screen Shot 2024-04-23 at 3 24 28 PM" src="https://github.com/NASA-IMPACT/veda-ui/assets/4583806/f61d052d-850b-4fa4-b97f-c6f89babc692">

- Is it valid to assume that if the 'mean' (average) value doesn't exist, then other statistical measures also don't exist?

### Validation / Testing
Try datasets that only cover ocean (such as Air-sea co2 flux) , and select aoi that doesn't have ocean coverage. 
