### PR TITLE
Do not render exploration component unless urlAtom is on the right page

### DIFF
--- a/app/scripts/components/exploration/container.tsx
+++ b/app/scripts/components/exploration/container.tsx
@@ -29,9 +29,11 @@ const tourProviderStyles = {
 
 export default function ExplorationAndAnalysisContainer() {
   const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
-  // @NOTE: 
+  // @NOTE: When Exploration page is preloaded (ex. Linked with react-router)
+  // atomWithLocation gets initialized outside of Exploration page and returns the previous page's value
+  // We check if url Atom actually returns the values for exploration page here.
   const [currentUrl]= useAtom(urlAtom);
-  if(!currentUrl.pathname?.includes(EXPLORATION_PATH)) return <></>;
+  if(!currentUrl.pathname?.includes(EXPLORATION_PATH)) return null;
   
   return (
     <TourProvider

--- a/app/scripts/components/exploration/container.tsx
+++ b/app/scripts/components/exploration/container.tsx
@@ -5,9 +5,12 @@ import { useAtom } from 'jotai';
 import { PopoverTourComponent, TourManager } from './tour-manager';
 import { timelineDatasetsAtom } from './atoms/datasets';
 import ExplorationAndAnalysis from '.';
+import { urlAtom } from '$utils/params-location-atom/url';
+import { EXPLORATION_PATH } from '$utils/routes';
 import { PageMainContent } from '$styles/page';
 import { LayoutProps } from '$components/common/layout-root';
 import PageHero from '$components/common/page-hero';
+
 
 /**
  * @VEDA2-REFACTOR-WORK
@@ -26,7 +29,10 @@ const tourProviderStyles = {
 
 export default function ExplorationAndAnalysisContainer() {
   const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
-
+  // @NOTE: 
+  const [currentUrl]= useAtom(urlAtom);
+  if(!currentUrl.pathname?.includes(EXPLORATION_PATH)) return <></>;
+  
   return (
     <TourProvider
       steps={[]}

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -51,7 +51,8 @@ import {
   ANALYSIS_PATH,
   ANALYSIS_RESULTS_PATH,
   DATASETS_PATH,
-  STORIES_PATH
+  STORIES_PATH,
+  EXPLORATION_PATH
 } from '$utils/routes';
 
 const composingComponents = [
@@ -122,7 +123,7 @@ function Root() {
 
                 {/* {useNewExploration && ( */}
                 <Route
-                  path='exploration'
+                  path={EXPLORATION_PATH}
                   element={<ExplorationAndAnalysis />}
                 />
                 {/* )} */}


### PR DESCRIPTION
**Related Ticket:** https://github.com/orgs/nasa-IMPACT/projects/17?pane=issue&itemId=74809616

### Description of Changes
Make Exploration page accept URL values only when urlAtom includes Exploration Page path. Currently, atomWithLocation gets initialized when the script is preploaded (Ex. when E&A page is linked with Link component from react-router) and returns the stale value on the route transition, making all the interesting problems. 

ex. https://deploy-preview-484--ghg-demo.netlify.app/stories/vulcan, if i click the "Explore Vulcan data" link, it takes me to the exploration page and shows options for datasets. But if I control click it and have it open in a new tab, it populates the vulcan data in the explore page (from @slesaad , thanks for reporting 🙇 )

☝️ This is happening because...
the stale value says that the pathname is `stories/vulcan` with no parameters (which sets datasets as an empty array [])
Then the children component accepts this empty array as the new data, and triggers the `setDatasets([])`, which rips off the query parameters. (This 'ripping off' happens in this specific callback that updates the style with the new datasets : https://github.com/NASA-IMPACT/veda-ui/blob/main/app/scripts/components/exploration/components/map/index.tsx#L94-L124 ) 


### Notes & Questions About Changes
I tried several things and decided to go with the least risky route. Is there any way to achieve the same output without checking the path in a hard-coded way?🤔 

### Validation / Testing

https://github.com/US-GHG-Center/veda-config-ghg/pull/488
Try click on the link on this preview: 
https://deploy-preview-488--ghg-demo.netlify.app/stories/vulcan

But also please test anylink to E&A, such as from data catalog.