### PR TITLE
Use sourceparams as it is when it is there

### DIFF
--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -181,11 +181,11 @@ export function resolveRenderParams(
   }
 
   // Check for the dashboard render configuration in queryData
-  if (!queryDataRenders) throw new Error ('No proper render parameter exists.');
+  if (!queryDataRenders) throw new Error ('No render parameter exists from stac endpoint.');
 
   // Check the namespace from render extension
   const renderKey = queryDataRenders.dashboard? 'dashboard' : datasetSourceParams?.assets;
-  if (!queryDataRenders[renderKey]) throw new Error ('No proper render parameter exists.');
+  if (!queryDataRenders[renderKey]) throw new Error ('No proper render parameter for dashboard namespace exists.');
 
   // Return the render extension parameter
   if (queryDataRenders[renderKey] && hasValidSourceParams(queryDataRenders[renderKey])) {

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -174,35 +174,22 @@ export function resolveRenderParams(
   datasetSourceParams: Record<string, any> | undefined,
   queryDataRenders: Record<string, any> | undefined
 ): Record<string, any> | undefined {
-  let renderParams: Record<string, any> | undefined;
   // Start with sourceParams from the dataset.
+  // Return the source param as it is if exists
   if (hasValidSourceParams(datasetSourceParams)) {
-    renderParams = datasetSourceParams;
+    return datasetSourceParams;
   }
 
   // Check for the dashboard render configuration in queryData if not defined.
-  if (!renderParams && queryDataRenders?.dashboard) {
-    renderParams = queryDataRenders.dashboard;
-
-    if (renderParams?.rescale) {
-      renderParams.rescale = flattenAndCalculateMinMax([renderParams.rescale]);
-    }
+  const renderKey = queryDataRenders?.dashboard? 'dashboard' : datasetSourceParams?.assets;
+  if (!queryDataRenders?.[renderKey]) throw new Error ('No proper render parameter exists.');
+  if (queryDataRenders[renderKey] && hasValidSourceParams(queryDataRenders[renderKey])) {
+    const renderParams = queryDataRenders.dashboard;
+    return {
+      ...renderParams,
+      rescale: flattenAndCalculateMinMax([renderParams.rescale])
+    };
   }
-
-  // Check for asset-specific renders using the sourceParams' assets property.
-  if (!renderParams && queryDataRenders?.[datasetSourceParams?.assets]) {
-    renderParams = queryDataRenders[datasetSourceParams?.assets];
-
-    if (renderParams?.rescale) {
-      renderParams.rescale = flattenAndCalculateMinMax(renderParams.rescale);
-    }
-  }
-
-  if (renderParams?.rescale) {
-    renderParams.rescale = flattenAndCalculateMinMax(renderParams.rescale);
-  }
-
-  return renderParams;
 }
 
 export function getTimeDensityStartDate(date: Date, timeDensity: TimeDensity) {

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -180,11 +180,16 @@ export function resolveRenderParams(
     return datasetSourceParams;
   }
 
-  // Check for the dashboard render configuration in queryData if not defined.
-  const renderKey = queryDataRenders?.dashboard? 'dashboard' : datasetSourceParams?.assets;
-  if (!queryDataRenders?.[renderKey]) throw new Error ('No proper render parameter exists.');
+  // Check for the dashboard render configuration in queryData
+  if (!queryDataRenders) throw new Error ('No proper render parameter exists.');
+
+  // Check the namespace from render extension
+  const renderKey = queryDataRenders.dashboard? 'dashboard' : datasetSourceParams?.assets;
+  if (!queryDataRenders[renderKey]) throw new Error ('No proper render parameter exists.');
+
+  // Return the render extension parameter
   if (queryDataRenders[renderKey] && hasValidSourceParams(queryDataRenders[renderKey])) {
-    const renderParams = queryDataRenders.dashboard;
+    const renderParams = queryDataRenders[renderKey];
     return {
       ...renderParams,
       rescale: flattenAndCalculateMinMax([renderParams.rescale])


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
While working on render extension talk, I realized that the authors don't necessarily use array format for rescale value (ex. rescale value for hls-ndvi layer in this file: https://raw.githubusercontent.com/NASA-IMPACT/veda-config/develop/datasets/hls-ndvi-ian.data.mdx is string `-1,1`) To support what we have now, I think we should return the source parameter as it is. 

### Notes & Questions About Changes
I also simplified the logic a little bit, please check if I am missing anything! 