### PR TITLE
Add font md size as 20px

### DIFF
--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -9,6 +9,7 @@
             "cap-height": 364px,
         ),
     ),
+    $theme-type-scale-md: 8,
     $theme-utility-breakpoints: (
         "mobile-lg": false,
         "desktop": false


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
I often find designs with a font size 20px, this one makes the `-md` utilities class to be 20px (https://designsystem.digital.gov/design-tokens/typesetting/font/ )
 @faustoperez - let's go through the font sizes we need and set the values accordingly soon!