### PR TITLE
Datacatalog followup

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -93,7 +93,7 @@ function BrowseControls(props: BrowseControlsProps) {
         key={name}
         prefix={name}
         items={[optionAll].concat(values)}
-        currentId={(taxonomies[name].length ? taxonomies[name][0] as string : 'all')}
+        currentId={(taxonomies[name] as string[] | null)?.length ? taxonomies[name][0] as string : 'all'}
         onChange={(v) => {
           onAction(FilterActions.TAXONOMY, { key: name, value: v });
         }}

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -11,6 +11,7 @@ import {
   themeVal,
   listReset,
 } from '@devseed-ui/theme-provider';
+import SmartLink from '../smart-link';
 import { CardBody, CardBlank, CardHeader, CardHeadline, CardTitle, CardOverline } from './styles';
 import HorizontalInfoCard, { HorizontalCardStyles } from './horizontal-info-card';
 import { variableBaseType, variableGlsp } from '$styles/variable-utils';
@@ -225,11 +226,9 @@ export interface LinkProperties {
   onLinkClick?: MouseEventHandler;
 }
 
-export interface CardComponentProps {
+export interface CardComponentBaseProps {
   title: JSX.Element | string;
-  linkProperties: {
-    linkTo: string,
-  } & LinkProperties;
+
   linkLabel?: string;
   className?: string;
   cardType?: CardType;
@@ -244,7 +243,19 @@ export interface CardComponentProps {
   onCardClickCapture?: MouseEventHandler;
 }
 
-function CardComponent(props: CardComponentProps) {
+// @TODO: Consolidate these props when the instance adapts the new syntax
+export interface CardComponentPropsDeprecated extends CardComponentBaseProps {
+  linkTo: string;
+  onLinkClick: MouseEventHandler;
+}
+export interface CardComponentProps extends CardComponentBaseProps {
+  linkProperties: {
+    linkTo: string,
+  } & LinkProperties;
+
+}
+
+function CardComponent(props: (CardComponentProps & CardComponentPropsDeprecated)) {
   const {
     className,
     title,
@@ -258,8 +269,15 @@ function CardComponent(props: CardComponentProps) {
     tagLabels,
     parentTo,
     footerContent,
+    linkTo,
+    onLinkClick,
     onCardClickCapture,
-    linkProperties
+    linkProperties = {
+      LinkElement: SmartLink,
+      pathAttributeKeyName: 'to',
+      linkTo,
+      onLinkClick
+    }
   } = props;
 
   const isExternalLink = /^https?:\/\//.test(linkProperties.linkTo);

--- a/app/scripts/components/common/catalog/controls/hooks/use-filters-with-query.ts
+++ b/app/scripts/components/common/catalog/controls/hooks/use-filters-with-query.ts
@@ -33,21 +33,13 @@ export function useFiltersWithURLAtom(): UseFiltersWithQueryResult {
 }
 
   export function useFiltersWithQS({
-    navigate,
-    push=false
+    navigate
   }: {
-    navigate: any,
-    push?: boolean,
+    navigate: any
   }): UseFiltersWithQueryResult {
 
-    let navCommit = navigate;
-
-    if (push) {
-      navCommit = ({ search }) => navigate.push(`?${search}`);
-    }
-
     const useQsState = useQsStateCreator({
-      commit: navCommit
+      commit: navigate
     });
 
   const [search, setSearch] = useQsState.memo(
@@ -68,9 +60,10 @@ export function useFiltersWithURLAtom(): UseFiltersWithQueryResult {
     []
   );
 
+
   const onAction = useCallback<FilterAction>(
-    (action, value) =>
-      onFilterAction(action, value, taxonomies, setSearch, setTaxonomies),
+    (action, value) => {
+      onFilterAction(action, value, taxonomies, setSearch, setTaxonomies);},
     [setSearch, setTaxonomies, taxonomies]
   );
 


### PR DESCRIPTION
**Related Ticket:**  Follow up of https://github.com/NASA-IMPACT/veda-ui/pull/1096 & https://github.com/NASA-IMPACT/veda-ui/commit/d84527bdf0eb2b4d7586646881796bb615b433b3#diff-7d1c949cac222e52ef45864275aff43e6fa94599bd4684d9611fa25b610e900b

### Description of Changes
- I accidentally removed the question mark operator while running a lint, I put the proper type so it doesn't happen with automatic lint
- I made the Card Component work backward compatible since the component is exposed to instance levels.