### PR TITLE
Lazyload SmartLink to avoid loading react-router-dom + use a proper linkProperties 

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -1,9 +1,9 @@
-import React, { MouseEventHandler } from 'react';
+import React, { lazy, MouseEventHandler } from 'react';
 import styled, { css } from 'styled-components';
 import { Link } from 'react-router-dom';
 import { format } from 'date-fns';
 import { CollecticonExpandTopRight } from '@devseed-ui/collecticons';
-
+const SmartLink = lazy(() => import('../smart-link'));
 import {
   glsp,
   media,
@@ -11,7 +11,7 @@ import {
   themeVal,
   listReset,
 } from '@devseed-ui/theme-provider';
-import SmartLink from '../smart-link';
+
 import { CardBody, CardBlank, CardHeader, CardHeadline, CardTitle, CardOverline } from './styles';
 import HorizontalInfoCard, { HorizontalCardStyles } from './horizontal-info-card';
 import { variableBaseType, variableGlsp } from '$styles/variable-utils';
@@ -226,9 +226,12 @@ export interface LinkProperties {
   onLinkClick?: MouseEventHandler;
 }
 
+export interface LinkWithPathProperties extends LinkProperties {
+  linkTo: string;
+}
+
 export interface CardComponentBaseProps {
   title: JSX.Element | string;
-
   linkLabel?: string;
   className?: string;
   cardType?: CardType;
@@ -249,9 +252,7 @@ export interface CardComponentPropsDeprecated extends CardComponentBaseProps {
   onLinkClick?: MouseEventHandler;
 }
 export interface CardComponentProps extends CardComponentBaseProps {
-  linkProperties: {
-    linkTo: string,
-  } & LinkProperties;
+  linkProperties: LinkWithPathProperties;
 }
 
 type CardComponentPropsType = CardComponentProps | CardComponentPropsDeprecated;
@@ -278,7 +279,7 @@ function CardComponent(props: CardComponentPropsType) {
     onCardClickCapture
   } = props;
 
-  let linkProperties;
+  let linkProperties: LinkWithPathProperties;
 
   if (hasLinkProperties(props)) {
     // Handle new props with linkProperties
@@ -287,10 +288,11 @@ function CardComponent(props: CardComponentPropsType) {
   } else {
     const { linkTo, onLinkClick,  } = props;
     linkProperties = {
-      to: linkTo,
+      linkTo,
       onLinkClick,
       pathAttributeKeyName: 'to',
-      linkComponent: SmartLink
+      // @ts-expect-error SmartLink needs to be lazily loaded temporarily to prevent ui-library from loading react-router-dom
+      LinkElement: SmartLink
     };
   }
 

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -1,8 +1,8 @@
-import React, { lazy, MouseEventHandler } from 'react';
+import React, { lazy, MouseEventHandler, ComponentType } from 'react';
 import styled, { css } from 'styled-components';
-import { Link } from 'react-router-dom';
 import { format } from 'date-fns';
 import { CollecticonExpandTopRight } from '@devseed-ui/collecticons';
+import { Link } from 'react-router-dom';
 const SmartLink = lazy(() => import('../smart-link'));
 import {
   glsp,
@@ -221,7 +221,7 @@ export function ExternalLinkFlag() {
 }
 
 export interface LinkProperties {
-  LinkElement: JSX.Element | ((props: any) => JSX.Element);
+  LinkElement: JSX.Element | ((props: any) => JSX.Element) | ComponentType<any>;
   pathAttributeKeyName: string;
   onLinkClick?: MouseEventHandler;
 }
@@ -247,6 +247,7 @@ export interface CardComponentBaseProps {
 }
 
 // @TODO: Consolidate these props when the instance adapts the new syntax
+// Specifically: https://github.com/US-GHG-Center/veda-config-ghg/blob/develop/custom-pages/news-and-events/component.tsx#L108
 export interface CardComponentPropsDeprecated extends CardComponentBaseProps {
   linkTo: string;
   onLinkClick?: MouseEventHandler;
@@ -278,7 +279,8 @@ function CardComponent(props: CardComponentPropsType) {
     footerContent,
     onCardClickCapture
   } = props;
-
+// @TODO: This process is not necessary once all the instances adapt the linkProperties syntax
+// Consolidate them to use LinkProperties only
   let linkProperties: LinkWithPathProperties;
 
   if (hasLinkProperties(props)) {
@@ -291,7 +293,6 @@ function CardComponent(props: CardComponentPropsType) {
       linkTo,
       onLinkClick,
       pathAttributeKeyName: 'to',
-      // @ts-expect-error SmartLink needs to be lazily loaded temporarily to prevent ui-library from loading react-router-dom
       LinkElement: SmartLink
     };
   }

--- a/app/scripts/instance.ts
+++ b/app/scripts/instance.ts
@@ -41,6 +41,8 @@ import Hug from "$styles/hug";
 import { Actions } from "$components/common/browse-controls/use-browse-controls";
 import Image from "$components/common/blocks/images";
 
+import SmartLink from "$components/common/smart-link";
+
 export {
   STORIES_PATH,
   DATASETS_PATH,
@@ -67,6 +69,7 @@ export {
   FoldProse,
   Hug,
   Image,
+  SmartLink,
   Pill,
   Tip,
   VarHeading


### PR DESCRIPTION
**Related Ticket:** follow up of follow up -_- https://github.com/NASA-IMPACT/veda-ui/pull/1159

### Description of Changes
Urg I used wrong attributes, so the previous fix didn't really fix the problem. 
The previous approach broke the library build too by including SmartLink, which uses react-router-dom. I think I worked around by lazy loading the component in this PR. I tested it locally but if you can, please give it another test 🙇 

### Notes & Questions About Changes


### Validation / Testing
ok, this time, I actually created a preview on GHG; this is the page that  uses Card component: https://deploy-preview-596--ghg-demo.netlify.app/learn
