### PR TITLE
Put a hot fix for URL search paramter *WIP*

### DIFF
--- a/.env
+++ b/.env
@@ -11,3 +11,5 @@ API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
 
 # Google form for feedback
 GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'
+
+FEATURE_NEW_EXPLORATION = 'TRUE'

--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -108,8 +108,7 @@ function CatalogContent({
 
   useEffect(() => {
     if (!selectedFilters.length) {
-      onAction(CatalogActions.CLEAR);
-
+      onAction(CatalogActions.CLEAR_TAXONOMY);
       if (!isSelectable) {
         navigate(DATASETS_PATH);
       }
@@ -118,6 +117,13 @@ function CatalogContent({
     setExclusiveSourceSelected(null);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters]);
+
+  // Trigger URL parameter set up first initialized without any search paramter
+  useEffect(() => {
+    if (!search) {
+      onAction(CatalogActions.CLEAR_SEARCH);
+    }
+  }, [search, onAction]);
 
   const getSelectedIdsWithParentData = (selectedIds) => {
     return selectedIds.map((selectedId: string) => {

--- a/app/scripts/components/common/catalog/utils.ts
+++ b/app/scripts/components/common/catalog/utils.ts
@@ -2,6 +2,8 @@ import { omit, set } from 'lodash';
 
 export enum CatalogActions {
   CLEAR = 'clear',
+  CLEAR_TAXONOMY = 'clear_taxonomy',
+  CLEAR_SEARCH = 'clear_search',
   SEARCH = 'search',
   TAXONOMY_MULTISELECT = 'taxonomy_multiselect'
 }
@@ -16,6 +18,14 @@ export function onCatalogAction(
   setTaxonomies: (value: any) => void
 ) {
   switch (action) {
+    case CatalogActions.CLEAR_TAXONOMY: {
+      setTaxonomies({});
+      break;
+    }
+    case CatalogActions.CLEAR_SEARCH: {
+      setSearch('');
+      break;
+    }
     case CatalogActions.CLEAR: {
       setSearch('');
       setTaxonomies({});

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
 import styled from 'styled-components';
 import { useAtom } from 'jotai';
 
@@ -77,8 +79,11 @@ export function DatasetSelectorModal(props: DatasetSelectorModalProps) {
   const { revealed, close } = props;
 
   const [timelineDatasets, setTimelineDatasets] = useAtom(timelineDatasetsAtom);
-
-  const [searchTerm, setSearchTerm] = useState('');
+  // Use the search url paramter for the initial value 
+  const [searchParams] = useSearchParams();
+  const search = searchParams.get('search');
+  
+  const [searchTerm, setSearchTerm] = useState(search?? '');
   const [taxonomies, setTaxonomies] = useState({});
   // Store a list of selected datasets and only confirm on save.
   const [selectedIds, setSelectedIds] = useState<string[]>(


### PR DESCRIPTION
**Related Ticket:**  #1016 

### Description of Changes

Several issues are occurring with data catalog and URL manipulations. I fixed some of them in this PR and hot-glued some of them (I think we can fix them better, though). 

1. The `Search` query parameter is not respected in the Data Catalog: I 'hotfix' it by reading the query parameter directly from the URL when the `search` parameter exists in the URL.
**Now it shows a weird behavior of URL bouncing back to data-catalog When 'Explore data' was clicked from a data overview page, without actually bouncing the page back. 🤔**  
2. The `search` query parameter gets wiped out when the page is loaded: This seems to be because the `CLEAR` action gets triggered on page load, which includes clearing both search terms and taxonomies. I separated these actions out 
3. The `taxonomies` parameters are not being respected when clicked from data overview page. 

### Notes

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
