### PR TITLE
Consolidate a place where to check linkProps

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -11,12 +11,14 @@ import {
   themeVal,
   listReset,
 } from '@devseed-ui/theme-provider';
+import SmartLink from '../smart-link';
 import { CardBody, CardBlank, CardHeader, CardHeadline, CardTitle, CardOverline } from './styles';
 import HorizontalInfoCard, { HorizontalCardStyles } from './horizontal-info-card';
 import { variableBaseType, variableGlsp } from '$styles/variable-utils';
 
 import { ElementInteractive } from '$components/common/element-interactive';
 import { Figure } from '$components/common/figure';
+
 
 
 type CardType = 'classic' | 'cover' | 'featured' | 'horizontal-info';
@@ -262,6 +264,11 @@ function CardComponent(props: CardComponentProps) {
 
   return (
     <ElementInteractive
+      linkProps={{
+        as: SmartLink,
+        to: linkTo,
+        onLinkClick
+      }}
       as={CardItem}
       cardType={cardType}
       className={className}

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -17,7 +17,7 @@ import { variableBaseType, variableGlsp } from '$styles/variable-utils';
 
 import { ElementInteractive } from '$components/common/element-interactive';
 import { Figure } from '$components/common/figure';
-import { getLinkProps } from '$utils/url';
+
 
 type CardType = 'classic' | 'cover' | 'featured' | 'horizontal-info';
 
@@ -259,8 +259,6 @@ function CardComponent(props: CardComponentProps) {
   } = props;
 
   const isExternalLink = /^https?:\/\//.test(linkTo);
-  const linkProps = getLinkProps(linkTo, Link, onLinkClick);
-
 
   return (
     <ElementInteractive
@@ -268,7 +266,8 @@ function CardComponent(props: CardComponentProps) {
       cardType={cardType}
       className={className}
       linkLabel={linkLabel ?? 'View more'}
-      linkProps={linkProps}
+      linkTo={linkTo}
+      onLinkClick={onLinkClick}
       onClickCapture={onCardClickCapture}
     >
       {

--- a/app/scripts/components/common/element-interactive.js
+++ b/app/scripts/components/common/element-interactive.js
@@ -1,9 +1,8 @@
 import React, { useCallback, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
-import SmartLink from './smart-link';
 
-const InteractiveLink = styled(SmartLink)`
+const InteractiveLink = styled.a`
   position: absolute;
   inset: 0;
   z-index: -1;
@@ -74,14 +73,7 @@ export const Wrapper = styled.div`
  */
 export const ElementInteractive = React.forwardRef(
   function ElementInteractiveFwd(props, ref) {
-    const {
-      linkTo,
-      onLinkClick,
-      linkLabel = 'View',
-      children,
-      ...rest
-    } = props;
-
+    const { linkProps = {}, linkLabel = 'View', children, ...rest } = props;
     const [isStateOver, setStateOver] = useState(false);
     const [isStateActive, setStateActive] = useState(false);
     const [isStateFocus, setStateFocus] = useState(false);
@@ -103,8 +95,7 @@ export const ElementInteractive = React.forwardRef(
       >
         {children}
         <InteractiveLink
-          to={linkTo}
-          onLinkClick={onLinkClick}
+          {...linkProps}
           onMouseDown={useCallback(() => setStateActive(true), [])}
           onMouseUp={useCallback(() => setStateActive(false), [])}
           onFocus={useCallback(() => setStateFocus(true), [])}
@@ -118,8 +109,6 @@ export const ElementInteractive = React.forwardRef(
 );
 
 ElementInteractive.propTypes = {
-  linkTo: T.string.isRequired,
-  onLinkClick: T.func,
   children: T.node.isRequired,
   linkLabel: T.string.isRequired,
   linkProps: T.object

--- a/app/scripts/components/common/element-interactive.js
+++ b/app/scripts/components/common/element-interactive.js
@@ -1,8 +1,9 @@
 import React, { useCallback, useState } from 'react';
 import T from 'prop-types';
 import styled from 'styled-components';
+import SmartLink from './smart-link';
 
-const InteractiveLink = styled.a`
+const InteractiveLink = styled(SmartLink)`
   position: absolute;
   inset: 0;
   z-index: -1;
@@ -73,7 +74,14 @@ export const Wrapper = styled.div`
  */
 export const ElementInteractive = React.forwardRef(
   function ElementInteractiveFwd(props, ref) {
-    const { linkProps = {}, linkLabel = 'View', children, ...rest } = props;
+    const {
+      linkTo,
+      onLinkClick,
+      linkLabel = 'View',
+      children,
+      ...rest
+    } = props;
+
     const [isStateOver, setStateOver] = useState(false);
     const [isStateActive, setStateActive] = useState(false);
     const [isStateFocus, setStateFocus] = useState(false);
@@ -95,7 +103,8 @@ export const ElementInteractive = React.forwardRef(
       >
         {children}
         <InteractiveLink
-          {...linkProps}
+          to={linkTo}
+          onLinkClick={onLinkClick}
           onMouseDown={useCallback(() => setStateActive(true), [])}
           onMouseUp={useCallback(() => setStateActive(false), [])}
           onFocus={useCallback(() => setStateFocus(true), [])}
@@ -109,6 +118,8 @@ export const ElementInteractive = React.forwardRef(
 );
 
 ElementInteractive.propTypes = {
+  linkTo: T.string.isRequired,
+  onLinkClick: T.func,
   children: T.node.isRequired,
   linkLabel: T.string.isRequired,
   linkProps: T.object

--- a/app/scripts/components/common/smart-link.tsx
+++ b/app/scripts/components/common/smart-link.tsx
@@ -5,6 +5,7 @@ import { getLinkProps } from '$utils/url';
 
 interface SmartLinkProps {
   to: string;
+  onLinkClick?: ()=> void;
   children?: ReactNode;
 }
 
@@ -12,9 +13,10 @@ interface SmartLinkProps {
  * Switches between a `a` and a `Link` depending on the url.
  */
 export default function SmartLink(props: SmartLinkProps) {
-  const { to, children, ...rest } = props;
+  const { to, onLinkClick, children, ...rest } = props;
   const isExternalLink = /^https?:\/\//.test(to);
-  const linkProps = getLinkProps(to);
+  const linkProps = getLinkProps(to, undefined, onLinkClick);
+
   return isExternalLink ? (
       <a {...linkProps} {...rest}> {children} </a>
   ) : (


### PR DESCRIPTION
**Related Ticket:** Very vaguely related to #946 

This PR makes the Card component delegate what link component to render to the `SmartLink` component. I initially started working on this PR to continue the work on https://github.com/NASA-IMPACT/veda-ui/pull/1096, more specifically, to make the link component come from props.  I thought this change was worth merging regardless of whether we work on the routing problem now or later.  