### PR TITLE
Floating Data Catalog Filters Sidebar Follow-up and starting some cleaning and modularizing

### DIFF
--- a/app/scripts/components/common/form/checkable-filter/index.tsx
+++ b/app/scripts/components/common/form/checkable-filter/index.tsx
@@ -74,7 +74,7 @@ interface CheckableFiltersProps {
     item?: OptionItem;
     callback?: React.Dispatch<React.SetStateAction<any>>;
   }
-  showFiltersOpened?: boolean;
+  calculateHeightCallback?: (height: number) => void;
 }
 
 export interface OptionItem {
@@ -84,10 +84,18 @@ export interface OptionItem {
 }
 
 export default function CheckableFilters(props: CheckableFiltersProps) {
-  const {items, title, onChanges, globallySelected, tagItemCleared} = props;
-  const [show, setShow] = useState<boolean>(props.showFiltersOpened ?? true);
+  const {
+    items,
+    title,
+    onChanges,
+    globallySelected,
+    tagItemCleared,
+    calculateHeightCallback
+  } = props;
+  const [show, setShow] = useState<boolean>(true);
   const [count, setCount] = useState<number>(0);
   const [selected, setSelected] = useState<OptionItem[]>([]);
+  const targetRef = React.useRef<HTMLDivElement>(null);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const idInfo = e.target.id.split('&&');
@@ -115,6 +123,13 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
   const isChecked = (item: OptionItem) => globallySelected.some((selected) => selected.id == item.id && selected.taxonomy == item.taxonomy);
   
   useEffect(() => {
+    if(targetRef.current && calculateHeightCallback) {
+      const height = targetRef.current.offsetHeight;
+      calculateHeightCallback(height);
+    }
+  }, [targetRef]);
+
+  useEffect(() => {
     if(!globallySelected || globallySelected.length === 0) {
       setCount(0);
     }
@@ -135,7 +150,7 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
   }, [tagItemCleared, globallySelected]);
 
   return (
-    <FilterMenu>
+    <FilterMenu ref={targetRef}>
       <FilterTitle>
         <div id='title-selected'>
           <CardTitle>{title}</CardTitle>

--- a/app/scripts/components/common/form/checkable-filter/index.tsx
+++ b/app/scripts/components/common/form/checkable-filter/index.tsx
@@ -74,7 +74,6 @@ interface CheckableFiltersProps {
     item?: OptionItem;
     callback?: React.Dispatch<React.SetStateAction<any>>;
   }
-  calculateHeightCallback?: (height: number) => void;
 }
 
 export interface OptionItem {
@@ -89,13 +88,11 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
     title,
     onChanges,
     globallySelected,
-    tagItemCleared,
-    calculateHeightCallback
+    tagItemCleared
   } = props;
   const [show, setShow] = useState<boolean>(true);
   const [count, setCount] = useState<number>(0);
   const [selected, setSelected] = useState<OptionItem[]>([]);
-  const targetRef = React.useRef<HTMLDivElement>(null);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const idInfo = e.target.id.split('&&');
@@ -121,13 +118,6 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
   }, [selected]);
 
   const isChecked = (item: OptionItem) => globallySelected.some((selected) => selected.id == item.id && selected.taxonomy == item.taxonomy);
