### PR TITLE
use getMap for access to hidden member from Scrollytelling

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -303,8 +303,9 @@ function Scrollytelling(props) {
           : undefined;
 
         projection &&
-          // @ts-expect-error setProjection is missing on type
-          mapRef.current?.setProjection(convertProjectionToMapbox(projection));
+          // setProjection is a hidden member, we need access to native map instance via getMap
+          // https://visgl.github.io/react-map-gl/docs/api-reference/map
+          mapRef.current?.getMap().setProjection(convertProjectionToMapbox(projection));
       });
 
     return () => {

--- a/app/scripts/components/sandbox/mdx-scrollytelling/page.mdx
+++ b/app/scripts/components/sandbox/mdx-scrollytelling/page.mdx
@@ -17,11 +17,11 @@
   </Chapter>
   <Chapter
     center={[0, 0]}
-    zoom={2}
+    zoom={0}
     datasetId='no2'
     layerId='no2-monthly-diff'
     datetime='2021-01-01'
-    projectionId='equirectangular'
+    projectionId='globe'
   >
   And now for some NO2
   </Chapter>


### PR DESCRIPTION
**Related Ticket:**
Fix for #1007 

### Description of Changes
Use `getMap` method to access to hidden method (`setProjection`) 

### Notes & Questions About Changes
- Would it be better to return the referenced object from react-map-go instance level? https://github.com/NASA-IMPACT/veda-ui/blob/main/app/scripts/components/common/map/map-component.tsx#L71
- Would it be better to wrap MDX Map component with MapProvider so we can use `useMap` to access mapRef? https://visgl.github.io/react-map-gl/docs/api-reference/use-map

### Validation / Testing
Check the scrolly telling example on sandbox page, see the projection changes.