### PR TITLE
Update Raster API endpoints as part of new version breaking changes

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@ APP_TITLE=VEDA UI
 APP_DESCRIPTION=User interface of module VEDA
 APP_CONTACT_EMAIL=email@example.org
 
-API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
-API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
+API_RASTER_ENDPOINT='https://staging.openveda.cloud/api/raster'
+API_STAC_ENDPOINT='https://staging.openveda.cloud/api/stac'
 
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -274,7 +274,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         /* eslint-enable no-console */
 
         const responseData = await requestQuickCache<any>({
-          url: `${tileApiEndpointToUse}/mosaic/register`,
+          url: `${tileApiEndpointToUse}/searches/register`,
           payload,
           controller
         });

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -274,13 +274,15 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         /* eslint-enable no-console */
         
         let responseData;
-        let fallbackToOld = false;
+
         try {
           responseData = await requestQuickCache<any>({
             url: `${tileApiEndpointToUse}/searches/register`,
             payload,
             controller
           });
+          const mosaicUrl = responseData.links[1].href;
+          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
         } catch (e) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
           if (e.request) {
@@ -290,16 +292,14 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
               payload,
               controller
             });
-            fallbackToOld = true;
+      
+            const mosaicUrl = responseData.links[1].href;
+            setMosaicUrl(mosaicUrl);
+          } else {
+              LOG && 
+                /* eslint-disable-next-line no-console */
+                console.log('Titiler /register endpoint error', 'color: red;', e);
           }
-        }
-        let mosaicUrl = responseData.links[1].href;
-        
-        if (fallbackToOld) { // @NOTE:  conditional logic TO BE REMOVED once new BE endpoints have moved to prod...
-          setMosaicUrl(mosaicUrl);
-        } else {
-          mosaicUrl = mosaicUrl.replace('/{tileMatrixSetId}', '');
-          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', ''));
         }
 
         /* eslint-disable no-console */

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -283,9 +283,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           });
           const mosaicUrl = responseData.links[1].href;
           setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
-        } catch (e) {
+        } catch (error) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
-          if (e.request) {
+          if (error.request) {
             // The request was made but no response was received
             responseData = await requestQuickCache<any>({
               url: `${tileApiEndpointToUse}/mosaic/register`, // @NOTE: This will fail anyways with "staging-raster.delta-backend.com" because its already deprecated...
@@ -298,8 +298,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           } else {
               LOG && 
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register endpoint error', 'color: red;', e);
-              changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
+              console.log('Titiler /register endpoint error', 'color: red;', error);
+              throw error;
           }
         }
 

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -297,8 +297,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             setMosaicUrl(mosaicUrl);
           } else {
               LOG && 
-                /* eslint-disable-next-line no-console */
-                console.log('Titiler /register endpoint error', 'color: red;', e);
+              /* eslint-disable-next-line no-console */
+              console.log('Titiler /register endpoint error', 'color: red;', e);
+              changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
           }
         }
 

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -274,7 +274,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         /* eslint-enable no-console */
         
         let responseData;
-
+        let fallbackToOld = false;
         try {
           responseData = await requestQuickCache<any>({
             url: `${tileApiEndpointToUse}/searches/register`,
@@ -290,10 +290,17 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
               payload,
               controller
             });
+            fallbackToOld = true;
           }
         }
-
-        setMosaicUrl(responseData.links[1].href);
+        let mosaicUrl = responseData.links[1].href;
+        
+        if (fallbackToOld) { // @NOTE:  conditional logic TO BE REMOVED once new BE endpoints have moved to prod...
+          setMosaicUrl(mosaicUrl);
+        } else {
+          mosaicUrl = mosaicUrl.replace('/{tileMatrixSetId}', '');
+          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', ''));
+        }
 
         /* eslint-disable no-console */
         LOG &&

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -298,7 +298,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           } else {
               LOG && 
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register endpoint error', 'color: red;', error);
+              console.log('Titiler /register %cEndpoint error', 'color: red;', error);
               throw error;
           }
         }

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -272,12 +272,26 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         LOG && console.log('Payload', payload);
         LOG && console.groupEnd();
         /* eslint-enable no-console */
+        
+        let responseData;
 
-        const responseData = await requestQuickCache<any>({
-          url: `${tileApiEndpointToUse}/searches/register`,
-          payload,
-          controller
-        });
+        try {
+          responseData = await requestQuickCache<any>({
+            url: `${tileApiEndpointToUse}/searches/register`,
+            payload,
+            controller
+          });
+        } catch (e) {
+          // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
+          if (e.request) {
+            // The request was made but no response was received
+            responseData = await requestQuickCache<any>({
+              url: `${tileApiEndpointToUse}/mosaic/register`, // @NOTE: This will fail anyways with "staging-raster.delta-backend.com" because its already deprecated...
+              payload,
+              controller
+            });
+          }
+        }
 
         setMosaicUrl(responseData.links[1].href);
 

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -298,7 +298,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
           } else {
               LOG && 
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register endpoint error', 'color: red;', error);
+              console.log('Titiler /register %cEndpoint error', 'color: red;', error);
               throw error;
           }
         }

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -283,9 +283,9 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
           });
           const mosaicUrl = responseData.links[1].href;
           setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