-  
-  useEffect(() => {
-    if(targetRef.current && calculateHeightCallback) {
-      const height = targetRef.current.offsetHeight;
-      calculateHeightCallback(height);
-    }
-  }, [targetRef]);
 
   useEffect(() => {
     if(!globallySelected || globallySelected.length === 0) {
@@ -150,7 +140,7 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
   }, [tagItemCleared, globallySelected]);
 
   return (
-    <FilterMenu ref={targetRef}>
+    <FilterMenu>
       <FilterTitle>
         <div id='title-selected'>
           <CardTitle>{title}</CardTitle>

--- a/app/scripts/components/common/form/checkable-filter/index.tsx
+++ b/app/scripts/components/common/form/checkable-filter/index.tsx
@@ -10,7 +10,7 @@ import { CardTitle } from '$components/common/card/styles';
 
 const FilterMenu = styled.div`
   border: 2px solid ${themeVal('color.base-200')};
-  border-radius: 4px;
+  border-radius: ${themeVal('shape.rounded')};
   padding: 12px;
   margin-bottom: 1.5rem;
 `;
@@ -74,6 +74,7 @@ interface CheckableFiltersProps {
     item?: OptionItem;
     callback?: React.Dispatch<React.SetStateAction<any>>;
   }
+  showFiltersOpened?: boolean;
 }
 
 export interface OptionItem {
@@ -84,7 +85,7 @@ export interface OptionItem {
 
 export default function CheckableFilters(props: CheckableFiltersProps) {
   const {items, title, onChanges, globallySelected, tagItemCleared} = props;
-  const [show, setShow] = useState<boolean>(false);
+  const [show, setShow] = useState<boolean>(props.showFiltersOpened ?? true);
   const [count, setCount] = useState<number>(0);
   const [selected, setSelected] = useState<OptionItem[]>([]);
 

--- a/app/scripts/components/data-catalog/container.tsx
+++ b/app/scripts/components/data-catalog/container.tsx
@@ -1,16 +1,32 @@
 import React from 'react';
+import { getString } from 'veda';
 import { allDatasets } from '$components/exploration/data-utils';
 import DataCatalog from '$components/data-catalog';
+import { PageMainContent } from '$styles/page';
+import { LayoutProps } from '$components/common/layout-root';
+import PageHero from '$components/common/page-hero';
+import { FeaturedDatasets } from '$components/common/featured-slider-section';
 
-// @VEDA2-REFACTOR-WORK
-
-// @NOTE: This container component serves as a wrapper for the purpose of data management, this is ONLY to support current instances. 
-// veda2 instances can just use the direct component, 'DataCatalog', and manage data directly in their page views
+/**
+ * @VEDA2-REFACTOR-WORK
+ * 
+ * @NOTE: This container component serves as a wrapper for the purpose of data management, this is ONLY to support current instances. 
+ * veda2 instances can just use the direct component, 'DataCatalog', and manage data directly in their page views
+ */
 
 export default function DataCatalogContainer() {
   return (
-    <>
+    <PageMainContent>
+      <LayoutProps
+        title='Data Catalog'
+        description={getString('dataCatalogBanner').other}
+      />
+      <PageHero
+        title='Data Catalog'
+        description={getString('dataCatalogBanner').other}
+      />
+      <FeaturedDatasets />
       <DataCatalog datasets={allDatasets} />
-    </>
+    </PageMainContent>
   );
 }

--- a/app/scripts/components/data-catalog/filters-control.tsx
+++ b/app/scripts/components/data-catalog/filters-control.tsx
@@ -36,9 +36,10 @@ export default function FiltersControl(props: FiltersMenuProps) {
     setClearedTagItem
   } = props;
 
-  const controlRef = useRef<HTMLDivElement>(null);
+  const controlsRef = useRef<HTMLDivElement>(null);
   const [controlsHeight, setControlsHeight] =  useState<number>(0);
   const { isHeaderHidden, wrapperHeight } = useSlidingStickyHeader();
+
 
   const handleChanges = useCallback((item: OptionItem) => {
     if(allSelected.some((selected) => selected.id == item.id && selected.taxonomy == item.taxonomy)) {
@@ -52,9 +53,9 @@ export default function FiltersControl(props: FiltersMenuProps) {
   }, [allSelected, setClearedTagItem, onChangeToFilters]);
 
   useEffect(() => {
-    if (!controlRef.current) return;
+    if (!controlsRef.current) return;
     
-    const height = controlRef.current.offsetHeight;
+    const height = controlsRef.current.offsetHeight;
     setControlsHeight(height);
     // Observe the height change of controls (from accordion folding)
     const resizeObserver = new ResizeObserver(([entry]) => {
@@ -64,14 +65,14 @@ export default function FiltersControl(props: FiltersMenuProps) {
         setControlsHeight(borderBoxSize.blockSize);
       }
     });
-    resizeObserver.observe(controlRef.current);
+    resizeObserver.observe(controlsRef.current);
     return () => resizeObserver.disconnect(); // clean up 
-  }, [controlRef]);
+  }, [controlsRef]);
 
 
   return (
     <ControlsWrapper widthValue={width} heightValue={controlsHeight+'px'} topValue={isHeaderHidden? '0px': `${wrapperHeight}px`}>
-      <div ref={controlRef}>
+      <div ref={controlsRef}>
         <SearchField
           size='large'
           placeholder='Search by title, description'

--- a/app/scripts/components/data-catalog/filters-control.tsx
+++ b/app/scripts/components/data-catalog/filters-control.tsx
@@ -10,7 +10,7 @@ const ControlsWrapper = styled.div<{ width?: string; height?: string }>`
   width: ${props => props.width ?? '20rem'};
   position: sticky;
   top: 0;
-  ${props => props.height == '100%' ? `height: props.height` : `height: calc(100vh + ${props.height}px)` };
+  height: ${props => props.height == '100%' ? `${props.height}` : `calc(100vh + ${props.height}px)`};
 `;
 
 interface FiltersMenuProps extends ReturnType<typeof useBrowserControls> {

--- a/app/scripts/components/data-catalog/filters-control.tsx
+++ b/app/scripts/components/data-catalog/filters-control.tsx
@@ -7,7 +7,10 @@ import { Actions, useBrowserControls } from '$components/common/browse-controls/
 
 const ControlsWrapper = styled.div<{ width?: string; }>`
   min-width: 20rem;
-  width: ${props => props.width ?? '3rem'};
+  width: ${props => props.width ?? '20rem'};
+  position: sticky;
+  top: 0;
+  height: 100vh;
 `;
 
 interface FiltersMenuProps extends ReturnType<typeof useBrowserControls> {
@@ -42,6 +45,10 @@ export default function FiltersControl(props: FiltersMenuProps) {
     }
   }, [allSelected, setClearedTagItem, onChangeToFilters]);
 
+
+  const displayFiltersOpened = React.useMemo(() => taxonomiesOptions.length > 4 ? false : true, [taxonomiesOptions]);
+
+
   return (
     <ControlsWrapper width={width}>
       <SearchField
@@ -61,6 +68,7 @@ export default function FiltersControl(props: FiltersMenuProps) {
               onChanges={handleChanges}
               globallySelected={allSelected}
               tagItemCleared={{item: clearedTagItem, callback: setClearedTagItem}}
+              showFiltersOpened={displayFiltersOpened}
             />
           );
         })

--- a/app/scripts/components/data-catalog/filters-control.tsx
+++ b/app/scripts/components/data-catalog/filters-control.tsx
@@ -67,8 +67,8 @@ export default function FiltersControl(props: FiltersMenuProps) {
     if (areaHeight && (controlsHeight >= areaHeight)) {
       setHeightStyle('100%');
     } else if (areaHeight) {
-      const diff = areaHeight - controlsHeight;
-      setHeightStyle(`${diff}`);
+      const total = (areaHeight - controlsHeight) / 3;
+      setHeightStyle(`${total}`);
     }
   }, [controlsHeight, areaHeight]);
 

--- a/app/scripts/components/data-catalog/index.tsx
+++ b/app/scripts/components/data-catalog/index.tsx
@@ -55,7 +55,7 @@ const BrowseFoldHeader = styled(FoldHeader)`
 const Content = styled.div`
   display: flex;
   margin-bottom: 8rem;
-  position: sticky;
+  position: relative;
 `;
 
 const CatalogWrapper = styled.div`
@@ -71,10 +71,6 @@ const BrowseSection = styled.div`
   padding-right: ${variableGlsp()};
   gap: ${variableGlsp()};
 `;
-
-// const FilterWrapper = styled.div`
-//   display: block;
-// `;
 
 const Cards = styled(CardList)`
   padding: 0 0 0 2rem;
@@ -142,8 +138,8 @@ function DataCatalog({ datasets }: DataCatalogProps) {
 
   const prevSelectedFilters = usePreviousValue(allSelectedFilters) || [];
 
-  // const targetRef = React.useRef<HTMLDivElement>(null);
-  // const [targetHeight, setTargetHeight] = React.useState<number>(0);
+  const targetRef = React.useRef<HTMLOListElement>(null);
+  const [targetHeight, setTargetHeight] = React.useState<number>(0);
 
   // Handlers
   const handleChangeAllSelectedFilters = React.useCallback((item: OptionItem, action: 'add' | 'remove') => {
@@ -167,12 +163,12 @@ function DataCatalog({ datasets }: DataCatalogProps) {
     setAllSelectedFilters([]);
   }, [setAllSelectedFilters]);
 
-  // React.useEffect(() => {
-  //   if(targetRef.current) {
-  //     const height = targetRef.current.offsetHeight;
-  //     console.log(`height: `, height);
-  //   }
-  // }, [targetRef]);
+  React.useEffect(() => {
+    if(targetRef.current) {
+      const height = targetRef.current.offsetHeight;
+      setTargetHeight(height);
+    }
+  }, [targetRef]);
 
   React.useEffect(() => {
     if (clearedTagItem && (allSelectedFilters.length == prevSelectedFilters.length-1)) {
@@ -233,20 +229,19 @@ function DataCatalog({ datasets }: DataCatalogProps) {
         </FoldHeadline>
       </BrowseFoldHeader>
       <Content>
-        {/* <FilterWrapper ref={targetRef}> */}
-          <FiltersControl
-            {...controlVars}
-            taxonomiesOptions={datasetTaxonomies}
-            onChangeToFilters={handleChangeAllSelectedFilters}
-            clearedTagItem={clearedTagItem}
-            setClearedTagItem={setClearedTagItem}
-            allSelected={allSelectedFilters}
-          />
-        {/* </FilterWrapper> */}
+        <FiltersControl
+          {...controlVars}
+          taxonomiesOptions={datasetTaxonomies}
+          onChangeToFilters={handleChangeAllSelectedFilters}
+          clearedTagItem={clearedTagItem}
+          setClearedTagItem={setClearedTagItem}
+          allSelected={allSelectedFilters}
+          areaHeight={targetHeight}
+        />
         <CatalogWrapper>
           {renderTags}
           {datasetsToDisplay.length ? (
-            <Cards>
+            <Cards ref={targetRef}>
               {datasetsToDisplay.map((d) => {
                 const topics = getTaxonomy(d, TAXONOMY_TOPICS)?.values;
                 const allTaxonomyValues = getAllTaxonomyValues(d).map((v) => v.name);

--- a/app/scripts/components/data-catalog/prepare-datasets.ts
+++ b/app/scripts/components/data-catalog/prepare-datasets.ts
@@ -1,0 +1,82 @@
+import { DatasetData } from 'veda';
+import { optionAll } from '$components/common/browse-controls/use-browse-controls';
+import { TAXONOMY_TOPICS } from '$utils/veda-data';
+
+const prepareDatasets = (
+  data: DatasetData[],
+  options: {
+    search: string;
+    taxonomies: Record<string, string | string[]> | null;
+    sortField: string | null;
+    sortDir: string | null;
+    filterLayers: boolean | null;
+  }
+) => {
+  const { sortField, sortDir, search, taxonomies, filterLayers } = options;
+  let filtered = [...data];
+
+  // Does the free text search appear in specific fields?
+  if (search.length >= 3) {
+    const searchLower = search.toLowerCase();
+    // Function to check if searchLower is included in any of the string fields
+    const includesSearchLower = (str) => str.toLowerCase().includes(searchLower);
+    // Function to determine if a layer matches the search criteria
+    const layerMatchesSearch = (layer) => 
+      includesSearchLower(layer.stacCol) ||
+      includesSearchLower(layer.name) ||
+      includesSearchLower(layer.parentDataset.name) ||
+      includesSearchLower(layer.parentDataset.id) ||
+      includesSearchLower(layer.description);
+
+    filtered = filtered
+      .filter((d) => {
+        // Pre-calculate lowercased versions to use in comparisons
+        const idLower = d.id.toLowerCase();
+        const nameLower = d.name.toLowerCase();
+        const descriptionLower = d.description.toLowerCase();
+        const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
+        // Check if any of the conditions for including the item are met
+        return (
+          idLower.includes(searchLower) ||
+          nameLower.includes(searchLower) ||
+          descriptionLower.includes(searchLower) ||
+          d.layers.some(layerMatchesSearch) ||
+          topicsTaxonomy?.values.some((t) => includesSearchLower(t.name))
+        );
+      });
+
+      if (filterLayers)
+        filtered = filtered.map((d) => ({
+          ...d,
+          layers: d.layers.filter(layerMatchesSearch),
+        }));
+  }
+
+  taxonomies &&
+    Object.entries(taxonomies).forEach(([name, value]) => {
+      if (!value.includes(optionAll.id)) {
+        filtered = filtered.filter((d) =>
+          d.taxonomy.some(
+            (t) => t.name === name && t.values.some((v) => value.includes(v.id))
+          )
+        );
+      }
+    });
+
+  sortField &&
+    /* eslint-disable-next-line fp/no-mutating-methods */
+    filtered.sort((a, b) => {
+      if (!a[sortField]) return Infinity;
+
+      return a[sortField]?.localeCompare(b[sortField]);
+    });
+
+  if (sortDir === 'desc') {
+    /* eslint-disable-next-line fp/no-mutating-methods */
+    filtered.reverse();
+  }
+
+  return filtered;
+};
+
+export default prepareDatasets;

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -28,7 +28,8 @@ import {
   TaxonomyFilterOption,
   useBrowserControls
 } from '$components/common/browse-controls/use-browse-controls';
-import { prepareDatasets, sortOptions } from '$components/data-catalog';
+import { sortOptions } from '$components/data-catalog';
+import prepareDatasets from '$components/data-catalog/prepare-datasets';
 import { TAXONOMY_SOURCE, getTaxonomy } from '$utils/veda-data';
 import { usePreviousValue } from '$utils/use-effect-previous';
 


### PR DESCRIPTION
**Related Ticket:**

Closes https://github.com/NASA-IMPACT/veda-ui/issues/926

### Description of Changes
* Make filters sidebar height `100%` when filters sidebar height (when all expanded) is greater than or equaled to the height of all the cards
* Calculate filters sidebar height with `position:sticky` when filters sidebar height (when all expanded) is less than height all of cards
* Display all filters opened now
* Move `prepareDatasets` to own logic file - cleaning
* Move layout components from Data Catalog component into the wrapper - starting to modularize

### Notes & Questions About Changes
**DEMO Here:**
https://www.loom.com/share/5f88edba7ca4422d9f2636464cebf7b6?sid=62ae3536-4174-4de0-adfe-a19b2e4a5893

### Validation / Testing
* Make sure when the height of the filters sidebar (when expanded) is greater than the height of all the cards, the sidebar doesn't behave sticky
* Make sure when the height of the filters sidebar (when expanded) is less than the height of all the cards, the sidebar behaves sticky