### PR TITLE
Update ghg endpoints in mock datasets for testing

### DIFF
--- a/app/scripts/components/sandbox/exploration-map/index.js
+++ b/app/scripts/components/sandbox/exploration-map/index.js
@@ -19,8 +19,8 @@ const mockDatasets = [
     status: 'success',
     data: {
       id: 'casa-gfed-co2-flux-hr',
-      stacApiEndpoint: 'https://ghg.center/api/stac',
-      tileApiEndpoint: 'https://ghg.center/api/raster',
+      stacApiEndpoint: 'https://earth.gov/ghgcenter/api/stac',
+      tileApiEndpoint: 'https://earth.gov/ghgcenter/api/raster',
       stacCol: 'casagfed-carbonflux-monthgrid-v3',
       name: 'Heterotrophic Respiration (Rh)',
       type: 'raster',

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -44,8 +44,8 @@ infoDescription: |
     - Data Latency: Updated annually, following the release of an updated [BP Statistical Review of World Energy report]
 layers:
   - id: casa-gfed-co2-flux
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Net Primary Production (NPP)
     type: raster
@@ -93,8 +93,8 @@ layers:
       temporalResolution: Monthly
       unit: 10¹⁵ molecules cm⁻²
   - id: casa-gfed-co2-flux-hr
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Heterotrophic Respiration (Rh)
     type: raster
@@ -137,8 +137,8 @@ layers:
         - '#92003F'
         - '#67001F'
   - id: casa-gfed-co2-flux-nee
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Net Ecosystem Exchange (NEE)
     type: raster
@@ -179,8 +179,8 @@ layers:
         - '#E26952'
         - '#B40426'
   - id: casa-gfed-co2-flux-fe
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Fire Emissions (FIRE)
     type: raster
@@ -223,8 +223,8 @@ layers:
         - '#92003F'
         - '#67001F'
   - id: casa-gfed-co2-flux-fuel
-    stacApiEndpoint: https://ghg.center/api/stac
-    tileApiEndpoint: https://ghg.center/api/raster
+    stacApiEndpoint: https://earth.gov/ghgcenter/api/stac
+    tileApiEndpoint: https://earth.gov/ghgcenter/api/raster
     stacCol: casagfed-carbonflux-monthgrid-v3
     name: Wood Fuel Emissions (FUEL)
     type: raster


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
We need to update the stac and raster api endpoints pointing at ghg. Selecing `CASA-GFED3` datasets in E&A returns a 500 error. 
❌ `https://ghg.center/api/stac/collections/casagfed-carbonflux-monthgrid-v3` does not work
✔️ `https://earth.gov/ghgcenter/api/stac/collections/casagfed-carbonflux-monthgrid-v3` works

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
