### PR TITLE
Update Staging Env Urls to point to New staging endpoints

### DIFF
--- a/.env
+++ b/.env
@@ -2,8 +2,8 @@ APP_TITLE=VEDA UI
 APP_DESCRIPTION=User interface of module VEDA
 APP_CONTACT_EMAIL=email@example.org
 
-API_RASTER_ENDPOINT='https://staging-raster.delta-backend.com'
-API_STAC_ENDPOINT='https://staging-stac.delta-backend.com'
+API_RASTER_ENDPOINT='https://staging.openveda.cloud/api/raster'
+API_STAC_ENDPOINT='https://staging.openveda.cloud/api/stac'
 
 # If the app is being served in from a subfolder, the domain url must be set.
 # For example, if the app is served from /mysite:


### PR DESCRIPTION
**Related Ticket:**  https://github.com/NASA-IMPACT/veda-ui/issues/1070
Related Slack [here](https://developmentseed.slack.com/archives/C045K5LAFA9/p1721849138598079) 

**We need to migrate to the new staging backend endpoints. Backend Docs with new endpoints [here](https://nasa-impact.github.io/veda-docs/services/apis.html)**

### Description of Changes
I noticed that some dataset layers in E&A were returning errors when trying to analyze in E&A page. And then saw this announcement in slack above. When switching to these, i no longer saw the errors.

<img width="1410" alt="Screenshot 2024-08-02 at 10 06 05 AM" src="https://github.com/user-attachments/assets/a326353d-2e4f-428d-b978-81c2843395c6">


### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
* **Manual Validation - check non ghg dataset/layers**
