### PR TITLE
Bump up the version to 5.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-ui",
   "description": "Dashboard",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
- Fix the `selectedCompareDate` not being sent in the API requests, resulting in a the comparison being broken [981](https://github.com/NASA-IMPACT/veda-ui/issues/981): https://github.com/NASA-IMPACT/veda-ui/pull/982
- Map core feature breakout, [899](https://github.com/NASA-IMPACT/veda-ui/issues/899) https://github.com/NASA-IMPACT/veda-ui/pull/962
- Add a preliminary STYLE_GUIDE.md, [956](https://github.com/NASA-IMPACT/veda-ui/issues/956) https://github.com/NASA-IMPACT/veda-ui/pull/977 
