### PR TITLE
Fix for the Exploration timeline playheads

### DIFF
--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -173,7 +173,7 @@ export function ExplorationMap(props: ExplorationMapProps) {
           {selectedDay && (
             <ExplorationMapLayers
               datasets={loadedDatasets}
-              selectedDay={selectedDay}
+              selectedDay={selectedCompareDay}
               idSuffix='-compare'
             />
           )}


### PR DESCRIPTION
**Related Ticket:** [981](https://github.com/NASA-IMPACT/veda-ui/issues/981)

### Description of Changes
Fix the `selectedCompareDate` not being sent in the API requests, resulting in a the comparison being broken.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
