### PR TITLE
v5.1.2: Use explore only datasets for exploration page

### DIFF
--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -17,7 +17,7 @@ import { timelineDatasetsAtom } from '../../atoms/datasets';
 import {
   reconcileDatasets,
   datasetLayers,
-  allDatasets
+  allExploreDatasets
 } from '../../data-utils';
 import RenderModalHeader from './header';
 import ModalFooterRender from './footer';
@@ -113,7 +113,7 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
       )}
       content={
         <CatalogContent
-          datasets={allDatasets}
+          datasets={allExploreDatasets}
           search={searchTerm}
           taxonomies={taxonomies}
           selectedIds={selectedIds}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "veda-ui",
   "description": "Dashboard",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
**Related Ticket:** #1010 

### Description of Changes
Use Exploration only datasets

### Notes & Questions About Changes


### Validation / Testing
Check if the new E&A page returns the dataset that has the `disableExplore` attribute as true.
