### PR TITLE
Clean up the themed controls when unmounted

### DIFF
--- a/app/scripts/components/common/map/controls/hooks/use-themed-control.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-themed-control.tsx
@@ -49,6 +49,10 @@ export default function useThemedControl(
         <ThemeProvider theme={theme}>{renderFn() as any}</ThemeProvider>
       );
     }
+    return () => {
+      rootRef.current?.unmount();
+      rootRef.current = null;
+    };
   }, [renderFn, theme]);
 
   useControl(() => new ThemedControl(), opts);


### PR DESCRIPTION

### Description of Changes
Clean up ref when themed controls are unmounted

### Notes & Questions About Changes

I kept seeing an error that 'cannot update unmounted root' from dev environment of Next instance. I think it is because our themed control doesn't clean up its ref when unmounted. (It happens when I revisit the page while navigating - does not happen on the first landing.)

<img width="1523" alt="Screenshot 2024-09-25 at 10 00 11 AM" src="https://github.com/user-attachments/assets/da5fa4b6-250f-4dd5-8125-ef73eaf1892f">

But I do have some questions 🤔 
- It doesn't happen on production env: https://veda-ui-next-test.netlify.app/stories/lahina-fire
- It happens only on the first map element of the page. Why would that be? 

