### PR TITLE
Follow up for R2 

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -47,6 +47,7 @@ const FilterOptionsWrapper = styled.div`
 const DropButton = styled(Button)`
   max-width: 12rem;
   > span {
+    max-width: 5rem;
     ${truncated()}
   }
 

--- a/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
+++ b/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
@@ -7,7 +7,7 @@ import {
   CollecticonDiscXmark,
   CollecticonArrowSpinCcw,
 } from '@devseed-ui/collecticons';
-import { glsp } from '@devseed-ui/theme-provider';
+import { glsp, truncated } from '@devseed-ui/theme-provider';
 import usePresetAOI from '../hooks/use-preset-aoi';
 
 const analysisStatesPreset = ["Alabama",
@@ -110,9 +110,7 @@ const OptionValueDisplay = styled.div`
   pointer-events: none;
   span {
     width: 85%;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    ${truncated()}
   }
 `;
 

--- a/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
+++ b/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
@@ -137,7 +137,6 @@ export default function PresetSelector({ selectedState, setSelectedState, onConf
       >
         <option> Analyze an area </option>
         <optgroup label='Country' />
-          <option value='United States'> United States</option>
           <option value='United States (Contiguous)'> Contiguous United States (CONUS)</option>
         <optgroup label='State' />
         {sortedPresets.map(e => {

--- a/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
+++ b/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
@@ -3,9 +3,11 @@ import styled, { css, keyframes } from 'styled-components';
 import { Feature, Polygon } from 'geojson';
 import { Button } from '@devseed-ui/button';
 import {
+  CollecticonChevronDownSmall,
   CollecticonDiscXmark,
   CollecticonArrowSpinCcw,
 } from '@devseed-ui/collecticons';
+import { glsp } from '@devseed-ui/theme-provider';
 import usePresetAOI from '../hooks/use-preset-aoi';
 
 const analysisStatesPreset = ["Alabama",
@@ -60,7 +62,19 @@ const analysisStatesPreset = ["Alabama",
 "West Virginia",
 "Wisconsin",
 "Wyoming"
-].map(e => ({label: e, value: e}));
+].map(e => ({group: 'state', label: e, value: e}));
+
+const analysisCountryPreset = [
+  {
+    group: 'country',
+    label: 'Contiguous United States (CONUS)',
+    value: 'United States (Contiguous)'
+  }
+];
+const analysisPresets = [
+  ...analysisStatesPreset,
+  ...analysisCountryPreset
+];
 
 // Disabling no mutating rule since we are mutating the copy
 // eslint-disable-next-line fp/no-mutating-methods
@@ -77,6 +91,29 @@ const SelectorWrapper = styled.div`
 const PresetSelect = styled.select`
   max-width: 200px;
   height: ${selectorHeight};
+  color: transparent;
+  background: none;
+  option { 
+    color: black;
+  }
+`;
+// This div is just to display the value with trucnated texts
+const OptionValueDisplay = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  padding: ${glsp(0.125)};
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  pointer-events: none;
+  span {
+    width: 85%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
 `;
 
 const SelectorSubAction = css`
@@ -127,8 +164,12 @@ export default function PresetSelector({ selectedState, setSelectedState, onConf
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[features]);
 
+  const currentlySelected = analysisPresets.find(e => e.value === selectedState);
+
   return (
     <SelectorWrapper>
+      <OptionValueDisplay><span>{currentlySelected? currentlySelected.label: 'Analyze an area'} </span><CollecticonChevronDownSmall /></OptionValueDisplay>
+      
       <PresetSelect
         id='preset-selector'
         name='presetSelector'
@@ -137,7 +178,11 @@ export default function PresetSelector({ selectedState, setSelectedState, onConf
       >
         <option> Analyze an area </option>
         <optgroup label='Country' />
-          <option value='United States (Contiguous)'> Contiguous United States (CONUS)</option>
+        {
+          analysisCountryPreset.map(e => {
+            return (<option key={`${e.value}-option-analysis`} value={e.value}>{e.label}</option>);
+          })
+        }
         <optgroup label='State' />
         {sortedPresets.map(e => {
           return (<option key={`${e.value}-option-analysis`} value={e.value}>{e.label}</option>);

--- a/app/scripts/components/data-catalog/container.tsx
+++ b/app/scripts/components/data-catalog/container.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { allDatasetsWithEnhancedLayers } from '$components/exploration/data-utils';
+import { allDatasets } from '$components/exploration/data-utils';
 import DataCatalog from '$components/data-catalog';
 
 // @VEDA2-REFACTOR-WORK
@@ -10,7 +10,7 @@ import DataCatalog from '$components/data-catalog';
 export default function DataCatalogContainer() {
   return (
     <>
-      <DataCatalog datasets={allDatasetsWithEnhancedLayers} />
+      <DataCatalog datasets={allDatasets} />
     </>
   );
 }

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import styled from 'styled-components';
-import { DatasetData, datasetTaxonomies, getString } from 'veda';
+import { DatasetData, getString } from 'veda';
 import { Link, useNavigate } from 'react-router-dom';
 import { themeVal } from '@devseed-ui/theme-provider';
 import { VerticalDivider } from '@devseed-ui/toolbar';
@@ -32,11 +32,12 @@ import TextHighlight from '$components/common/text-highlight';
 import { Pill } from '$styles/pill';
 import { FeaturedDatasets } from '$components/common/featured-slider-section';
 import { CardSourcesList } from '$components/common/card-sources';
-import { DatasetDataWithEnhancedLayers } from '$components/exploration/data-utils';
+import { DatasetDataWithEnhancedLayers, allDatasets } from '$components/exploration/data-utils';
 import {
   getAllTaxonomyValues,
   getTaxonomy,
   getTaxonomyByIds,
+  generateTaxonomies,
   TAXONOMY_SOURCE,
   TAXONOMY_TOPICS
 } from '$utils/veda-data';
@@ -188,6 +189,8 @@ function DataCatalog({ datasets }: DataCatalogProps) {
   const { taxonomies, sortField, sortDir, onAction } = controlVars;
   const search = controlVars.search ?? '';
   let urlTaxonomyItems: OptionItem[] = [];
+
+  const datasetTaxonomies = generateTaxonomies(allDatasets);
 
   if (taxonomies) {
     urlTaxonomyItems = Object.entries(taxonomies).map(([key, val]) => getTaxonomyByIds(key, val, datasetTaxonomies)).flat() || [];

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -32,7 +32,6 @@ import TextHighlight from '$components/common/text-highlight';
 import { Pill } from '$styles/pill';
 import { FeaturedDatasets } from '$components/common/featured-slider-section';
 import { CardSourcesList } from '$components/common/card-sources';
-import { DatasetDataWithEnhancedLayers, allDatasets } from '$components/exploration/data-utils';
 import {
   getAllTaxonomyValues,
   getTaxonomy,
@@ -45,6 +44,7 @@ import { DatasetClassification } from '$components/common/dataset-classification
 import { variableBaseType, variableGlsp } from '$styles/variable-utils';
 import { OptionItem } from '$components/common/form/checkable-filter';
 import { usePreviousValue } from '$utils/use-effect-previous';
+import { getAllDatasetsWithEnhancedLayers } from '$components/exploration/data-utils';
 
 const BrowseFoldHeader = styled(FoldHeader)`
   margin-bottom: 4rem;
@@ -176,7 +176,7 @@ export const prepareDatasets = (
 };
 
 export interface DataCatalogProps {
-  datasets: DatasetDataWithEnhancedLayers[]
+  datasets: DatasetData[];
 }
 
 function DataCatalog({ datasets }: DataCatalogProps) {
@@ -190,14 +190,16 @@ function DataCatalog({ datasets }: DataCatalogProps) {
   const search = controlVars.search ?? '';
   let urlTaxonomyItems: OptionItem[] = [];
 
-  const datasetTaxonomies = generateTaxonomies(allDatasets);
+  const datasetTaxonomies = generateTaxonomies(datasets);
 
   if (taxonomies) {
     urlTaxonomyItems = Object.entries(taxonomies).map(([key, val]) => getTaxonomyByIds(key, val, datasetTaxonomies)).flat() || [];
   }
 
+  const allDatasetsWithEnhancedLayers = React.useMemo(() => getAllDatasetsWithEnhancedLayers(datasets), [datasets]);
+
   const [datasetsToDisplay, setDatasetsToDisplay] = React.useState<DatasetData[]>(
-    prepareDatasets(datasets, {
+    prepareDatasets(allDatasetsWithEnhancedLayers, {
     search,
     taxonomies,
     sortField,
@@ -246,7 +248,7 @@ function DataCatalog({ datasets }: DataCatalogProps) {
   }, [allSelectedFilters]);
 
   React.useEffect(() => {
-    const updated = prepareDatasets(datasets, {
+    const updated = prepareDatasets(allDatasetsWithEnhancedLayers, {
       search,
       taxonomies,
       sortField,

--- a/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/header.tsx
@@ -1,6 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from 'styled-components';
-import { datasetTaxonomies } from 'veda';
 import {
   ModalHeadline
 } from '@devseed-ui/modal';
@@ -12,6 +11,10 @@ import {
   TaxonomyFilterOption,
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
+import {
+  allExploreDatasetsWithEnhancedLayers as allDatasets
+} from '$components/exploration/data-utils';
+import { generateTaxonomies } from '$utils/veda-data';
 import { sortOptions } from '$components/data-catalog';
 
 const StyledModalHeadline = styled(ModalHeadline)`
@@ -22,9 +25,9 @@ export default function RenderModalHeader ({defaultSelect}: {defaultSelect?: Tax
   const controlVars = useBrowserControls({
     sortOptions
   });
-
-  React.useEffect(() => {
-    if(defaultSelect) {
+  const datasetTaxonomies = generateTaxonomies(allDatasets);
+  useEffect(() => {
+    if (defaultSelect) {
       controlVars.onAction(Actions.TAXONOMY, { key: defaultSelect.taxonomyType, value: defaultSelect.value });
     }
   }, [defaultSelect]);

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -63,7 +63,7 @@ function enhanceDatasetLayers(dataset) {
 
 export const allExploreDatasetsWithEnhancedLayers: DatasetDataWithEnhancedLayers[] = allExploreDatasets.map(enhanceDatasetLayers);
 
-export const allDatasetsWithEnhancedLayers: DatasetDataWithEnhancedLayers[] = allDatasets.map(enhanceDatasetLayers);
+export const getAllDatasetsWithEnhancedLayers = (dataset): DatasetDataWithEnhancedLayers[] => dataset.map(enhanceDatasetLayers);
 
 export const datasetLayers = Object.values(veda_datasets)
   .flatMap((dataset) => {

--- a/app/scripts/utils/veda-data.ts
+++ b/app/scripts/utils/veda-data.ts
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
+import { uniqBy } from 'lodash';
 import {
   stories,
   datasets,
   DatasetData,
   StoryData,
-  Taxonomy
+  Taxonomy,
+  TaxonomyItem
 } from 'veda';
 
 import { MDXContent, MDXModule } from 'mdx/types';
@@ -94,6 +96,27 @@ export function useMdxPageLoader(loader?: () => Promise<MDXModule>) {
 
   return pageMdx;
 }
+
+export function generateTaxonomies(data): Taxonomy[] {
+  const concat = (arr, v) => (arr || []).concat(v);
+
+  const taxonomyData = {};
+  // for loops are faster than reduces.
+  for (const { taxonomy } of data) {
+    for (const { name, values } of taxonomy) {
+      if (!name || !values?.length) continue;
+      taxonomyData[name] = concat(taxonomyData[name], values);
+    }
+  }
+
+  const taxonomiesUnique = Object.entries(taxonomyData).map(([key, tx]): Taxonomy => ({
+    name: key,
+    // eslint-disable-next-line fp/no-mutating-methods
+    values: uniqBy(tx as TaxonomyItem[], (t) => t.id).sort((a, b) => a.name.localeCompare(b.name)) as TaxonomyItem[]
+  }));
+  return taxonomiesUnique;
+}
+
 
 // Taxonomies with special meaning as they're used in the app, like in the cards
 // for example.

--- a/app/scripts/utils/veda-data.ts
+++ b/app/scripts/utils/veda-data.ts
@@ -12,6 +12,7 @@ import {
 
 import { MDXContent, MDXModule } from 'mdx/types';
 import { S_IDLE, S_LOADING, S_SUCCEEDED } from './status';
+import { DatasetDataWithEnhancedLayers } from '$components/exploration/data-utils';
 
 /**
  * List with the meta information of all datasets.
@@ -97,7 +98,7 @@ export function useMdxPageLoader(loader?: () => Promise<MDXModule>) {
   return pageMdx;
 }
 
-export function generateTaxonomies(data): Taxonomy[] {
+export function generateTaxonomies(data: DatasetDataWithEnhancedLayers[] | DatasetData[]): Taxonomy[] {
   const concat = (arr, v) => (arr || []).concat(v);
 
   const taxonomyData = {};

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -264,14 +264,10 @@ export interface LayerInfo {
   export const stories: VedaData<StoryData>;
 
   /**
-   * Named exports: datasetTaxonomies.
-   * Array with all the veda datasets taxonomies.
-   */
-  export const datasetTaxonomies: Taxonomy[];
-
-  /**
    * Named exports: storyTaxonomies.
-   * Array with all the veda story taxonomies.
+   * Contains a static array of Veda story taxonomies.
+   * Unlike DatasetTaxonomies which are generated dynamically,
+   * story taxonomies are predefined as dynamic filters are not anticipated.
    */
   export const storyTaxonomies: Taxonomy[];
 

--- a/parcel-resolver-veda/index.js
+++ b/parcel-resolver-veda/index.js
@@ -199,10 +199,6 @@ module.exports = new Resolver({
 
         export const theme = ${JSON.stringify(result.theme) || null};
 
-        export const datasetTaxonomies = ${generateTaxonomiesModuleOutput(
-          datasetsData.data
-        )}
-
         export const storyTaxonomies = ${generateTaxonomiesModuleOutput(
           storiesData.data
         )}


### PR DESCRIPTION
**Related Ticket:** Portions of https://github.com/NASA-IMPACT/veda-ui/issues/926 , https://github.com/NASA-IMPACT/veda-ui/issues/924

### Description of Changes
- Generate taxonomies depending on datasets
- Truncate texts on Preset Selector
- Truncate texts on BrowseControl 
- Leave only CONUS for country option

### Notes & Questions About Changes

I moved the part that generates taxonomies of the dataset to source code, but did not move the ones which generates taxonomies of stories. (It might be worth moving it since we want to move towards not using veda-resolver in the future?) 

### Validation / Testing
Check if the changes in the descriptions are reflected.
