### PR TITLE
Use VizDataset data type for block map, set a default value for interactive

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -178,9 +178,9 @@ function MapBlock(props: MapBlockProps) {
     return totalLayers;
   },[layerId]);
 
-  const [layers, setLayers] = useState<VizDataset[] | undefined>(layersToFetch);
+  const [layers, setLayers] = useState<VizDataset[]>(layersToFetch);
 
-  useReconcileWithStacMetadata(layersToFetch, setLayers);
+  useReconcileWithStacMetadata(layers, setLayers);
 
   const selectedDatetime: (Date | undefined) = dateTime
     ? utcString2userTzDate(dateTime)
@@ -295,7 +295,7 @@ function MapBlock(props: MapBlockProps) {
         }}
       >
         <Basemap basemapStyleId={mapBasemapId} />
-        {selectedDatetime && layerId && baseDataLayer && (
+        {selectedDatetime && baseDataLayer && (
           <Layer
             key={baseDataLayer.data.id}
             id={`base-${baseDataLayer.data.id}`}
@@ -352,8 +352,7 @@ function MapBlock(props: MapBlockProps) {
         {selectedCompareDatetime && (
           <Compare>
             <Basemap basemapStyleId={mapBasemapId} />
-            {layerId &&
-              compareDataLayer && (
+            {compareDataLayer && (
                 <Layer
                   key={compareDataLayer.data.id}
                   id={`compare-${compareDataLayer.data.id}`}

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import styled from 'styled-components';
+// @NOTE: This should be replaced by types/veda once the changes are consolidated
 import { ProjectionOptions } from 'veda';
 import { MapboxOptions } from 'mapbox-gl';
 import {

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -303,7 +303,6 @@ function MapBlock(props: MapBlockProps) {
         {baseDataLayer?.data.legend && (
           // Map overlay element
           // Layer legend for the active layer.
-          // @NOTE: LayerLegendContainer is in old mapbox directory, may want to move this over to /map directory once old directory is deprecated
           <LayerLegendContainer>
             <LayerLegend
               id={`base-${baseDataLayer.data.id}`}

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -129,6 +129,7 @@ const getDataLayer = (layerIndex: number, layers: VizDataset[] | undefined): (Vi
   if (!layers || layers.length <= layerIndex) return null;
   const layer = layers[layerIndex];
 
+  // @NOTE: What to do when data returns ERROR
   if (layer.status !== DatasetStatus.SUCCESS) return null;
   return {
     ...layer,
@@ -161,19 +162,21 @@ function MapBlock(props: MapBlockProps) {
     throw new HintedError('Malformed Map Block', errors);
   }
 
-  const [baseMapStaticData] = reconcileDatasets([layerId], datasetLayers, []);
-  let layersToFetch = [baseMapStaticData];
-  
-  const baseMapStaticCompareData = baseMapStaticData.data.compare;
-  if (baseMapStaticCompareData && 'layerId' in baseMapStaticCompareData) {
-    const compareLayerId = baseMapStaticCompareData.layerId;
-    const [compareMapStaticData] = reconcileDatasets(
-      compareLayerId ? [compareLayerId] : [],
-      datasetLayers,
-      []
-    );
-    layersToFetch = [...layersToFetch, compareMapStaticData];
-  }
+  const layersToFetch = useMemo(() => {
+    const [baseMapStaticData] = reconcileDatasets([layerId], datasetLayers, []);
+    let totalLayers = [baseMapStaticData];
+    const baseMapStaticCompareData = baseMapStaticData.data.compare;
+    if (baseMapStaticCompareData && 'layerId' in baseMapStaticCompareData) {
+      const compareLayerId = baseMapStaticCompareData.layerId;
+      const [compareMapStaticData] = reconcileDatasets(
+        compareLayerId ? [compareLayerId] : [],
+        datasetLayers,
+        []
+      );
+      totalLayers = [...totalLayers, compareMapStaticData];
+    }
+    return totalLayers;
+  },[layerId]);
 
   const [layers, setLayers] = useState<VizDataset[] | undefined>(layersToFetch);
 

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -28,10 +28,10 @@ import {
   ScaleControl
 } from '$components/common/map/controls';
 import { Layer } from '$components/exploration/components/map/layer';
-import { S_SUCCEEDED } from '$utils/status';
 import {
   VizDataset,
-  VizDatasetSuccess
+  VizDatasetSuccess,
+  DatasetStatus
 } from '$components/exploration/types.d.ts';
 
 import { reconcileDatasets } from '$components/exploration/data-utils';
@@ -197,7 +197,7 @@ function MapBlock(props: MapBlockProps) {
     if (!baseLayers || baseLayers.length !== 1) return null;
     const baseLayer = baseLayers[0];
 
-    if (baseLayer.status !== S_SUCCEEDED) return null;
+    if (baseLayer.status !== DatasetStatus.SUCCESS) return null;
     return {
       ...baseLayer,
       settings: {
@@ -214,7 +214,7 @@ function MapBlock(props: MapBlockProps) {
     if (!compareLayers || compareLayers.length !== 1) return null;
     const compareLayer = compareLayers[0];
 
-    if (compareLayer.status !== S_SUCCEEDED) return null;
+    if (compareLayer.status !== DatasetStatus.SUCCESS) return null;
 
     return {
       ...compareLayer,

--- a/app/scripts/components/common/map/map-component.tsx
+++ b/app/scripts/components/common/map/map-component.tsx
@@ -19,7 +19,7 @@ export default function MapComponent({
   projection,
   mapRef,
   onMapLoad,
-  interactive
+  interactive = true
 }: {
   controls: ReactElement[];
   isCompared?: boolean;

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -204,6 +204,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             'color: red;',
             id
           );
+        // Temporarily turning on log for debugging
+        /* eslint-disable-next-line no-console */
+        console.log(error);
         return;
       }
     };


### PR DESCRIPTION
**Related Ticket:** 
Kind of related to https://github.com/NASA-IMPACT/veda-ui/issues/905 ? We would still need to revisit 'compare' - but I think we can deprecate it soon?

### Description of Changes
- Make BlockMap use the new type `VizDataset.` 
- Simplify some redundant logic (ex. `resolveConfig` now happens at the layer level, so I don't think we need to do it on block map level)
- While working on it, I realized that a new flag, `interactive,` blocks the interaction such as dragging to pan - I set the default value as `true` (which was an implicit value before.)
