### PR TITLE
Allow `<Map>` component comparison to support configurable datasets/layers

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -112,7 +112,7 @@ interface MapBlockProps {
   datasets: VedaDatum<DatasetData>;
   dateTime?: string;
   compareDateTime?: string;
-  compareDataSetId?: string;
+  compareDatasetId?: string;
   compareLayerId?: string;
   center?: [number, number];
   zoom?: number;
@@ -148,7 +148,7 @@ function MapBlock(props: MapBlockProps) {
     layerId,
     dateTime,
     compareDateTime,
-    compareDataSetId,
+    compareDatasetId,
     compareLayerId,
     compareLabel,
     center,
@@ -171,9 +171,9 @@ function MapBlock(props: MapBlockProps) {
     const [baseMapStaticData] = reconcileDatasets([layerId], datasetLayers, []);
     let totalLayers = [baseMapStaticData];
     const baseMapStaticCompareData =
-      !!compareDataSetId && !!compareLayerId
+      !!(compareDatasetId && compareLayerId)
         ? {
-            datasetId: compareDataSetId,
+            datasetId: compareDatasetId,
             layerId: compareLayerId
           }
         : baseMapStaticData.data.compare;

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -112,6 +112,8 @@ interface MapBlockProps {
   datasets: VedaDatum<DatasetData>;
   dateTime?: string;
   compareDateTime?: string;
+  compareDataSetId?: string;
+  compareLayerId?: string;
   center?: [number, number];
   zoom?: number;
   compareLabel?: string;
@@ -146,6 +148,8 @@ function MapBlock(props: MapBlockProps) {
     layerId,
     dateTime,
     compareDateTime,
+    compareDataSetId,
+    compareLayerId,
     compareLabel,
     center,
     zoom,
@@ -166,7 +170,13 @@ function MapBlock(props: MapBlockProps) {
   const layersToFetch = useMemo(() => {
     const [baseMapStaticData] = reconcileDatasets([layerId], datasetLayers, []);
     let totalLayers = [baseMapStaticData];
-    const baseMapStaticCompareData = baseMapStaticData.data.compare;
+    const baseMapStaticCompareData =
+      !!compareDataSetId && !!compareLayerId
+        ? {
+            datasetId: compareDataSetId,
+            layerId: compareLayerId
+          }
+        : baseMapStaticData.data.compare;
     if (baseMapStaticCompareData && 'layerId' in baseMapStaticCompareData) {
       const compareLayerId = baseMapStaticCompareData.layerId;
       const [compareMapStaticData] = reconcileDatasets(

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -171,7 +171,7 @@ function MapBlock(props: MapBlockProps) {
     const [baseMapStaticData] = reconcileDatasets([layerId], datasetLayers, []);
     let totalLayers = [baseMapStaticData];
     const baseMapStaticCompareData =
-      !!(compareDatasetId && compareLayerId)
+      (!!compareDatasetId && !!compareLayerId)
         ? {
             datasetId: compareDatasetId,
             layerId: compareLayerId

--- a/docs/content/MDX_BLOCKS.md
+++ b/docs/content/MDX_BLOCKS.md
@@ -484,6 +484,8 @@ Syntax for Chart used in Wide Figure Block looks like this. Check how the data i
 | datasetId | string | `''` | `id` defined in dataset mdx. |
 | layerId | string | `''` | `id` for layer to display. The layer should be a part of the dataset above. |
 | dateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. When omitted, the very first available dateTime for the dataset will be displayed |
+| compareDataSetId | string | `''` | `id` The `id` defined in the dataset MDX. Include this only if a comparison with the dataset defined by `datasetId` is needed.  |
+| compareLayerId | string | `''` | `id` The `id` for the comparison layer to display. This layer must be part of the comparison dataset specified by `compareDataSetId` . |
 | compareDateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. A date should only be specified if you wish to display the comparison slider |
 | compareLabel | string | `''` | Text to display over the map when the comparison is active. If is for example used to indicate what dates are being compared. If not provided it will default to the value specified in the [dataset layer configuration](./frontmatter/layer.md#compare) |
 | projectionId | string | `mercator` | The id of the [projection](./frontmatter/layer.md#projections) to load. |

--- a/docs/content/MDX_BLOCKS.md
+++ b/docs/content/MDX_BLOCKS.md
@@ -484,8 +484,8 @@ Syntax for Chart used in Wide Figure Block looks like this. Check how the data i
 | datasetId | string | `''` | `id` defined in dataset mdx. |
 | layerId | string | `''` | `id` for layer to display. The layer should be a part of the dataset above. |
 | dateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. When omitted, the very first available dateTime for the dataset will be displayed |
-| compareDataSetId | string | `''` | `id` The `id` defined in the dataset MDX. Include this only if a comparison with the dataset defined by `datasetId` is needed.  |
-| compareLayerId | string | `''` | `id` The `id` for the comparison layer to display. This layer must be part of the comparison dataset specified by `compareDataSetId` . |
+| compareDatasetId | string | `''` | `id` The `id` defined in the dataset MDX. Include this only if a comparison with the dataset defined by `datasetId` is needed.  |
+| compareLayerId | string | `''` | `id` The `id` for the comparison layer to display. This layer must be part of the comparison dataset specified by `compareDatasetId` . |
 | compareDateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. A date should only be specified if you wish to display the comparison slider |
 | compareLabel | string | `''` | Text to display over the map when the comparison is active. If is for example used to indicate what dates are being compared. If not provided it will default to the value specified in the [dataset layer configuration](./frontmatter/layer.md#compare) |
 | projectionId | string | `mercator` | The id of the [projection](./frontmatter/layer.md#projections) to load. |


### PR DESCRIPTION
Previously, comparing datasets involved manually assigning the dataset to the properties of a dataset layer. With this change, you can now pass two additional parameters  `compareDatasetId` and `compareLayerId` to the `Map` block, allowing it to compare the specified dataset with the one defined by `datasetId` and `layerId`.