### PR TITLE
Safelist react-calendar related classes

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -22,8 +22,8 @@ let plugins = [require('autoprefixer'), require('postcss-import')];
 const purge = require('@fullhuman/postcss-purgecss')({
   content: contentPaths,
   safelist: {
-    deep: [/usa-banner$/],
-    greedy: [/^usa-banner/]
+    deep: [/usa-banner$/, /react-calendar$/],
+    greedy: [/^usa-banner/, /^react-calendar/]
   }
 });
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -5,18 +5,33 @@ const CWD = process.cwd();
 const vedaPath = path.resolve(CWD, '.veda/ui');
 const isVedaInstance = fs.existsSync(vedaPath);
 
-let uswdsPath = path.resolve(CWD, 'node_modules/@trussworks/react-uswds/lib');
+let basePath = CWD;
+let uswdsPath = path.resolve(
+  basePath,
+  'node_modules/@trussworks/react-uswds/lib'
+);
+let reactCalendarPath = path.resolve(
+  basePath,
+  'node_modules/react-calendar/dist/**/*.css'
+);
 
-if (isVedaInstance)
+if (isVedaInstance) {
+  basePath = vedaPath;
   uswdsPath = path.resolve(
-    CWD,
-    '.veda/ui',
+    basePath,
     'node_modules/@trussworks/react-uswds/lib'
   );
+  reactCalendarPath = path.resolve(
+    basePath,
+    'node_modules/react-calendar/dist/**/*.css'
+  );
+}
 
-const contentPaths = isVedaInstance
-  ? ['.veda/ui/app/**/*.{js,jsx,ts,tsx}', `${uswdsPath}/index.css`]
-  : ['./app/**/*.{js,jsx,ts,tsx}', `${uswdsPath}/index.css`];
+const contentPaths = [
+  `${basePath}/app/**/*.{js,jsx,ts,tsx}`,
+  `${uswdsPath}/index.css`,
+  reactCalendarPath
+];
 
 let plugins = [require('autoprefixer'), require('postcss-import')];
 const purge = require('@fullhuman/postcss-purgecss')({


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
This PR adds the react-calendar component as part of the safelist for purgeCSS not to remove some of its classes. 

See the [GHG update PR to v4.5.0](https://deploy-preview-456--ghg-demo.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22air-sea-co2%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2022-11-30T23%3A00%3A00.000Z) as an example of how the date picker would look like without this change:

<img width="382" alt="Screenshot 2024-08-02 at 15 00 08" src="https://github.com/user-attachments/assets/5ae32006-f762-4de4-a613-c8e85de384aa">

Should be as the screenshot below:

<img width="371" alt="Screenshot 2024-08-02 at 15 01 33" src="https://github.com/user-attachments/assets/16f8d1d4-7f53-4b52-9fd9-14558191a37d">

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
