### PR TITLE
Sort catalog items alphabetically in the E&A modal and the data catalog

### DIFF
--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -37,6 +37,7 @@ export interface CatalogContentProps {
 }
 
 const DEFAULT_SORT_OPTION = 'asc';
+const DEFAULT_SORT_FIELD = 'name';
 
 export const findParentDataset = (layerId: string, datasets) => {
   const parentDataset: DatasetData | undefined = Object.values(datasets).find((dataset: DatasetData) =>
@@ -82,7 +83,7 @@ function CatalogContent({
     prepareDatasets(allDatasetsWithEnhancedLayers, {
     search,
     taxonomies,
-    sortField: DEFAULT_SORT_OPTION,
+    sortField: DEFAULT_SORT_FIELD,
     sortDir: DEFAULT_SORT_OPTION,
     filterLayers: filterLayers ?? false
   }));
@@ -176,7 +177,7 @@ function CatalogContent({
     const updated = prepareDatasets(allDatasetsWithEnhancedLayers, {
       search,
       taxonomies,
-      sortField: DEFAULT_SORT_OPTION,
+      sortField: DEFAULT_SORT_FIELD,
       sortDir: DEFAULT_SORT_OPTION,
       filterLayers: filterLayers ?? false
     });

--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -30,7 +30,7 @@ export function prepareDatasets (
     // Function to check if searchLower is included in any of the string fields
     const includesSearchLower = (str) => str.toLowerCase().includes(searchLower);
     // Function to determine if a layer matches the search criteria
-    const layerMatchesSearch = (layer) => 
+    const layerMatchesSearch = (layer) =>
       includesSearchLower(layer.stacCol) ||
       includesSearchLower(layer.name) ||
       includesSearchLower(layer.parentDataset.name) ||
@@ -79,6 +79,15 @@ export function prepareDatasets (
 
       return a[sortField]?.localeCompare(b[sortField]);
     });
+
+  if (filterLayers && sortField) {
+    filtered = filtered.map((d) => ({
+      ...d,
+      layers:
+        isDatasetData(d) &&
+        d.layers.sort((a, b) => a[sortField]?.localeCompare(b[sortField]) || 0)
+    })) as DatasetData[];
+  }
 
   if (sortDir === 'desc') {
     /* eslint-disable-next-line fp/no-mutating-methods */

--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -10,8 +10,8 @@ const isDatasetData = (data: DatasetData | StoryData): data is DatasetData => {
 interface FilterOptionsType {
   search: string | null;
   taxonomies: Record<string, string | string[]> | null;
-  sortField?: string | null;
-  sortDir?: string | null;
+  sortField?: 'pubDate' | 'name';
+  sortDir?: 'asc' | 'desc';
   filterLayers?: boolean | null;
 }
 

--- a/app/scripts/components/stories/hub/index.tsx
+++ b/app/scripts/components/stories/hub/index.tsx
@@ -63,22 +63,24 @@ const BrowseFoldHeader = styled(FoldHeader)`
 const FoldWithTopMargin = styled(Fold)`
   margin-top: ${glsp()};
 `;
- 
+
 function StoriesHub() {
   const controlVars = useFiltersWithQS();
 
   const { search, taxonomies, onAction } = controlVars;
-  
+
 
   const displayStories = useMemo(
     () =>
       prepareDatasets(allStories, {
         search,
-        taxonomies
+        taxonomies,
+        sortField: 'pubDate',
+        sortDir: 'desc',
       }),
     [search, taxonomies]
   );
-  
+
   const isFiltering = !!(
     (taxonomies && Object.keys(taxonomies).length )||
     search
@@ -160,7 +162,7 @@ function StoriesHub() {
                             }}
                           />
                           <VerticalDivider variation='dark' />
-                          
+
                           {!isNaN(pubDate.getTime()) && (
                               <PublishedDate date={pubDate} />
                           )}


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1038

### Description of Changes
Add fix that sorts catalog content alphabetically by default for the Data Catalog view and the E&A modal. This behavior was there for the Data Catalog before the last release, but not for the old E&A modal (due to it using horizontal cards).

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
1. The filtering, sorting and search work as before for the Data Catalog and the E&A modal
