### PR TITLE
Update PageHeader/Nav to not throw

### DIFF
--- a/app/scripts/components/common/page-header/nav-menu-item.tsx
+++ b/app/scripts/components/common/page-header/nav-menu-item.tsx
@@ -58,6 +58,7 @@ const DropMenuNavItem = styled(DropMenuItem)`
   `}
 `;
 
+const LOG = true;
 
 function LinkDropMenuNavItem({ child, onClick }: { child: NavLinkItem, onClick?:() => void}) {
   const { title, type, ...rest } = child;
@@ -79,7 +80,12 @@ function LinkDropMenuNavItem({ child, onClick }: { child: NavLinkItem, onClick?:
         </DropMenuNavItem>
       </li>
     );
-  } else throw Error('Invalid child Nav item type');
+  } else {
+    LOG &&
+      /* eslint-disable-next-line no-console */
+      console.error(`Invalid child Nav Item type, type "${type}" is not of `, NavItemType);
+    return null;
+  }
 }
 
 
@@ -144,5 +150,10 @@ export default function NavMenuItem({ item, alignment, onClick }: {item: NavItem
       </DropdownScrollable>
              </li>);
     }
-  } else throw Error('Invalid type for Nav Items');
+  } else {
+    LOG &&
+      /* eslint-disable-next-line no-console */
+      console.error(`Invalid type for Nav Items, type "${type}" is not of `, NavItemType);
+    return null;
+  }
 }

--- a/app/scripts/components/common/page-header/types.d.ts
+++ b/app/scripts/components/common/page-header/types.d.ts
@@ -12,12 +12,15 @@ export interface InternalNavLink {
   to: string;
   type: NavItemType.INTERNAL_LINK;
 }
+
 export interface ExternalNavLink {
   title: string;
   href: string;
   type: NavItemType.EXTERNAL_LINK;
 }
+
 export type NavLinkItem = (ExternalNavLink | InternalNavLink);
+
 export interface ModalNavLink {
   title: string;
   type: NavItemType.MODAL;


### PR DESCRIPTION
Was playing around a bit with nav header with next instance and noticed something I did not catch in the initial PR review. But we dont want to throw an error when type is incorrect. This will **break** the app because nothing is catching it. Instead we should still render the rest of the nav items that are correct.

I opted in for logging the error for incorrect types but if we prefer a different way like catching and bubbling up the error, lmk.

Updated behavior looks like:
![Screenshot 2024-09-11 at 12 08 28 PM](https://github.com/user-attachments/assets/f8bd38db-c4fb-4f3c-99c3-a5a4ae06a074)
