### PR TITLE
Fix the label formatting for annual datasets

### DIFF
--- a/app/scripts/components/exploration/components/timeline/timeline-utils.ts
+++ b/app/scripts/components/exploration/components/timeline/timeline-utils.ts
@@ -89,7 +89,7 @@ export const getLabelFormat = (timeDensity) => {
     case 'month':
       return 'MMM yyyy';
     case 'year':
-      return 'MMMM yyyy';
+      return 'yyyy';
     default:
       return 'MMM d yyyy';
   }


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1113

### Description of Changes
The change fixes the label formatting of the timeline view and the datepicker labels when selecting annual datasets. The labels should show only in `yyyy` instead of `MM yyyy` format when annual datasets are the lowest common denominator selected.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

- Add a dataset with annual time density and verify that the timeline view labels and the datepicker labels show only the year
- Add datasets with month time density, and verify that now the labels show the month and the year
- The rest should work as before (date picker shows the appropriate calendar view)