### PR TITLE
Make focus style more subtle

### DIFF
--- a/app/scripts/styles/_mixins.scss
+++ b/app/scripts/styles/_mixins.scss
@@ -1,3 +1,5 @@
+@use "uswds-core/src/styles/functions/utilities" as utils;
+
 @mixin only-focus-visible {
   &:focus {
     outline: none;

--- a/app/scripts/styles/_mixins.scss
+++ b/app/scripts/styles/_mixins.scss
@@ -3,7 +3,7 @@
 @mixin only-focus-visible {
   &:focus {
     outline: none;
-    box-shadow: 1px #ccc;
+    box-shadow: 1px utils.color('gray-5');
   }
   &:focus-visible {
     outline: 1px solid;

--- a/app/scripts/styles/_mixins.scss
+++ b/app/scripts/styles/_mixins.scss
@@ -1,0 +1,16 @@
+@mixin only-focus-visible {
+  &:focus {
+    outline: none;
+    box-shadow: 1px #ccc;
+  }
+  &:focus-visible {
+    outline: 1px solid;
+  }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      outline: 1px solid;
+    }
+  }
+}
+

--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -1,3 +1,4 @@
+// You can find the tokens from https://designsystem.digital.gov/documentation/settings/
 @use 'uswds-core' as * with (
     $utilities-use-important: true,
     $theme-show-notifications: false,
@@ -13,6 +14,8 @@
         "mobile-lg": false,
         "desktop": false
     ),
+    $theme-focus-width: '1px',
+    $theme-focus-offset: '1px',
     $theme-font-type-sans: baseFontFamily,
     $theme-font-type-serif: baseFontFamily,
 );

--- a/app/scripts/styles/styles.scss
+++ b/app/scripts/styles/styles.scss
@@ -5,3 +5,14 @@
 @use "usa-banner";
 @use "usa-button";
 @use "usa-card";
+
+.blocklink {
+  &:focus { outline: none; }
+  &:focus-visible { outline: 1px solid  #0076d6; }
+
+  @supports not selector(:focus-visible) {
+    &:focus {
+      outline: 1px solid  #0076d6;
+    }
+  }
+}


### PR DESCRIPTION
This PR makes the focus style from uswds more subtle. This PR also adds a mixin `only-focus-visible`, which gives focus style only for keyboard interactions.