### PR TITLE
Override the style to leave the button for DatePicker

### DIFF
--- a/app/scripts/components/common/datepicker/index.scss
+++ b/app/scripts/components/common/datepicker/index.scss
@@ -1,14 +1,15 @@
-@use "usa-date-picker/src/styles";
+@use "usa-date-picker/src/styles" as datepicker;
 
 .usa-date-picker {
     position: relative;
-    width: 0;
-    height: 0;
+    // width: 0;
+    // height: 0;
 
     &__calendar {
       width: 20rem;
       position: absolute;
       top: 100%;
+      left: 0;
       border: 1px solid rgb(230, 230, 230);
     }
 
@@ -22,9 +23,16 @@
         z-index: 9999;
     }
 
-    .usa-input,
-    &__button,
-    &__status {
-        display: none;
+    .usa-input {
+    // &__button,
+    // &__status {
+        // pointer-events: none;
+        // background-color: #f6f7f8;
+        // border: 0;
+        display:none;
+    }
+    &__button {
+      height: 3rem;
+      background-image: url("data:image/svg+xml,%3Csvg%20width%3D%2230%22%20height%3D%2215%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20%3E%3Cpolygon%20points%3D'14.586%2C3.586%208%2C10.172%201.414%2C3.586%200%2C5%208%2C13%2016%2C5'%20%2F%3E%3C%2Fsvg%3E");
     }
 }

--- a/app/scripts/components/common/datepicker/index.tsx
+++ b/app/scripts/components/common/datepicker/index.tsx
@@ -37,7 +37,7 @@ export const SimpleDatePicker = ({ disabled, tipContent, onConfirm, id, triggerH
     return (
       <>
         {renderTriggerElement({
-          onClick: toggleCalendar,
+          onClick: () => {},
           disabled,
           tipContent,
           triggerHeadReference,

--- a/app/scripts/components/exploration/components/timeline/timeline-datepicker.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-datepicker.tsx
@@ -52,7 +52,6 @@ export const TimelineDatePicker = ({
         >
           <span className='head-reference'>{triggerHeadReference}</span>
           <span>{moment(selectedDay ?? new Date()).format('MMM Do, YYYY')}</span>
-          <CollecticonChevronDownSmall />
         </DatePickerTrigger>
       )}
     />

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -15,6 +15,9 @@ import CompareImage from './components/common/blocks/images/compare';
 import Embed from './components/common/blocks/embed';
 import TProvider from './theme-provider';
 
+import { LayoutRootContextProvider } from '$components/common/layout-root/context';
+import { ReactQueryProvider } from '$context/react-query';
+
 export {
   DataCatalog,
   Block,
@@ -27,5 +30,7 @@ export {
   Chart,
   Table,
   Embed,
-  TProvider
+  TProvider,
+  LayoutRootContextProvider,
+  ReactQueryProvider
 };

--- a/app/scripts/styles/styles.scss
+++ b/app/scripts/styles/styles.scss
@@ -1,1 +1,2 @@
 @forward 'uswds-theme';
+@use "uswds-helpers/src/styles" as helpers;


### PR DESCRIPTION
I honestly am not sure if this is a better approach. (We will still need to manually trigger the calendar if we want to sync the default calendar view to the temporal resolution.) But opening a pr in case it is any helpful.

preview : https://deploy-preview-1047--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22no2-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22min%22%2C%22label%22%3A%22Min%22%2C%22chartLabel%22%3A%22Min%22%2C%22themeColor%22%3A%22infographicA%22%2C%22style%22%3A%7B%22strokeDasharray%22%3A%222+2%22%7D%7D%2C%7B%22id%22%3A%22max%22%2C%22label%22%3A%22Max%22%2C%22chartLabel%22%3A%22Max%22%2C%22themeColor%22%3A%22infographicC%22%2C%22style%22%3A%7B%22strokeDasharray%22%3A%222+2%22%7D%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2023-12-01T05%3A00%3A00.000Z