### PR TITLE
Add isHidden prop for optional hiding of stories

### DIFF
--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -15,20 +15,29 @@ interface FilterOptionsType {
   filterLayers?: boolean | null;
 }
 
-export function prepareDatasets(data: DatasetData[], options: FilterOptionsType): DatasetData[];
-export function prepareDatasets(data: StoryData[], options: FilterOptionsType): StoryData[];
-export function prepareDatasets (
+export function prepareDatasets(
+  data: DatasetData[],
+  options: FilterOptionsType
+): DatasetData[];
+export function prepareDatasets(
+  data: StoryData[],
+  options: FilterOptionsType
+): StoryData[];
+export function prepareDatasets(
   data: DatasetData[] | StoryData[],
   options: FilterOptionsType
 ) {
   const { sortField, sortDir, search, taxonomies, filterLayers } = options;
   let filtered = [...data];
 
+  filtered = filtered.filter((d) => !d.isHidden);
+
   // Does the free text search appear in specific fields?
   if (search && search.length >= 3) {
     const searchLower = search.toLowerCase();
     // Function to check if searchLower is included in any of the string fields
-    const includesSearchLower = (str) => str.toLowerCase().includes(searchLower);
+    const includesSearchLower = (str) =>
+      str.toLowerCase().includes(searchLower);
     // Function to determine if a layer matches the search criteria
     const layerMatchesSearch = (layer) =>
       includesSearchLower(layer.stacCol) ||
@@ -37,28 +46,27 @@ export function prepareDatasets (
       includesSearchLower(layer.parentDataset.id) ||
       includesSearchLower(layer.description);
 
-    filtered = filtered
-      .filter((d) => {
-        // Pre-calculate lowercased versions to use in comparisons
-        const idLower = d.id.toLowerCase();
-        const nameLower = d.name.toLowerCase();
-        const descriptionLower = d.description.toLowerCase();
-        const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
-        // Check if any of the conditions for including the item are met
-        return (
-          idLower.includes(searchLower) ||
-          nameLower.includes(searchLower) ||
-          descriptionLower.includes(searchLower) ||
-          (isDatasetData(d) && d.layers.some(layerMatchesSearch)) ||
-          topicsTaxonomy?.values.some((t) => includesSearchLower(t.name))
-        );
-      });
+    filtered = filtered.filter((d) => {
+      // Pre-calculate lowercased versions to use in comparisons
+      const idLower = d.id.toLowerCase();
+      const nameLower = d.name.toLowerCase();
+      const descriptionLower = d.description.toLowerCase();
+      const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
+      // Check if any of the conditions for including the item are met
+      return (
+        idLower.includes(searchLower) ||
+        nameLower.includes(searchLower) ||
+        descriptionLower.includes(searchLower) ||
+        (isDatasetData(d) && d.layers.some(layerMatchesSearch)) ||
+        topicsTaxonomy?.values.some((t) => includesSearchLower(t.name))
+      );
+    });
 
-      if (filterLayers)
-        filtered = filtered.map((d) => ({
-          ...d,
-          layers: (isDatasetData(d) && d.layers.filter(layerMatchesSearch)),
-        })) as DatasetData[];
+    if (filterLayers)
+      filtered = filtered.map((d) => ({
+        ...d,
+        layers: isDatasetData(d) && d.layers.filter(layerMatchesSearch)
+      })) as DatasetData[];
   }
 
   taxonomies &&

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -5,7 +5,7 @@ import { MDXModule } from 'mdx/types';
 // ///////////////////////////////////////////////////////////////////////////
 //  Datasets                                                                //
 // ///////////////////////////////////////////////////////////////////////////
-export type DatasetLayerType = 'raster' | 'vector' | 'zarr'| 'cmr';
+export type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr';
 
 //
 // Dataset Layers
@@ -26,7 +26,7 @@ interface DatasetLayerCommonCompareProps {
   mapLabel?: string | DatasetDatumFn<DatasetDatumReturnType>;
 }
 
-interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps{
+interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps {
   zoomExtent?: number[];
   bounds?: number[];
   sourceParams?: Record<string, any>;
@@ -35,8 +35,7 @@ interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps{
 export type DatasetDatumFn<T> = (bag: DatasetDatumFnResolverBag) => T;
 export type DatasetDatumReturnType = Primitives | Date;
 
-export interface DatasetLayerCompareSTAC
-  extends DatasetLayerCommonProps {
+export interface DatasetLayerCompareSTAC extends DatasetLayerCommonProps {
   stacCol: string;
   type: DatasetLayerType;
   name: string;
@@ -44,8 +43,7 @@ export interface DatasetLayerCompareSTAC
   legend?: LayerLegendCategorical | LayerLegendGradient;
 }
 
-export interface DatasetLayerCompareInternal
-  extends DatasetLayerCommonProps {
+export interface DatasetLayerCompareInternal extends DatasetLayerCommonProps {
   datasetId: string;
   layerId: string;
 }
@@ -56,10 +54,10 @@ export enum TimeDensity {
   DAY = 'day'
 }
 export interface LayerInfo {
-source: string;
-spatialExtent: string;
-temporalResolution: string;
-unit: string;
+  source: string;
+  spatialExtent: string;
+  temporalResolution: string;
+  unit: string;
 }
 export interface DatasetLayer extends DatasetLayerCommonProps {
   id: string;
@@ -83,7 +81,7 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   assetUrlReplacements?: {
     from: string;
     to: string;
-  },
+  };
   time_density?: TimeDensity;
   info?: LayerInfo;
 }
@@ -91,14 +89,12 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
 // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The
 // difference with a "base" dataset layer is not having a name and
 // description.
-export interface DatasetLayerCompareBase
-  extends DatasetLayerCommonProps {
+export interface DatasetLayerCompareBase extends DatasetLayerCommonProps {
   id: string;
   stacCol: string;
   type: DatasetLayerType;
 }
-export interface DatasetLayerCompareNormalized
-  extends DatasetLayerCommonProps {
+export interface DatasetLayerCompareNormalized extends DatasetLayerCommonProps {
   id: string;
   name: string;
   description: string;
@@ -129,7 +125,6 @@ export interface DatasetDatumFnResolverBag {
 interface LayerLegendUnit {
   label: string;
 }
-
 
 export interface LayerLegendGradient {
   type: 'gradient';
@@ -189,6 +184,7 @@ export interface DatasetData {
   layers: DatasetLayer[];
   related?: RelatedContentData[];
   disableExplore?: boolean;
+  isHidden?: boolean;
 }
 
 // ///////////////////////////////////////////////////////////////////////////
@@ -208,6 +204,7 @@ export interface StoryData {
   taxonomy: Taxonomy[];
   related?: RelatedContentData[];
   asLink?: LinkContentData;
+  isHidden?: boolean;
 }
 
 // ///////////////////////////////////////////////////////////////////////////

--- a/mock/stories/life-of-water.stories.mdx
+++ b/mock/stories/life-of-water.stories.mdx
@@ -22,7 +22,6 @@ related:
     id: no2
   - type: story
     id: external-link-test
-isHidden: true
 ---
 
 <Block>

--- a/mock/stories/life-of-water.stories.mdx
+++ b/mock/stories/life-of-water.stories.mdx
@@ -22,6 +22,7 @@ related:
     id: no2
   - type: story
     id: external-link-test
+isHidden: true
 ---
 
 <Block>

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -7,7 +7,7 @@ declare module 'veda' {
   // ///////////////////////////////////////////////////////////////////////////
   //  Datasets                                                                //
   // ///////////////////////////////////////////////////////////////////////////
-  type DatasetLayerType = 'raster' | 'vector' | 'zarr'| 'cmr';
+  type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr';
 
   //
   // Dataset Layers
@@ -28,7 +28,7 @@ declare module 'veda' {
     mapLabel?: string | DatasetDatumFn<DatasetDatumReturnType>;
   }
 
-  interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps{
+  interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps {
     zoomExtent?: number[];
     bounds?: number[];
     sourceParams?: Record<string, any>;
@@ -36,9 +36,8 @@ declare module 'veda' {
 
   export type DatasetDatumFn<T> = (bag: DatasetDatumFnResolverBag) => T;
   export type DatasetDatumReturnType = Primitives | Date;
-  
-  export interface DatasetLayerCompareSTAC
-    extends DatasetLayerCommonProps {
+
+  export interface DatasetLayerCompareSTAC extends DatasetLayerCommonProps {
     stacCol: string;
     type: DatasetLayerType;
     name: string;
@@ -46,8 +45,7 @@ declare module 'veda' {
     legend?: LayerLegendCategorical | LayerLegendGradient;
   }
 
-  export interface DatasetLayerCompareInternal
-    extends DatasetLayerCommonProps {
+  export interface DatasetLayerCompareInternal extends DatasetLayerCommonProps {
     datasetId: string;
     layerId: string;
   }
@@ -57,12 +55,12 @@ declare module 'veda' {
     MONTH = 'month',
     DAY = 'day'
   }
-export interface LayerInfo {
-  source: string;
-  spatialExtent: string;
-  temporalResolution: string;
-  unit: string;
-}
+  export interface LayerInfo {
+    source: string;
+    spatialExtent: string;
+    temporalResolution: string;
+    unit: string;
+  }
   export interface DatasetLayer extends DatasetLayerCommonProps {
     id: string;
     stacCol: string;
@@ -85,7 +83,7 @@ export interface LayerInfo {
     assetUrlReplacements?: {
       from: string;
       to: string;
-    },
+    };
     time_density?: TimeDensity;
     info?: LayerInfo;
   }
@@ -93,8 +91,7 @@ export interface LayerInfo {
   // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The
   // difference with a "base" dataset layer is not having a name and
   // description.
-  export interface DatasetLayerCompareBase
-    extends DatasetLayerCommonProps {
+  export interface DatasetLayerCompareBase extends DatasetLayerCommonProps {
     id: string;
     stacCol: string;
     type: DatasetLayerType;
@@ -190,6 +187,7 @@ export interface LayerInfo {
     layers: DatasetLayer[];
     related?: RelatedContentData[];
     disableExplore?: boolean;
+    isHidden?: boolean;
   }
 
   // ///////////////////////////////////////////////////////////////////////////
@@ -209,6 +207,7 @@ export interface LayerInfo {
     taxonomy: Taxonomy[];
     related?: RelatedContentData[];
     asLink?: LinkContentData;
+    isHidden?: boolean;
   }
 
   // ///////////////////////////////////////////////////////////////////////////
@@ -251,24 +250,23 @@ export interface LayerInfo {
     id: string;
     name: string;
   }
-    /**
-     * Not exporting this type 
-     * Since we are moving forward to ditching VEDA faux module
-     */
+  /**
+   * Not exporting this type
+   * Since we are moving forward to ditching VEDA faux module
+   */
 
   enum BannerType {
     info = 'info',
-    warning ='warning'
+    warning = 'warning'
   }
-  
+
   const infoTypeFlag = BannerType.info;
   interface BannerData {
-    expires: Date,
-    url: string,
-    text: string,
-    type?: BannerType
+    expires: Date;
+    url: string;
+    text: string;
+    type?: BannerType;
   }
-  
 
   /**
    * Named exports: datasets.


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1088

### Description of Changes
This ticket introduces a `isHidden` prop for both stories and datasets, so that they could be hidden from the appropriate catalogs. If a story has this new prop, then it will not be shown in the stories catalog, but it will still be known to the veda-ui and could be navigated to via routing.

Example with "This is the life of water":

Stories catalog (hidden): https://deploy-preview-1090--veda-ui.netlify.app/stories
Story page: https://deploy-preview-1090--veda-ui.netlify.app/stories/life-of-water

Note: the story will still appear as a featured story unless `isFeatured` is also set to false in the .mdx, so it's pretty configurable.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
