### PR TITLE
Make layer order depend on definitions in the mdx file

### DIFF
--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -80,15 +80,6 @@ export function prepareDatasets (
       return a[sortField]?.localeCompare(b[sortField]);
     });
 
-  if (filterLayers && sortField) {
-    filtered = filtered.map((d) => ({
-      ...d,
-      layers:
-        isDatasetData(d) &&
-        d.layers.sort((a, b) => a[sortField]?.localeCompare(b[sortField]) || 0)
-    })) as DatasetData[];
-  }
-
   if (sortDir === 'desc') {
     /* eslint-disable-next-line fp/no-mutating-methods */
     filtered.reverse();


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
We recently made a change to further order the layers within the datasets in the E&A Modal in alphabetical way. However, the behavior there should be such that:

1. The datasets should be ordered alphabetically
2. The layers within the datasets should depend on their order in the mdx file

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
1. Check that the datasets in the E&A Modal are ordered alphabetically
2. Check that the layers within those datasets in the E&A Modal are ordered as per their order in the mdx file
3. (Optional) Check Data Catalog and that it's ordering is in alphabetical way 