-        } catch (e) {
+        } catch (error) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
-          if (e.request) {
+          if (error.request) {
             // The request was made but no response was received
             responseData = await requestQuickCache({
               url: `${tileApiEndpointToUse}/mosaic/register`, // @NOTE: This will fail anyways with "staging-raster.delta-backend.com" because its already deprecated...
@@ -298,8 +298,8 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
           } else {
               LOG && 
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register endpoint error', 'color: red;', e);
-              changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
+              console.log('Titiler /register endpoint error', 'color: red;', error);
+              throw error;
           }
         }
 

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -274,13 +274,15 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         /* eslint-enable no-console */
 
         let responseData;
-        let fallbackToOld = false;
+
         try {
           responseData = await requestQuickCache({
             url: `${tileApiEndpointToUse}/searches/register`,
             payload,
             controller
           });
+          const mosaicUrl = responseData.links[1].href;
+          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
         } catch (e) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
           if (e.request) {
@@ -290,19 +292,15 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
               payload,
               controller
             });
-            fallbackToOld = true;
+            
+            const mosaicUrl = responseData.links[1].href;
+            setMosaicUrl(mosaicUrl);
+          } else {
+              LOG && 
+              /* eslint-disable-next-line no-console */
+              console.log('Titiler /register endpoint error', 'color: red;', e);
           }
         }
-
-        let mosaicUrl = responseData.links[1].href;
-        
-        if (fallbackToOld) { // @NOTE:  conditional logic TO BE REMOVED once new BE endpoints have moved to prod...
-          setMosaicUrl(mosaicUrl);
-        } else {
-          mosaicUrl = mosaicUrl.replace('/{tileMatrixSetId}', '');
-          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', ''));
-        }
-
 
         /* eslint-disable no-console */
         LOG &&

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -274,7 +274,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         /* eslint-enable no-console */
 
         const responseData = await requestQuickCache({
-          url: `${tileApiEndpointToUse}/mosaic/register`,
+          url: `${tileApiEndpointToUse}/searches/register`,
           payload,
           controller
         });

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -273,11 +273,27 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         LOG && console.groupEnd();
         /* eslint-enable no-console */
 
-        const responseData = await requestQuickCache({
-          url: `${tileApiEndpointToUse}/searches/register`,
-          payload,
-          controller
-        });
+        let responseData;
+
+        try {
+          responseData = await requestQuickCache({
+            url: `${tileApiEndpointToUse}/searches/register`,
+            payload,
+            controller
+          });
+        } catch (e) {
+          // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance... 
+          if (e.request) {
+            // The request was made but no response was received
+            responseData = await requestQuickCache({
+              url: `${tileApiEndpointToUse}/mosaic/register`, // @NOTE: This will fail anyways with "staging-raster.delta-backend.com" because its already deprecated...
+              payload,
+              controller
+            });
+          }
+        }
+
+
 
         setMosaicUrl(responseData.links[1].href);
 

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -274,7 +274,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
         /* eslint-enable no-console */
 
         let responseData;
-
+        let fallbackToOld = false;
         try {
           responseData = await requestQuickCache({
             url: `${tileApiEndpointToUse}/searches/register`,
@@ -290,12 +290,19 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
               payload,
               controller
             });
+            fallbackToOld = true;
           }
         }
 
+        let mosaicUrl = responseData.links[1].href;
+        
+        if (fallbackToOld) { // @NOTE:  conditional logic TO BE REMOVED once new BE endpoints have moved to prod...
+          setMosaicUrl(mosaicUrl);
+        } else {
+          mosaicUrl = mosaicUrl.replace('/{tileMatrixSetId}', '');
+          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', ''));
+        }
 
-
-        setMosaicUrl(responseData.links[1].href);
 
         /* eslint-disable no-console */
         LOG &&

--- a/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
+++ b/app/scripts/components/common/mapbox/layers/raster-timeseries.tsx
@@ -299,6 +299,7 @@ export function MapLayerRasterTimeseries(props: MapLayerRasterTimeseriesProps) {
               LOG && 
               /* eslint-disable-next-line no-console */
               console.log('Titiler /register endpoint error', 'color: red;', e);
+              changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
           }
         }
 


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1070

⚠️ **This needs to be coordinated with veda BE team on when this can be merged. BE team needs to merge their changes into their prod before this can merge.**

### Description of Changes
Updating raster api (titiler) endpoints as part of new version breaking changes. This does not worry about integrating new endpoints.

### Notes & Questions About Changes
* [VEDA BACKEND PR](https://github.com/NASA-IMPACT/veda-backend/pull/398) for ref
* [Titiler version migration guide](https://stac-utils.github.io/titiler-pgstac/latest/migrations/v1_migration/#searchid-id) for ref

### Relevant API Changes
[**yes**] rename mosaic/ endpoint to searches/
[**no**] for `/register` endpoints, update `searchId` to `id`
[**no**] a dd new /collections/{collection_id} endpoint
[**no**] add new /colorMaps endpoint
[**no**] rename stac/ endpoint to /collections/{collection_id}/items/{item_id}
[**no**] rename stac-alt/ endpoint to /alt/collections/{collection_id}/items/{item_id}

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
