### PR TITLE
Check dastaset analysis exclude attribute before running analysis

### DIFF
--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -107,6 +107,18 @@ export async function requestDatasetTimeseriesData({
     };
   }
 
+  if (datasetData.analysis?.exclude) {
+    return {
+      status: DatasetStatus.ERROR,
+      meta: {},
+      error: new ExtendedError(
+        'Analysis is turend off for the dataset',
+        'ANALYSIS_NOT_SUPPORTED'
+      ),
+      data: null
+    };
+  }
+
   const id = datasetData.id;
 
   onProgress({

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -112,7 +112,7 @@ export async function requestDatasetTimeseriesData({
       status: DatasetStatus.ERROR,
       meta: {},
       error: new ExtendedError(
-        'Analysis is turend off for the dataset',
+        'Analysis is turned off for the dataset',
         'ANALYSIS_NOT_SUPPORTED'
       ),
       data: null


### PR DESCRIPTION
**Related Ticket:** #1164 

### Description of Changes
Check `analysis.exclude` before running analysis and throw a guided error if it is marked as excluded from analysis

<img width="2393" alt="Screenshot 2024-09-26 at 9 46 45 AM" src="https://github.com/user-attachments/assets/b49f1194-9e73-4356-8e4d-1c4b5e6b8fab">
