### PR TITLE
Add a flag not to show the colormap

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,4 @@ API_STAC_ENDPOINT='https://staging.openveda.cloud/api/stac'
 GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'
 
 FEATURE_NEW_EXPLORATION = 'TRUE'
+SHOW_CONFIGURABLE_COLOR_MAP = 'TRUE'

--- a/.env
+++ b/.env
@@ -13,4 +13,4 @@ API_STAC_ENDPOINT='https://staging.openveda.cloud/api/stac'
 GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f88hX8RZ4Qef7qBsTtDqxjTSkg/viewform?embedded=true'
 
 FEATURE_NEW_EXPLORATION = 'TRUE'
-SHOW_CONFIGURABLE_COLOR_MAP = 'TRUE'
+SHOW_CONFIGURABLE_COLOR_MAP = 'FALSE'

--- a/app/scripts/components/common/map/layer-legend.tsx
+++ b/app/scripts/components/common/map/layer-legend.tsx
@@ -272,7 +272,6 @@ export function LayerLegendContainer(props: LayerLegendContainerProps) {
 
 export function LayerCategoricalGraphic(props: LayerLegendCategorical) {
   const { stops } = props;
-
   return (
     <LegendList>
       {stops.map((stop) => (
@@ -350,20 +349,19 @@ export const LayerGradientGraphic = (props: LayerLegendGradient) => {
 export const LayerGradientColormapGraphic = (props: Omit<LayerLegendGradient, 'stops' | 'type'>) => {
   const { colorMap, ...otherProps } = props;
 
-  const colormap = findColormapByName(colorMap ?? 'viridis');
-  if (!colormap) {
+  const colormapResult = findColormapByName(colorMap ?? 'viridis');
+  if (!colormapResult) {
     return null;
   }
+  const { foundColorMap, isReversed } = colormapResult;
 
-  const stops = Object.values(colormap).map((value) => {
-    if (Array.isArray(value) && value.length === 4) {
-      return `rgba(${value.join(',')})`;
-    } else {
-      return `rgba(0, 0, 0, 1)`;
-    }
+  const stops = Object.values(foundColorMap)
+  .filter(value => Array.isArray(value) && value.length === 4)
+  .map((value) => {
+    return `rgba(${(value as Array<number>).join(',')})`;
   });
 
-  const processedStops = colormap.isReversed
+  const processedStops = isReversed
   ? stops.reduceRight((acc, stop) => [...acc, stop], [])
   : stops;
 
@@ -380,5 +378,5 @@ export const findColormapByName = (name: string) => {
     return null;
   }
 
-  return { ...colormap, isReversed };
+  return { foundColorMap: {...colormap}, isReversed };
 };

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -17,7 +17,7 @@ import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
 import { TipButton } from '$components/common/tip-button';
 import {
-  LayerCategoricalGraphic, LayerGradientColormapGraphic
+  LayerCategoricalGraphic, LayerGradientColormapGraphic, LayerGradientGraphic
 } from '$components/common/map/layer-legend';
 
 import { TimelineDataset } from '$components/exploration/types.d.ts';
@@ -102,6 +102,9 @@ const LegendColorMapTrigger = styled.div`
   cursor: pointer;
 `;
 
+// Hiding configurable map for now until Instances are ready to adapt it
+const showConfigurableColorMap = false;
+
 export default function DataLayerCard(props: CardProps) {
   const {
     dataset,
@@ -176,38 +179,48 @@ export default function DataLayerCard(props: CardProps) {
         {datasetLegend?.type === 'categorical' && (
           <LayerCategoricalGraphic type='categorical' stops={datasetLegend.stops} />
         )}
-        {/* Show a loading skeleton when the color map is not categorical and the dataset
-        status is 'loading'. This is because we color map sometimes might come from the titiler
-        which could introduce a visual flash when going from the 'default' color map to the one
-        configured in titiler */}
-        {dataset.status === 'loading'  && datasetLegend?.type === 'gradient' && <div className='display-flex flex-align-center height-8'><LoadingSkeleton /></div>}
-        {dataset.status === 'success' && datasetLegend?.type === 'gradient' && (
-          <div className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md' ref={triggerRef}>
-            <LayerGradientColormapGraphic
-              min={min}
-              max={max}
-              colorMap={colorMap}
-            />
-            <Tippy
-              className='colormap-options'
-              content={
-                <ColormapOptions
-                  colorMap={colorMap}
-                  setColorMap={setColorMap}
-                />
-              }
-              appendTo={() => document.body}
-              visible={isColorMapOpen}
-              interactive={true}
-              placement='top'
-              onClickOutside={(_, event) => handleClickOutside(event)}
-            >
-              <LegendColorMapTrigger className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05' onClick={handleColorMapTriggerClick}>
-                <CollecticonChevronDownSmall />
-              </LegendColorMapTrigger>
-            </Tippy>
-          </div>
-        )}
+
+          {/* Show a loading skeleton when the color map is not categorical and the dataset
+          status is 'loading'. This is because we color map sometimes might come from the titiler
+          which could introduce a visual flash when going from the 'default' color map to the one
+          configured in titiler */}
+
+          {showConfigurableColorMap && dataset.status === 'loading'  && datasetLegend?.type === 'gradient' && <div className='display-flex flex-align-center height-8'><LoadingSkeleton /></div>}
+          {showConfigurableColorMap && dataset.status === 'success' && datasetLegend?.type === 'gradient' && (
+            <div className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md' ref={triggerRef}>
+              <LayerGradientColormapGraphic
+                min={min}
+                max={max}
+                colorMap={colorMap}
+              />
+              <Tippy
+                className='colormap-options'
+                content={
+                  <ColormapOptions
+                    colorMap={colorMap}
+                    setColorMap={setColorMap}
+                  />
+                }
+                appendTo={() => document.body}
+                visible={isColorMapOpen}
+                interactive={true}
+                placement='top'
+                onClickOutside={(_, event) => handleClickOutside(event)}
+              >
+                <LegendColorMapTrigger className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05' onClick={handleColorMapTriggerClick}>
+                  <CollecticonChevronDownSmall />
+                </LegendColorMapTrigger>
+              </Tippy>
+            </div>
+          )}
+        {!showConfigurableColorMap && 
+          <LayerGradientColormapGraphic
+            min={min}
+            max={max}
+            colorMap={colorMap}
+          />
+        }
+
       </DatasetInfo>
     </>
   );

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -214,6 +214,7 @@ export default function DataLayerCard(props: CardProps) {
             </div>
           )}
         {!showConfigurableColorMap && 
+          datasetLegend?.type === 'gradient' && 
           <LayerGradientColormapGraphic
             min={min}
             max={max}

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -17,7 +17,7 @@ import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
 import { TipButton } from '$components/common/tip-button';
 import {
-  LayerCategoricalGraphic, LayerGradientColormapGraphic, LayerGradientGraphic
+  LayerCategoricalGraphic, LayerGradientColormapGraphic
 } from '$components/common/map/layer-legend';
 
 import { TimelineDataset } from '$components/exploration/types.d.ts';
@@ -103,7 +103,7 @@ const LegendColorMapTrigger = styled.div`
 `;
 
 // Hiding configurable map for now until Instances are ready to adapt it
-const showConfigurableColorMap = false;
+const showConfigurableColorMap = process.env.SHOW_CONFIGURABLE_COLOR_MAP?? false;
 
 export default function DataLayerCard(props: CardProps) {
   const {
@@ -218,8 +218,7 @@ export default function DataLayerCard(props: CardProps) {
             min={min}
             max={max}
             colorMap={colorMap}
-          />
-        }
+          />}
 
       </DatasetInfo>
     </>

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -23,6 +23,7 @@ import {
 import { TimelineDataset } from '$components/exploration/types.d.ts';
 import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 import { ParentDatasetTitle } from '$components/common/catalog/catalog-content';
+import { checkEnvFlag } from '$utils/utils';
 
 import 'tippy.js/dist/tippy.css';
 import { LoadingSkeleton } from '$components/common/loading-skeleton';
@@ -103,7 +104,7 @@ const LegendColorMapTrigger = styled.div`
 `;
 
 // Hiding configurable map for now until Instances are ready to adapt it
-const showConfigurableColorMap = process.env.SHOW_CONFIGURABLE_COLOR_MAP?? false;
+const showConfigurableColorMap = checkEnvFlag(process.env.SHOW_CONFIGURABLE_COLOR_MAP);
 
 export default function DataLayerCard(props: CardProps) {
   const {


### PR DESCRIPTION
**Related Ticket:** #1142 

### Description of Changes
Turn off colormap configurability. It is default to off, but instances can turn it on by setting up environment variable `SHOW_CONFIGURABLE_COLOR_MAP`


While working on it, I noticed a black end of the gradient color bar, so I included the fix here, too. 

<img width="420" alt="Screenshot 2024-09-05 at 4 50 11 PM" src="https://github.com/user-attachments/assets/306eec0c-af9a-4128-971a-1dfb974cc091">

