### PR TITLE
FIX: update external link in top navigation target

### DIFF
--- a/app/scripts/components/common/page-header/nav-menu-item.tsx
+++ b/app/scripts/components/common/page-header/nav-menu-item.tsx
@@ -100,7 +100,7 @@ export default function NavMenuItem({ item, alignment, onClick }: {item: NavItem
       <li key={`${title}-nav-item`}>
       <GlobalMenuLink 
         as='a'
-        target='blank'
+        target='_blank'
         rel='noopener'
         onClick={onClick}
         href={(rest as ExternalNavLink).href}


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
this updates the `nav-menu-item` with external links to have  `target="_bank"`  instead of  `target="blank"`.  There's [a slight difference in the behavior](https://css-tricks.com/targetblank/).
and other external links have used the underscore.