### PR TITLE
Use simple select for preset so it can be deleted

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
@@ -168,7 +168,7 @@ function CustomAoI({
     });
     const pids = mbDraw.add(fc);
     setPresetIds(pids);
-    mbDraw.changeMode('simple_static', {
+    mbDraw.changeMode('simple_select', {
       featureIds: pids
     });
 


### PR DESCRIPTION
follow-up of https://github.com/US-GHG-Center/veda-config-ghg/pull/372

This will make the aoi behave like before, but not draggable. (vertex is editable) - this is a quick fix that I Can think of now.
