### PR TITLE
Set public url as a prefix for preset dasta

### DIFF
--- a/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import { getAoiAppropriateFeatures } from './use-custom-aoi';
 
-const presetFilePath = `${process.env.PUBLIC_URL ?? '/'}/public/geo-data/states/`;
+const presetFilePath = `${process.env.PUBLIC_URL ?? ''}/public/geo-data/states/`;
 const presetSuffix = `.geojson`;
 
 function usePresetAOI(selectedState) {

--- a/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
@@ -4,7 +4,7 @@ import axios from 'axios';
 
 import { getAoiAppropriateFeatures } from './use-custom-aoi';
 
-const presetFilePath = `/public/geo-data/states/`;
+const presetFilePath = `${process.env.PUBLIC_URL ?? '/'}/public/geo-data/states/`;
 const presetSuffix = `.geojson`;
 
 function usePresetAOI(selectedState) {

--- a/app/scripts/components/common/meta-tags.js
+++ b/app/scripts/components/common/meta-tags.js
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 const appTitle = process.env.APP_TITLE;
 const baseUrl = window.location.origin;
 
-const defaultMetaImage = `${process.env.PUBLIC_URL ?? '/'}/meta/meta-image.png`;
+const defaultMetaImage = `${process.env.PUBLIC_URL ?? ''}/meta/meta-image.png`;
 
 function MetaTags({ title, description, thumbnail, children }) {
   const theme = useTheme();


### PR DESCRIPTION
Close https://github.com/US-GHG-Center/veda-config-ghg/issues/377
I somehow thought that we were handling baseurl on axios configuration level, but it seems we are not.  

Thanks @slesaad for putting a work-around. - I have a question based on my curiosity - why did preset request work on staging? I think it should have failed since the requests were made directly to staging.earth.gov, not staging.earth.gov/ghgcenter but they worked. Do you have an idea ?