### PR TITLE
Expose sum as statistics option

### DIFF
--- a/app/scripts/components/analysis/results/analysis-metrics-dropdown.tsx
+++ b/app/scripts/components/analysis/results/analysis-metrics-dropdown.tsx
@@ -15,7 +15,8 @@ export interface DataMetric {
     | 'infographicB'
     | 'infographicC'
     | 'infographicD'
-    | 'infographicE';
+    | 'infographicE'
+    | 'infographicF';
 }
 
 export const DATA_METRICS: DataMetric[] = [

--- a/app/scripts/components/analysis/results/analysis-metrics-dropdown.tsx
+++ b/app/scripts/components/analysis/results/analysis-metrics-dropdown.tsx
@@ -48,6 +48,12 @@ export const DATA_METRICS: DataMetric[] = [
     label: 'Median',
     chartLabel: 'Median',
     themeColor: 'infographicE'
+  },
+  {
+    id: 'sum',
+    label: 'Sum',
+    chartLabel: 'Sum',
+    themeColor: 'infographicF'
   }
 ];
 

--- a/app/scripts/components/exploration/components/datasets/analysis-metrics.tsx
+++ b/app/scripts/components/exploration/components/datasets/analysis-metrics.tsx
@@ -13,7 +13,8 @@ export interface DataMetric {
     | 'infographicB'
     | 'infographicC'
     | 'infographicD'
-    | 'infographicE';
+    | 'infographicE'
+    | 'infographicF';
   style?: Record<string, string>
 }
 
@@ -49,6 +50,12 @@ export const DATA_METRICS: DataMetric[] = [
     label: 'Median',
     chartLabel: 'Median',
     themeColor: 'infographicE'
+  },
+  {
+    id: 'sum',
+    label: 'Sum',
+    chartLabel: 'Sum',
+    themeColor: 'infographicF'
   }
 ];
 

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -26,7 +26,8 @@ export const VEDA_OVERRIDE_THEME = {
     infographicB: '#6138BE', // Ave
     infographicC: '#83868A', // Max
     infographicD: '#F2F2F2', // STD
-    infographicE: '#3094E3' // Median
+    infographicE: '#3094E3', // Median
+    infographicF: '#6138BE' // Sum
   },
   type: {
     base: {

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -27,7 +27,7 @@ export const VEDA_OVERRIDE_THEME = {
     infographicC: '#83868A', // Max
     infographicD: '#F2F2F2', // STD
     infographicE: '#3094E3', // Median
-    infographicF: '#6138BE' // Sum
+    infographicF: '#1D5C5D' // Sum
   },
   type: {
     base: {

--- a/docs/content/frontmatter/layer.md
+++ b/docs/content/frontmatter/layer.md
@@ -245,6 +245,7 @@ Available metrics:
 - max (Max)
 - std (Standard Deviation)
 - median (Median)
+- sum (Sum)
 
 **analysis.sourceParams** 
 `object`


### PR DESCRIPTION
**Related Ticket:** 

Closing https://github.com/NASA-IMPACT/veda-ui/issues/911

### Description of Changes

Adding an option for showing the sum of all pixels in an analyzed area, in the analysis feature of the Exploration & Analysis interface.

### Notes & Questions About Changes

- [x] Added parameters
- [x] Tested functioning
- [x] Validated results
- [x] Checked with @faustoperez about line color - used `#1D5C5D` 
   ![image](https://github.com/NASA-IMPACT/veda-ui/assets/3404817/67723ab8-706c-4f19-955f-d0c9a0fd5676)


### Validation / Testing

1. In E&A, calculate statistics for a region of interest
2. From the chart options, select sum