### PR TITLE
Add a preliminary STYLE_GUIDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,5 @@ temp
 tmp
 .tmp
 dist
+.vscode/*
+!.vscode/settings.json.sample

--- a/.vscode/settings.json.sample
+++ b/.vscode/settings.json.sample
@@ -1,0 +1,14 @@
+{
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": "explicit"
+    },
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ]
+}
+  

--- a/docs/development/STYLE_GUIDE.md
+++ b/docs/development/STYLE_GUIDE.md
@@ -1,0 +1,67 @@
+# Style Guide
+
+This style guide is an evolving document and will be updated as the VEDA UI project develops. The following guidelines are designed to streamline the current development experience and ensure consistency among contributors. Please review and adhere to these guidelines when contributing to the project.
+
+## Code Reviews
+
+### Who Resolves PR Comments?
+
+- The PR maker resolves the conversation once the issue is resolved / fixed. The reviewer can start another conversation if the problem persists.
+
+## PR Branching
+
+### Naming for Branches
+
+- Use the related GitHub issue number; if not available, use `hotfix` or `update`.
+
+## Tagging in PRs
+
+### Tagging Developers
+
+- Tag all developers in PRs for now.
+- Ping people in Slack if more than one developer's eyes are needed.
+
+### When to Tag Designer
+
+- Tag Designer when visual/UI changes are introduced.
+- Tag project owner when UX/functionality changes are introduced. Confirm with relevant stakeholders if there are potential conflicts.
+
+### Changes to Open PRs
+
+- When another developer introduces changes to an already open PR, it can go directly to the same branch unless it is an experimental or critical change for which a separate branch might be better.
+
+## Code Conventions
+
+### Inline Code Notes
+
+- Special cases use `@TODO`, `@FIXME`, and `@NOTE` tags for annotations in the code. We also use the temporary `@VEDA2-REFACTOR-WORK` note for core features while working to build a UI library out of VEDA UI
+
+### Folder/File Naming Conventions
+
+- Follow the patterns currently used throughout the project
+
+### ESLint Configuration for VSCode
+
+The project uses `ESLint` and `Prettier` for code formatting and linting which can be configured to ensure consistency:
+
+1. Install the `ESLint` and `Prettier` extensions in VSCode
+2. Open the VSCode settings (`settings.json`)
+3. Add the following configuration to your VSCode `settings.json`:
+
+```
+{
+    ...
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.fixAll.eslint": true
+    },
+    "eslint.validate": [
+        "javascript",
+        "javascriptreact",
+        "typescript",
+        "typescriptreact"
+    ],
+    "prettier.requireConfig": true,
+    "prettier.useEditorConfig": false
+}
+```

--- a/docs/development/STYLE_GUIDE.md
+++ b/docs/development/STYLE_GUIDE.md
@@ -44,7 +44,7 @@ This style guide is an evolving document and will be updated as the VEDA UI proj
 
 To maintain consistent code formatting and linting across all contributors, follow these steps to configure your VS Code settings according to the project's guidelines:
 
-1. Navigate to the `.vscode` directory at the root of the project. If it doesn't exist, create it
+1. Navigate to the `.vscode` directory at the root of the project
 2. Copy the `settings.json.sample` file from the veda-ui repository
 3. Rename the copied file to `settings.json`
 4. Customize the `settings.json` file with your personal preferences as needed

--- a/docs/development/STYLE_GUIDE.md
+++ b/docs/development/STYLE_GUIDE.md
@@ -51,9 +51,10 @@ The project uses `ESLint` and `Prettier` for code formatting and linting which c
 ```
 {
     ...
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": true
+        "source.fixAll.eslint": "explicit"
     },
     "eslint.validate": [
         "javascript",
@@ -62,6 +63,5 @@ The project uses `ESLint` and `Prettier` for code formatting and linting which c
         "typescriptreact"
     ],
     "prettier.requireConfig": true,
-    "prettier.useEditorConfig": false
 }
 ```

--- a/docs/development/STYLE_GUIDE.md
+++ b/docs/development/STYLE_GUIDE.md
@@ -40,28 +40,11 @@ This style guide is an evolving document and will be updated as the VEDA UI proj
 
 - Follow the patterns currently used throughout the project
 
-### ESLint Configuration for VSCode
+### Recommended VS Code Settings
 
-The project uses `ESLint` and `Prettier` for code formatting and linting which can be configured to ensure consistency:
+To maintain consistent code formatting and linting across all contributors, follow these steps to configure your VS Code settings according to the project's guidelines:
 
-1. Install the `ESLint` and `Prettier` extensions in VSCode
-2. Open the VSCode settings (`settings.json`)
-3. Add the following configuration to your VSCode `settings.json`:
-
-```
-{
-    ...
-    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-    "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": {
-        "source.fixAll.eslint": "explicit"
-    },
-    "eslint.validate": [
-        "javascript",
-        "javascriptreact",
-        "typescript",
-        "typescriptreact"
-    ],
-    "prettier.requireConfig": true,
-}
-```
+1. Navigate to the `.vscode` directory at the root of the project. If it doesn't exist, create it
+2. Copy the `settings.json.sample` file from the veda-ui repository
+3. Rename the copied file to `settings.json`
+4. Customize the `settings.json` file with your personal preferences as needed


### PR DESCRIPTION
**Related Ticket:** [956](https://github.com/NASA-IMPACT/veda-ui/issues/956)

### Description of Changes
Add a preliminary style guide for contributing to the VEDA UI. This is an WIP and an evolving document and will be updated as the VEDA UI project develops and converts to a UI library.

### Notes & Questions About Changes
@hanbyul-here @sandrahoang686 I've added a sample `settings.json` file for recommended VS Code settings for the `veda-ui` repository (based on the linting rules we already use). This will help ensure consistency in code formatting among contributors, including ourselves. Additionally, devs could further customize this file with their own preferences. Please let me know if there is anything else we should add to it as a recommended setting.

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
