### PR TITLE
Fix Block validation for the case of lazy loading

### DIFF
--- a/app/scripts/components/common/blocks/index.tsx
+++ b/app/scripts/components/common/blocks/index.tsx
@@ -249,10 +249,23 @@ export function BlockComponent(props: BlockComponentProps) {
   const childrenAsArray = Children.toArray(children);
 
   const childrenComponents: string[] = childrenAsArray.map(
+    (e) => {
     // @ts-expect-error type may not exist depending on the node, but the error
     // will be caught and this won't break.
-    (e) => e.type?.displayName ?? 'undefined'
+    const typeVal = e.type;
+      // When children components are loaded as lazy component - and the component is not resolved yet
+      if (typeVal?._payload && !!typeVal._payload?.value.length) {
+        return typeVal._payload.value[typeVal._payload.value.length-1];
+      // When children components are loaded as lazy component - and the component is resolved
+      } else if (typeVal?._payload?.value?.displayName) {
+        return typeVal._payload.value.displayName;
+      } else {
+        return typeVal?.displayName ?? 'undefined';
+      }
+      
+    }
   );
+
   const childrenNames = childrenComponents.reduce(
     (acc, curr) => acc + curr,
     ''


### PR DESCRIPTION
**Related Ticket:** This fix does not have an independent ticket, but this will remove some of blockers for NEXT JS prototypes + library tickets. 

### Description of Changes
We depend on the static property, `displayName`  to check if the block has children components in an expected way. We cannot access the static properties of the lazy components  (ex. When Block component is loaded as a client component from NEXT instance) in the same way since a lazy component returns Chunk instead of component itself, and saves the component-related properties under `_payload.value`


### Notes & Questions About Changes

Note: I could see the returned value of a lazy component through console, but had a hard time figuring out the actual expected type of the value. (I am still a bit uncertain about this case - https://github.com/NASA-IMPACT/veda-ui/pull/1005/files#diff-140481b3b47ad783893a7ef639e110c3d7e131046499c76299523acb04a6affdR258) Some of the links, references I used are: 
 - An article about how lazy works internally: https://jser.dev/2023-07-25-how-lazy-works-internally/
 - React Lazy source code: https://github.com/facebook/react/blob/107a2f8c3e43ee5f4f6872e68cd9aff14f3fa6d3/packages/react/src/ReactLazy.js#L129

Further question: Do we need this strict validation? Can we give more flexibility to editors while still keeping redable layouts?


### Validation / Testing

Pick the change from this branch, build the library, and use it through Next Instance.
Should check if this doens't bring unnecessary changes to the current use of Blocks 