### PR TITLE
Make Node version more flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "engines": {
-    "node": "20.x.x"
+    "node": ">=18.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.16.0",


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/947 follow up of https://github.com/NASA-IMPACT/veda-ui/pull/917

### Description of Changes
I realized that it is better to make the Node version flexible in package.json, so VEDA-UI users don't have to be on exact Node v20. 

### Notes & Questions About Changes
I think v18 is a reasonable choice to be the minimum version number since 1. We don't have a package that requires specific Node version and 2. 18 is the actively maintained Node at this point (https://nodejs.org/en/about/previous-releases) 🤔 Is there any more thing to consider?
