### PR TITLE
Fix sortField bug

### DIFF
--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -82,7 +82,6 @@ function CatalogContent({
     prepareDatasets(allDatasetsWithEnhancedLayers, {
     search,
     taxonomies,
-    sortField: DEFAULT_SORT_OPTION,
     sortDir: DEFAULT_SORT_OPTION,
     filterLayers: filterLayers ?? false
   }));
@@ -176,7 +175,6 @@ function CatalogContent({
     const updated = prepareDatasets(allDatasetsWithEnhancedLayers, {
       search,
       taxonomies,
-      sortField: DEFAULT_SORT_OPTION,
       sortDir: DEFAULT_SORT_OPTION,
       filterLayers: filterLayers ?? false
     });

--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -7,11 +7,13 @@ const isDatasetData = (data: DatasetData | StoryData): data is DatasetData => {
   return 'layers' in data;
 };
 
+type SortOptions = 'asc' | 'desc';
+
 interface FilterOptionsType {
   search: string | null;
   taxonomies: Record<string, string | string[]> | null;
   sortField?: string | null;
-  sortDir?: string | null;
+  sortDir?: SortOptions | null;
   filterLayers?: boolean | null;
 }
 
@@ -21,7 +23,7 @@ export function prepareDatasets (
   data: DatasetData[] | StoryData[],
   options: FilterOptionsType
 ) {
-  const { sortField, sortDir, search, taxonomies, filterLayers } = options;
+  const { sortField = 'name', sortDir, search, taxonomies, filterLayers } = options;
   let filtered = [...data];
 
   // Does the free text search appear in specific fields?


### PR DESCRIPTION
**Related Ticket:** [_{link related ticket here}_
](https://github.com/NASA-IMPACT/veda-ui/issues/1038)

https://github.com/NASA-IMPACT/veda-ui/issues/1038

### Description of Changes
set `sortField` to default to `'name'`

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
