### PR TITLE
Convert the time to usertzdate

### DIFF
--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -8,6 +8,7 @@ import {
   DatasetStatus
 } from './types.d.ts';
 import { ExtendedError } from './data-utils';
+import { utcString2userTzDate } from '$utils/date';
 import {
   fixAoiFcForStacSearch,
   getFilterPayload
@@ -58,10 +59,9 @@ async function getDatasetAssets(
     },
     opts
   );
-
   return {
     assets: searchReqRes.data.features.map((o) => ({
-      date: new Date(o.properties.start_datetime || o.properties.datetime),
+      date: utcString2userTzDate(o.properties.start_datetime || o.properties.datetime),
       url: o.assets[assets].href
     }))
   };
@@ -218,6 +218,7 @@ export async function requestDatasetTimeseriesData({
             );
           }
         );
+
         onProgress({
           status: DatasetStatus.LOADING,
           error: null,


### PR DESCRIPTION
**Related Ticket:** https://github.com/US-GHG-Center/ghgc-architecture/issues/235

### Description of Changes
Because Javascript Date object outputs the local time of the computer, the output of the date was converted to earlier time than the value we got from the search result. 
ex. search result value: `"2023-12-01T00:00:00+00:00"`
output date value (on my computer) ( new Date( "2023-12-01T00:00:00+00:00")) `Thu Nov 30 2023 19:00:00 GMT-0500 (Eastern Standard Time)`

### Notes & Questions About Changes
