### PR TITLE
[RELEASE] Bump minor to v5.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@developmentseed/veda-ui",
   "description": "Dashboard",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
## 🎉 Features
- [E&A] Implement colormap configurability https://github.com/NASA-IMPACT/veda-ui/pull/1117
- [E&A] Feature flag colormap configurability https://github.com/NASA-IMPACT/veda-ui/pull/1147
- Add font md size as 20px for new Design System https://github.com/NASA-IMPACT/veda-ui/pull/1125
## 🚀 Improvements
- [E&A] Return default value of colormap along with other settings https://github.com/NASA-IMPACT/veda-ui/pull/1128
- Create new raster paint layer module and factor out BaseTimeseriesProps https://github.com/NASA-IMPACT/veda-ui/pull/1105
- Consolidate a place where to check linkProps https://github.com/NASA-IMPACT/veda-ui/pull/1121 https://github.com/NASA-IMPACT/veda-ui/pull/1160
- Expose Data Catalog and update child components to pass in routing/nav for library build https://github.com/NASA-IMPACT/veda-ui/pull/1096 https://github.com/NASA-IMPACT/veda-ui/pull/1159
- Set up eslint rule for no trailing spaces https://github.com/NASA-IMPACT/veda-ui/pull/1146
- Replace cmr-stac with titiler-cmr https://github.com/NASA-IMPACT/veda-ui/pull/1131
## 🐛 Fixes
- Update external link in top navigation target https://github.com/NASA-IMPACT/veda-ui/pull/1145
- Update PageHeader/Nav to not throw https://github.com/NASA-IMPACT/veda-ui/pull/1149
- [E&A] Fix to convert the time to usertzdate https://github.com/NASA-IMPACT/veda-ui/pull/1151
- Use sourceparams as it is when it is there https://github.com/NASA-IMPACT/veda-ui/pull/1148
- Fix compare label on block map https://github.com/NASA-IMPACT/veda-ui/pull/1153
- Discard the previous sourceExclusive value to fix the case when the datasets with different sourceExclusive can be selected together https://github.com/NASA-IMPACT/veda-ui/pull/1161
- Show the name of the selected filter on story hub https://github.com/NASA-IMPACT/veda-ui/pull/1161