### PR TITLE
Restrict dynamic colormaps to applicable layer types

### DIFF
--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -140,6 +140,18 @@ const hasValidSourceParams = (params) => {
 };
 
 /**
+ * Utility to check if render parameters are applicable based on dataset type.
+ *
+ * @param datasetType The type of the dataset (e.g., 'vector').
+ * @returns Boolean indicating if render parameters are applicable.
+ */
+export const isRenderParamsApplicable = (datasetType: string): boolean => {
+  const nonApplicableTypes = ['vector'];
+
+  return !nonApplicableTypes.includes(datasetType);
+};
+
+/**
  * Util to flatten and process rescale values,
  *
  * The need for flattening is because the `rescale` values can be received
@@ -182,14 +194,23 @@ export function resolveRenderParams(
   }
 
   // Check for the dashboard render configuration in queryData
-  if (!queryDataRenders) throw new Error ('No render parameter exists from stac endpoint.');
+  if (!queryDataRenders)
+    throw new Error('No render parameter exists from stac endpoint.');
 
   // Check the namespace from render extension
-  const renderKey = queryDataRenders.dashboard? 'dashboard' : datasetSourceParams?.assets;
-  if (!queryDataRenders[renderKey]) throw new Error ('No proper render parameter for dashboard namespace exists.');
+  const renderKey = queryDataRenders.dashboard
+    ? 'dashboard'
+    : datasetSourceParams?.assets;
+  if (!queryDataRenders[renderKey])
+    throw new Error(
+      'No proper render parameter for dashboard namespace exists.'
+    );
 
   // Return the render extension parameter
-  if (queryDataRenders[renderKey] && hasValidSourceParams(queryDataRenders[renderKey])) {
+  if (
+    queryDataRenders[renderKey] &&
+    hasValidSourceParams(queryDataRenders[renderKey])
+  ) {
     const renderParams = queryDataRenders[renderKey];
     return {
       ...renderParams,

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -19,7 +19,12 @@ import {
 } from './components/datasets/analysis-metrics';
 import { DEFAULT_COLORMAP } from './components/datasets/colormap-options';
 import { utcString2userTzDate } from '$utils/date';
-import { DatasetLayer, VedaDatum, DatasetData } from '$types/veda';
+import {
+  DatasetLayer,
+  VedaDatum,
+  DatasetData,
+  DatasetLayerType
+} from '$types/veda';
 
 // @NOTE: All fns from './date-utils` should eventually move here to get rid of their faux modules dependencies
 // `./date-utils` to be deprecated!!
@@ -145,7 +150,9 @@ const hasValidSourceParams = (params) => {
  * @param datasetType The type of the dataset (e.g., 'vector').
  * @returns Boolean indicating if render parameters are applicable.
  */
-export const isRenderParamsApplicable = (datasetType: string): boolean => {
+export const isRenderParamsApplicable = (
+  datasetType: DatasetLayerType
+): boolean => {
   const nonApplicableTypes = ['vector'];
 
   return !nonApplicableTypes.includes(datasetType);

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -13,7 +13,8 @@ import {
 } from '../types.d.ts';
 import {
   resolveLayerTemporalExtent,
-  resolveRenderParams
+  resolveRenderParams,
+  isRenderParamsApplicable
 } from '../data-utils-no-faux-module';
 import { useEffectPrevious } from '$utils/use-effect-previous';
 import { SetState } from '$types/aliases';
@@ -47,10 +48,14 @@ function reconcileQueryDataWithDataset(
     if (queryData.status === DatasetStatus.SUCCESS) {
       const domain = resolveLayerTemporalExtent(base.data.id, queryData.data);
 
-      const renderParams = resolveRenderParams(
-        base.data.sourceParams,
-        queryData.data.renders
-      );
+      let renderParams;
+
+      if (isRenderParamsApplicable(base.data.type)) {
+        renderParams = resolveRenderParams(
+          base.data.sourceParams,
+          queryData.data.renders
+        );
+      }
 
       base = {
         ...base,
@@ -58,7 +63,7 @@ function reconcileQueryDataWithDataset(
           ...base.data,
           ...queryData.data,
           domain,
-          sourceParams: renderParams
+          ...(renderParams && { sourceParams: renderParams })
         }
       };
     }


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1182

### Description of Changes
1. Added util function `isRenderParamsApplicable` to handle the exclusion of render parameters for vector datasets (for now, add more if applicable in the future)
2. Updated logic in `reconcileQueryDataWithDataset` to prevent errors when processing vector datasets that don't support colormaps or rescaling

### Notes & Questions About Changes
Vector datasets should be excluded from applying dynamic colormaps.

### Validation / Testing

1. Verify that vector datasets no longer trigger errors in the exploration view
2. Test colormap functionality on raster datasets and make sure there are no regressions