### PR TITLE
Make cookie consent component not to receive mouse events when closed

### DIFF
--- a/app/scripts/components/common/cookie-consent/index.scss
+++ b/app/scripts/components/common/cookie-consent/index.scss
@@ -1,3 +1,7 @@
 .animation--fade-out {
   transition: opacity 0.5s ease-in-out 0.125s;
 }
+
+.pointer-events--none {
+  pointer-events: none;
+}

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -57,7 +57,7 @@ export const CookieConsent = ({
     <div
       id='cookie-consent'
       className={`margin-0 tablet:margin-2 shadow-2 position-fixed z-top maxw-full tablet:maxw-tablet-lg animation--fade-out right-0 bottom-0 ${
-        cookieConsentResponded || closeConsent ? ' opacity-0' : 'opacity-1'
+        cookieConsentResponded || closeConsent ? ' opacity-0 z-bottom pointer-events--none' : 'opacity-1 z-top'
       }`}
     >
       <USWDSAlert


### PR DESCRIPTION
**Related Ticket:** #953 

### Description of Changes
Make cookie consent component not to receive mouse events when closed.

### Notes & Questions About Changes
This might be able to be resolved with #1170 , but here is a quick fix.


### Validation / Testing
Go to https://veda-ui.netlify.app/exploration?datasets=%5B%5D&taxonomy=%7B%7D , close cookie consent form and try to add datasets. The button click is blocked because we are hiding the component only with opacity.  (And check the same work flow on this PR's preview)
