### PR TITLE
Cap heights for the theme typeface in USWDS

### DIFF
--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -8,6 +8,36 @@
             "display-name": var(--base-font-family),
             "cap-height": 364px,
         ),
+        "system": (
+            "cap-height": 364px
+        ),
+        "georgia": (
+            "cap-height": 364px
+        ),
+        "helvetica": (
+            "cap-height": 364px
+        ),
+        "tahoma": (
+            "cap-height": 364px
+        ),
+        "verdana": (
+            "cap-height": 364px
+        ),
+        "open-sans": (
+            "cap-height": 364px
+        ),
+        "merriweather": (
+            "cap-height": 364px
+        ),
+        "roboto-mono": (
+            "cap-height": 364px
+        ),
+        "source-sans-pro": (
+            "cap-height": 364px
+        ),
+        "public-sans": (
+            "cap-height": 364px
+        )
     ),
     $theme-type-scale-md: 8,
     $theme-utility-breakpoints: (

--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -11,33 +11,6 @@
         "system": (
             "cap-height": 364px
         ),
-        "georgia": (
-            "cap-height": 364px
-        ),
-        "helvetica": (
-            "cap-height": 364px
-        ),
-        "tahoma": (
-            "cap-height": 364px
-        ),
-        "verdana": (
-            "cap-height": 364px
-        ),
-        "open-sans": (
-            "cap-height": 364px
-        ),
-        "merriweather": (
-            "cap-height": 364px
-        ),
-        "roboto-mono": (
-            "cap-height": 364px
-        ),
-        "source-sans-pro": (
-            "cap-height": 364px
-        ),
-        "public-sans": (
-            "cap-height": 364px
-        )
     ),
     $theme-type-scale-md: 8,
     $theme-utility-breakpoints: (

--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -11,6 +11,66 @@
         "system": (
             "cap-height": 364px
         ),
+        "merriweather": (
+            display-name: "Merriweather Web",
+            cap-height: 364px,
+            stack: 'font-stack-georgia',
+            src: (
+                dir: "merriweather",
+                roman: (
+                    100: false,
+                    200: false,
+                    300: "Latin-Merriweather-Light",
+                    400: "Latin-Merriweather-Regular",
+                    500: false,
+                    600: false,
+                    700: "Latin-Merriweather-Bold",
+                    800: false,
+                    900: "Latin-Merriweather-Black",
+                ),
+                italic: (
+                    100: false,
+                    200: false,
+                    300: "Latin-Merriweather-LightItalic",
+                    400: "Latin-Merriweather-Italic",
+                    500: false,
+                    600: false,
+                    700: "Latin-Merriweather-BoldItalic",
+                    800: false,
+                    900: "Latin-Merriweather-BlackItalic",
+                ),
+            ),
+        ),
+        "roboto-mono": (
+            display-name: "Roboto Mono Web",
+            cap-height: 364px,
+            stack: 'font-stack-monospace',
+            src: (
+                dir: "roboto-mono",
+                roman: (
+                    100: "roboto-mono-v5-latin-100",
+                    200: false,
+                    300: "roboto-mono-v5-latin-300",
+                    400: "roboto-mono-v5-latin-regular",
+                    500: "roboto-mono-v5-latin-500",
+                    600: false,
+                    700: "roboto-mono-v5-latin-700",
+                    800: false,
+                    900: false,
+                ),
+                italic: (
+                    100: "roboto-mono-v5-latin-100italic",
+                    200: false,
+                    300: "roboto-mono-v5-latin-300italic",
+                    400: "roboto-mono-v5-latin-italic",
+                    500: "roboto-mono-v5-latin-500italic",
+                    600: false,
+                    700: "roboto-mono-v5-latin-700italic",
+                    800: false,
+                    900: false,
+                ),
+            ),
+        ),
     ),
     $theme-type-scale-md: 8,
     $theme-utility-breakpoints: (
@@ -18,5 +78,4 @@
         "desktop": false
     ),
     $theme-font-type-sans: baseFontFamily,
-    $theme-font-type-serif: baseFontFamily,
 );


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1144

### Description of Changes
USWDS normalizes font sizes across different typefaces to ensure optical consistency, but this feature isn't necessary for our current needs. Here we're trying to streamline the font sizes across all typefaces to ensure they have uniform sizing without normalization.

I found the [function where USWDS normalizes the typefaces](https://github.com/uswds/uswds/blob/e6a8bb2670e00cbd57177eb8c19d34313b7a53bb/packages/uswds-core/src/styles/functions/font/normalize-type-scale.scss#L15), which is based on the cap-height of each typeface. Since each typeface has a slightly different [cap-height setting](https://github.com/uswds/uswds/blob/e6a8bb2670e00cbd57177eb8c19d34313b7a53bb/packages/uswds-core/src/styles/tokens/font/typefaces.scss), I bypassed this by configuring the custom tokens that we need to use a fixed default cap-height of 364px.

To verify the changes, I tested with the following examples:


```
<h1 className='font-serif-3xs'>Lorem ipsum dolor sit amet, consectetur adipiscing elit </h1>
<h2 className='font-sans-3xs'>Lorem ipsum dolor sit amet, consectetur adipiscing elit </h2>
```

These previously would have been normalized differently, but now output the same `rem` value.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

The example from the description can be used for testing
