### PR TITLE
Color maps range slider implementation

### DIFF
--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -13,6 +13,7 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   colorMap?: string | undefined;
   tileParams: Record<string, any>;
   generatorPrefix?: string;
+  scale?: { min: number; max: number };
 }
 
 export function RasterPaintLayer(props: RasterPaintLayerProps) {
@@ -24,7 +25,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     hidden,
     opacity,
     colorMap,
-    generatorPrefix = 'raster',
+    scale,
+    generatorPrefix = 'raster'
   } = props;
 
   const { updateStyle } = useMapStyle();
@@ -32,8 +34,14 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
   const generatorId = `${generatorPrefix}-${id}`;
 
   const updatedTileParams = useMemo(() => {
-    return { ...tileParams, ...colorMap &&  {colormap_name: colorMap}};
-  }, [tileParams, colorMap]);
+    return {
+      ...tileParams,
+      ...(colorMap && {
+        colormap_name: colorMap
+      }),
+      ...(scale && { rescale: Object.values(scale) })
+    };
+  }, [tileParams, colorMap, scale]);
 
   //
   // Generate Mapbox GL layers and sources for raster timeseries
@@ -47,7 +55,9 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
 
   useEffect(
     () => {
-      const tileParamsAsString = qs.stringify(updatedTileParams, { arrayFormat: 'comma' });
+      const tileParamsAsString = qs.stringify(updatedTileParams, {
+        arrayFormat: 'comma'
+      });
 
       const zarrSource: RasterSource = {
         type: 'raster',
@@ -63,8 +73,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
         paint: {
           'raster-opacity': hidden ? 0 : rasterOpacity,
           'raster-opacity-transition': {
-            duration: 320,
-          },
+            duration: 320
+          }
         },
         minzoom: minZoom,
         metadata: {
@@ -93,7 +103,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       tileApiEndpoint,
       haveTileParamsChanged,
       generatorParams,
-      colorMap
+      colorMap,
+      scale
       // generatorParams includes hidden and opacity
       // hidden,
       // opacity,

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -13,7 +13,7 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   colorMap?: string | undefined;
   tileParams: Record<string, any>;
   generatorPrefix?: string;
-  scale?: { min: number; max: number };
+  reScale?: { min: number; max: number };
 }
 
 export function RasterPaintLayer(props: RasterPaintLayerProps) {
@@ -25,7 +25,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     hidden,
     opacity,
     colorMap,
-    scale,
+    reScale,
     generatorPrefix = 'raster'
   } = props;
 
@@ -39,9 +39,9 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       ...(colorMap && {
         colormap_name: colorMap
       }),
-      ...(scale && { rescale: Object.values(scale) })
+      ...(reScale && { rescale: Object.values(reScale) })
     };
-  }, [tileParams, colorMap, scale]);
+  }, [tileParams, colorMap, reScale]);
 
   //
   // Generate Mapbox GL layers and sources for raster timeseries
@@ -104,7 +104,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       haveTileParamsChanged,
       generatorParams,
       colorMap,
-      scale
+      reScale
       // generatorParams includes hidden and opacity
       // hidden,
       // opacity,

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -367,7 +367,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           {
             assets: 'cog_default',
             ...(sourceParams ?? {}),
-            ...(colorMap && { colormap_name: colorMap, rescale: Object.values(reScale) })
+            ...(colorMap && { colormap_name: colorMap }),
+            ...(reScale && {rescale: Object.values(reScale)})
           },
           // Temporary solution to pass different tile parameters for hls data
           {

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -63,10 +63,10 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     stacApiEndpoint,
     tileApiEndpoint,
     colorMap,
+    reScale
   } = props;
 
   const { current: mapInstance } = useMaps();
-
   const theme = useTheme();
   const { updateStyle } = useMapStyle();
 
@@ -270,7 +270,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             controller
           });
           const mosaicUrl = responseData.links[1].href;
-          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
+          setMosaicUrl(
+            mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad')
+          );
         } catch (error) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance...
           if (error.request) {
@@ -284,10 +286,14 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             const mosaicUrl = responseData.links[1].href;
             setMosaicUrl(mosaicUrl);
           } else {
-              LOG &&
+            LOG &&
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register %cEndpoint error', 'color: red;', error);
-              throw error;
+              console.log(
+                'Titiler /register %cEndpoint error',
+                'color: red;',
+                error
+              );
+            throw error;
           }
         }
 
@@ -361,7 +367,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           {
             assets: 'cog_default',
             ...(sourceParams ?? {}),
-            ...colorMap &&  {colormap_name: colorMap}
+            ...(colorMap && { colormap_name: colorMap, rescale: Object.values(reScale) })
           },
           // Temporary solution to pass different tile parameters for hls data
           {
@@ -489,6 +495,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   }, [
     mosaicUrl,
     colorMap,
+    reScale,
     points,
     minZoom,
     haveSourceParamsChanged,

--- a/app/scripts/components/common/map/types.d.ts
+++ b/app/scripts/components/common/map/types.d.ts
@@ -54,6 +54,7 @@ export interface BaseTimeseriesProps extends BaseGeneratorParams {
   zoomExtent?: number[];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   colorMap?: string;
+  reScale?: { min: number; max: number };
 }
 
 // export interface ZarrTimeseriesProps extends BaseTimeseriesProps {

--- a/app/scripts/components/common/uswds/index.tsx
+++ b/app/scripts/components/common/uswds/index.tsx
@@ -2,3 +2,5 @@ export { USWDSAlert } from './alert';
 export { USWDSButtonGroup, USWDSButton } from './button';
 export { USWDSLink } from './link';
 export { USWDSBanner, USWDSBannerContent } from './banner';
+
+export { USWDSTextInput, USWDSTextInputMask } from './input';

--- a/app/scripts/components/common/uswds/input.tsx
+++ b/app/scripts/components/common/uswds/input.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { TextInput, TextInputMask } from "@trussworks/react-uswds";
+
+export function USWDSTextInput(props) {
+  return <TextInput {...props} />;
+}
+
+export function USWDSTextInputMask(props) {
+    return <TextInputMask {...props} />;
+  }

--- a/app/scripts/components/exploration/atoms/hooks.ts
+++ b/app/scripts/components/exploration/atoms/hooks.ts
@@ -157,6 +157,17 @@ export function useTimelineDatasetColormap(
   return useAtom(colorMapAtom);
 }
 
+export function useTimelineDatasetColormapScale(
+  datasetAtom: PrimitiveAtom<TimelineDataset>
+) {
+  const colorMapScaleAtom = useMemo(() => {
+    return focusAtom(datasetAtom, (optic) =>
+      optic.prop('settings').prop('scale')
+    );
+  }, [datasetAtom]);
+
+  return useAtom(colorMapScaleAtom);
+}
 export const useTimelineDatasetAnalysis = (
   datasetAtom: PrimitiveAtom<TimelineDataset>
 ) => {

--- a/app/scripts/components/exploration/components/datasets/color-range-slider.scss
+++ b/app/scripts/components/exploration/components/datasets/color-range-slider.scss
@@ -1,12 +1,3 @@
-
-.slider__track {
-  background-color: #dddfe2;
-}
-
-.slider__range {
-  background-color: #1565ef;
-}
-
 /* Removing the default appearance */
 .thumb,
 .thumb::-webkit-slider-thumb {
@@ -18,9 +9,6 @@
 
 .thumb {
   pointer-events: none;
-}
-.middle-marker {
-  background-color: #1b2631;
 }
 /* For Chrome browsers */
 .thumb::-webkit-slider-thumb {

--- a/app/scripts/components/exploration/components/datasets/color-range-slider.scss
+++ b/app/scripts/components/exploration/components/datasets/color-range-slider.scss
@@ -1,3 +1,4 @@
+
 .slider__track {
   background-color: #dddfe2;
 }
@@ -9,6 +10,8 @@
 /* Removing the default appearance */
 .thumb,
 .thumb::-webkit-slider-thumb {
+  touch-action: 'none';
+
   -webkit-appearance: none;
   -webkit-tap-highlight-color: transparent;
 }
@@ -16,8 +19,8 @@
 .thumb {
   pointer-events: none;
 }
-.middle_marker{
-  background-color: #1B2631;
+.middle-marker {
+  background-color: #1b2631;
 }
 /* For Chrome browsers */
 .thumb::-webkit-slider-thumb {

--- a/app/scripts/components/exploration/components/datasets/color-range-slider.scss
+++ b/app/scripts/components/exploration/components/datasets/color-range-slider.scss
@@ -1,0 +1,59 @@
+.slider__track {
+  background-color: #dddfe2;
+}
+
+.slider__range {
+  background-color: #1565ef;
+}
+
+/* Removing the default appearance */
+.thumb,
+.thumb::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.thumb {
+  pointer-events: none;
+}
+.middle_marker{
+  background-color: #1B2631;
+}
+/* For Chrome browsers */
+.thumb::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  pointer-events: all;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border-radius: 50%;
+  border: 2px solid #1565ef;
+  border-width: 1px;
+  box-shadow: 0 0 0 1px #c6c6c6;
+  cursor: pointer;
+}
+
+/* For Firefox browsers */
+.thumb::-moz-range-thumb {
+  -webkit-appearance: none;
+  pointer-events: all;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border-radius: 50%;
+  border: 2px solid #1565ef;
+  border-width: 1px;
+  box-shadow: 0 0 0 1px #c6c6c6;
+  cursor: pointer;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type='number'] {
+  -moz-appearance: textfield;
+}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
@@ -212,7 +212,7 @@ export function ColorRangeSlider({
               {min < 0 ? (
                 <div
                   ref={middleMarker}
-                  className='position-relative height-2 width-1px middle_marker'
+                  className='position-relative height-2 width-1px middle-marker'
                 />
               ) : null}
             </div>

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
@@ -111,7 +111,7 @@ export function ColorRangeSlider({
         }
       }
     }
-
+    // determining if there is an initial colorMapeScale or if it is the default min and max
     if (
       !colorMapScale ||
       (colorMapScale.max == max && colorMapScale.min == min)

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
@@ -25,9 +25,6 @@ export function ColorRangeSlider({
   colorMapScale,
   setColorMapScale
 }: ColorrangeRangeSlideProps) {
-  const fromInput = useRef(null);
-  const toInput = useRef(null);
-
   const [minVal, setMinVal] = useState(min);
   const [maxVal, setMaxVal] = useState(max);
   const [inputError, setInputError] = useState({ min: false, max: false });
@@ -103,11 +100,10 @@ export function ColorRangeSlider({
         </label>
 
         <USWDSTextInput
-          ref={fromInput}
           type='number'
           id='range slider min'
           name='min'
-          placeHolder={minValRef.current}
+          placeholder={minValRef.current}
           className={`${textInputClasses} ${
             inputError.min
               ? 'border-secondary-vivid text-secondary-vivid'
@@ -185,11 +181,10 @@ export function ColorRangeSlider({
           </div>
         </div>
         <USWDSTextInput
-          ref={toInput}
           type='number'
           id='range slider max'
           name='max'
-          placeHolder={maxValRef.current}
+          placeholder={maxValRef.current}
           className={`${textInputClasses} ${
             inputError.max
               ? 'border-secondary-vivid text-secondary-vivid'

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useEffect, useState, useRef } from 'react';
+
+import './color-range-slider.scss';
+
+import { USWDSTextInput } from '$components/common/uswds';
+
+export function ColorRangeSlider({ min, max, onChange }) {
+  const fromInput = useRef(null);
+  const toInput = useRef(null);
+
+  const [minVal, setMinVal] = useState(min);
+  const [maxVal, setMaxVal] = useState(max);
+  const [inputError, setInputError] = useState({ min: false, max: false });
+
+  const minValRef = useRef(min);
+  const maxValRef = useRef(max);
+  const range = useRef(null);
+  const middleMarker = useRef(null);
+
+  // Convert to percentage
+  const getPercent = useCallback(
+    (value) => Math.round(((value - min) / (max - min)) * 100),
+    [min, max]
+  );
+
+  // Set width of the range to decrease from the right side
+  useEffect(() => {
+    let maxValPrevious;
+
+    let minValPrevious;
+    if (maxVal != maxValPrevious) {
+      maxValPrevious = maxVal;
+      const minPercent = getPercent(minValRef.current);
+      const maxPercent = getPercent(maxVal);
+
+      if (range.current) {
+        range.current.style.width = `${
+          maxPercent - minPercent >= 100 ? 100 : maxPercent - minPercent
+        }%`;
+        if (middleMarker.current)
+          middleMarker.current.style.left = `${range.current.style.width}%`;
+      }
+    }
+    if (minVal != minValPrevious) {
+      minValPrevious = maxVal;
+      const minPercent = getPercent(minVal);
+      const maxPercent = getPercent(maxValRef.current);
+
+      if (range.current) {
+        range.current.style.left = `${minPercent}%`;
+        range.current.style.width = `${
+          maxPercent - minPercent >= 100 ? 100 : maxPercent - minPercent
+        }%`;
+      }
+    }
+    onChange({ min: minVal, max: maxVal });
+  }, [maxVal, minVal, getPercent, onChange]);
+
+  const textInputClasses =
+    'flex-1 radius-md height-3 font-size-3xs width-5 border-2px ';
+  const thumbPosition = `position-absolute pointer-events width-card height-0 outline-0`;
+
+  const dynamicStepIncrement = (max, min) => {
+    // determining numeric distance between min and max
+    const value = Math.abs(max - min);
+    const tenLog = Math.floor(Math.log(value) / Math.log(10));
+  };
+  return (
+    <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
+      <form className='usa-form display-flex flex-row flex-justify flex-align-center padding-bottom-1'>
+        <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1 flex-1'>
+          Rescale
+        </label>
+
+        <USWDSTextInput
+          ref={fromInput}
+          type='number'
+          id='range slider min'
+          name='min'
+          placeHolder={minValRef.current}
+          className={`${textInputClasses} ${
+            inputError.min
+              ? 'border-secondary-vivid text-secondary-vivid'
+              : ' border-base-light'
+          }`}
+          value={minValRef.current}
+          min={min}
+          max={max}
+          onChange={(event) => {
+            const value = Number(event.target.value);
+
+            if (value < min || value > max) {
+              return setInputError({ max: inputError.max, min: true });
+            }
+            setInputError({ max: inputError.max, min: false });
+
+            setMinVal(value);
+            return (minValRef.current = value);
+          }}
+        />
+
+        <div className='position-relative container display-flex flex-align-center flex-justify-center padding-x-2'>
+          <input
+            type='range'
+            min={min}
+            max={max}
+            step='.001'
+            value={minVal}
+            onChange={(event) => {
+              setMinVal(Math.min(Number(event.target.value), maxVal - 0.01));
+              minValRef.current = Number(event.target.value);
+            }}
+            className={`thumb ${thumbPosition} z-index-300`}
+            style={{ zIndex: minVal >= max - 10 * 0.01 ? '500' : '300' }}
+          />
+          <input
+            type='range'
+            min={min}
+            step='.001'
+            max={max}
+            value={maxVal}
+            onChange={(event) => {
+              setMaxVal(Math.max(Number(event.target.value), minVal + 0.01));
+              maxValRef.current = Number(event.target.value);
+            }}
+            className={`thumb ${thumbPosition} z-400`}
+            style={{ zIndex: minVal <= max - 10 * 0.01 ? '500' : '400' }}
+          />
+          <div className='slider width-card position-relative height-3 display-flex flex-align-center'>
+            <div className='slider__track radius-md position-absolute height-05 z-100 width-full display-flex flex-align-center' />
+            <div
+              ref={range}
+              className='slider__range display-flex flex-align-center flex-justify-center radius-md position-absolute height-05 z-200'
+            >
+              {min < 0 ? (
+                <div
+                  ref={middleMarker}
+                  className='position-relative height-2 width-1px middle_marker'
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <USWDSTextInput
+          ref={toInput}
+          type='number'
+          id='range slider max'
+          name='max'
+          min={min}
+          max={max}
+          placeHolder={maxValRef.current}
+          className={`${textInputClasses} ${
+            inputError.max
+              ? 'border-secondary-vivid text-secondary-vivid'
+              : ' border-base-light'
+          }`}
+          value={maxValRef.current}
+          onChange={(event) => {
+            const value = Number(event.target.value);
+
+            if (value < min || value > max) {
+              return setInputError({ max: true, min: inputError.min });
+            } else{
+            setInputError({ max: false, min: inputError.min });
+            setMaxVal(value);
+            return (maxValRef.current = value);}
+
+            //NEED to find the value on change for color maps.
+          }}
+        />
+      </form>
+      {inputError.max || inputError.min ? (
+        <p className='text-secondary-vivid'>
+          Please enter a value between {min} and {max}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider.tsx
@@ -29,8 +29,12 @@ export function ColorRangeSlider({
   const [maxVal, setMaxVal] = useState(max);
   const [inputError, setInputError] = useState({ min: false, max: false });
 
-  const minValRef = useRef(colorMapScale?.min ? colorMapScale.min : min);
-  const maxValRef = useRef(colorMapScale?.max ? colorMapScale.max : max);
+  const minValRef = useRef(
+    String(colorMapScale?.min ? colorMapScale.min : min)
+  );
+  const maxValRef = useRef(
+    String(colorMapScale?.max ? colorMapScale.max : max)
+  );
   const range = useRef(null);
   const middleMarker = useRef(null);
 
@@ -65,7 +69,6 @@ export function ColorRangeSlider({
         const maxPercent = getPercent(maxVal);
         rangeCalculation(maxPercent, minPercent);
       }
-
       if (minVal != minValPrevious) {
         minValPrevious = minVal;
         const minPercent = getPercent(minVal);
@@ -76,22 +79,19 @@ export function ColorRangeSlider({
     }
     if (
       !colorMapScale ||
-      colorMapScale.max == max ||
-      colorMapScale.min == min
+      (colorMapScale.max == max && colorMapScale.min == min)
     ) {
       setColorMapScale({ min: minVal, max: maxVal });
-    }
+    } else
+      setColorMapScale({
+        min: Number(minValRef.current),
+        max: Number(maxValRef.current)
+      });
   }, [maxVal, minVal, getPercent, setColorMapScale]);
 
   const textInputClasses =
     'flex-1 radius-md height-3 font-size-3xs width-5 border-2px ';
   const thumbPosition = `position-absolute pointer-events width-card height-0 outline-0`;
-
-  const dynamicStepIncrement = (max, min) => {
-    // determining numeric distance between min and max
-    const value = Math.abs(max - min);
-    const tenLog = Math.floor(Math.log(value) / Math.log(10));
-  };
   return (
     <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
       <form className='usa-form display-flex flex-row flex-justify flex-align-center padding-bottom-1'>
@@ -112,18 +112,14 @@ export function ColorRangeSlider({
           value={minValRef.current}
           onChange={(event) => {
             const value = Number(event.target.value);
-            if (value > maxVal - 0.01) return false;
-            if (value < min || value > max) {
-              return setInputError({ max: inputError.max, min: true });
-            }
-            setInputError({ max: inputError.max, min: false });
-            setMinVal(Math.min(value, minVal + 0.01));
-            setColorMapScale({
-              min: minValRef.current,
-              max: colorMapScale.max
-            });
-
-            return (minValRef.current = value);
+            minValRef.current = value;
+            setTimeout(() => {
+              if (value > maxVal - 0.001) return false;
+              if (value < min || value > max) {
+                return setInputError({ max: inputError.max, min: true });
+              } else setInputError({ max: inputError.max, min: false });
+              setMinVal(Math.min(value, maxVal - 0.001));
+            }, 2500);
           }}
         />
 
@@ -136,15 +132,11 @@ export function ColorRangeSlider({
             value={minValRef.current}
             onChange={(event) => {
               const value = Number(event.target.value);
-              setMinVal(Math.min(value, maxVal - 0.01));
+              setMinVal(Math.min(value, maxVal - 0.001));
               minValRef.current = value;
-              setColorMapScale({
-                min: minValRef.current,
-                max: colorMapScale.max
-              });
             }}
             className={`thumb ${thumbPosition} z-index-300`}
-            style={{ zIndex: minVal >= max - 10 * 0.01 ? '500' : '300' }}
+            style={{ zIndex: minVal >= max - 10 * 0.001 ? '500' : '300' }}
           />
           <input
             type='range'
@@ -153,17 +145,13 @@ export function ColorRangeSlider({
             max={max}
             value={maxValRef.current}
             onChange={(event) => {
-              setMaxVal(Math.max(Number(event.target.value), minVal + 0.01));
-              maxValRef.current = Number(event.target.value);
-              console.log('maxValRef.current', maxValRef.current);
+              const value = Number(event.target.value);
 
-              setColorMapScale({
-                min: colorMapScale.min,
-                max: maxValRef.current
-              });
+              setMaxVal(Math.max(value, minVal + 0.001));
+              maxValRef.current = value;
             }}
             className={`thumb ${thumbPosition} z-400`}
-            style={{ zIndex: minVal <= max - 10 * 0.01 ? '500' : '400' }}
+            style={{ zIndex: minVal <= max - 10 * 0.001 ? '500' : '400' }}
           />
           <div className='slider width-card position-relative height-3 display-flex flex-align-center'>
             <div className='slider__track radius-md position-absolute height-05 z-100 width-full display-flex flex-align-center' />
@@ -182,6 +170,7 @@ export function ColorRangeSlider({
         </div>
         <USWDSTextInput
           type='number'
+          data-validate-numerical='[0-9]*'
           id='range slider max'
           name='max'
           placeholder={maxValRef.current}
@@ -193,17 +182,13 @@ export function ColorRangeSlider({
           value={maxValRef.current}
           onChange={(event) => {
             const value = Number(event.target.value);
-            if (value < minVal + 0.01) return false;
+            if (value < minVal + 0.001) return false;
             if (value < min || value > max) {
               return setInputError({ max: true, min: inputError.min });
             } else {
               setInputError({ max: false, min: inputError.min });
-              setMaxVal(Math.max(value, minVal + 0.01));
-              setColorMapScale({
-                min: colorMapScale.min,
-                max: maxValRef.current
-              });
-              return (maxValRef.current = value);
+              setMaxVal(Math.max(value, minVal + 0.001));
+              maxValRef.current = event.target.value;
             }
           }}
         />

--- a/app/scripts/components/exploration/components/datasets/colormap-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/colormap-options.tsx
@@ -10,6 +10,7 @@ import {
 
 import './colormap-options.scss';
 import { ColorRangeSlider } from './colorRangeSlider';
+import { colorMapScale } from '$components/exploration/types.d.ts';
 
 export const DEFAULT_COLORMAP = 'viridis';
 
@@ -51,6 +52,8 @@ interface ColormapOptionsProps {
   setColorMap: (colorMap: string) => void;
   min: number;
   max: number;
+  setColorMapScale: (colorMapScale: colorMapScale) => void;
+  colorMapScale: colorMapScale | undefined;
 }
 
 export const getColormapColors = (
@@ -79,7 +82,9 @@ export function ColormapOptions({
   colorMap = DEFAULT_COLORMAP,
   min,
   max,
-  setColorMap
+  setColorMap,
+  setColorMapScale,
+  colorMapScale
 }: ColormapOptionsProps) {
   const initialIsReversed = colorMap.endsWith('_r');
   const initialColorMap = normalizeColorMap(colorMap);
@@ -154,7 +159,12 @@ export function ColormapOptions({
       </div>
 
       <div className='display-flex flex-align-center flex-column flex-justify border-top-1px border-bottom-1px border-base-lightest bg-base-lightest padding-2'>
-        <ColorRangeSlider min={min} max={max} onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)} />
+        <ColorRangeSlider
+          min={min}
+          max={max}
+          colorMapScale={colorMapScale}
+          setColorMapScale={setColorMapScale}
+        />
         <div
           className='display-flex flex-align-center width-full padding-top-1'
           onClick={handleReverseToggle}

--- a/app/scripts/components/exploration/components/datasets/colormap-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/colormap-options.tsx
@@ -1,23 +1,39 @@
 import React, { useEffect, useState } from 'react';
-import { Icon } from "@trussworks/react-uswds";
+import { Icon } from '@trussworks/react-uswds';
 import { CollecticonDrop } from '@devseed-ui/collecticons';
-import { sequentialColorMaps, divergingColorMaps, restColorMaps } from './colorMaps';
+
+import {
+  sequentialColorMaps,
+  divergingColorMaps,
+  restColorMaps
+} from './colorMaps';
 
 import './colormap-options.scss';
+import { ColorRangeSlider } from './colorRangeSlider';
 
 export const DEFAULT_COLORMAP = 'viridis';
 
 const CURATED_SEQUENTIAL_COLORMAPS = [
-  'viridis', 'plasma', 'inferno', 'magma', 'cividis',
-  'purples', 'blues', 'reds', 'greens', 'oranges',
-  'ylgnbu', 'ylgn', 'gnbu'
+  'viridis',
+  'plasma',
+  'inferno',
+  'magma',
+  'cividis',
+  'purples',
+  'blues',
+  'reds',
+  'greens',
+  'oranges',
+  'ylgnbu',
+  'ylgn',
+  'gnbu'
 ];
 
-const CURATED_DIVERGING_COLORMAPS = [
-  'rdbu', 'rdylbu', 'bwr', 'coolwarm'
-];
+const CURATED_DIVERGING_COLORMAPS = ['rdbu', 'rdylbu', 'bwr', 'coolwarm'];
 
-export const classifyColormap = (colormapName: string): 'sequential' | 'diverging' | 'rest' | 'unknown' => {
+export const classifyColormap = (
+  colormapName: string
+): 'sequential' | 'diverging' | 'rest' | 'unknown' => {
   const baseName = normalizeColorMap(colormapName);
 
   if (sequentialColorMaps[baseName]) {
@@ -33,9 +49,14 @@ export const classifyColormap = (colormapName: string): 'sequential' | 'divergin
 interface ColormapOptionsProps {
   colorMap: string | undefined;
   setColorMap: (colorMap: string) => void;
+  min: number;
+  max: number;
 }
 
-export const getColormapColors = (colormapName: string, isReversed: boolean): string[] => {
+export const getColormapColors = (
+  colormapName: string,
+  isReversed: boolean
+): string[] => {
   const baseName = normalizeColorMap(colormapName);
   const colormapData =
     sequentialColorMaps[baseName] ||
@@ -49,10 +70,17 @@ export const getColormapColors = (colormapName: string, isReversed: boolean): st
     return `rgba(${r}, ${g}, ${b}, ${a})`;
   });
 
-  return isReversed ? colors.reduceRight((acc, color) => [...acc, color], []) : colors;
+  return isReversed
+    ? colors.reduceRight((acc, color) => [...acc, color], [])
+    : colors;
 };
 
-export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: ColormapOptionsProps) {
+export function ColormapOptions({
+  colorMap = DEFAULT_COLORMAP,
+  min,
+  max,
+  setColorMap
+}: ColormapOptionsProps) {
   const initialIsReversed = colorMap.endsWith('_r');
   const initialColorMap = normalizeColorMap(colorMap);
 
@@ -63,9 +91,15 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
   const [customColorMap, setCustomColorMap] = useState<string | null>(null);
 
   useEffect(() => {
-    if (colormapType === 'sequential' && !CURATED_SEQUENTIAL_COLORMAPS.includes(selectedColorMap)) {
+    if (
+      colormapType === 'sequential' &&
+      !CURATED_SEQUENTIAL_COLORMAPS.includes(selectedColorMap)
+    ) {
       setCustomColorMap(selectedColorMap);
-    } else if (colormapType === 'diverging' && !CURATED_DIVERGING_COLORMAPS.includes(selectedColorMap)) {
+    } else if (
+      colormapType === 'diverging' &&
+      !CURATED_DIVERGING_COLORMAPS.includes(selectedColorMap)
+    ) {
       setCustomColorMap(selectedColorMap);
     }
   }, [selectedColorMap, colormapType]);
@@ -74,15 +108,25 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
   if (colormapType === 'sequential') {
     if (customColorMap) {
-      availableColormaps = [{ name: customColorMap }, ...CURATED_SEQUENTIAL_COLORMAPS.map(name => ({ name }))];
+      availableColormaps = [
+        { name: customColorMap },
+        ...CURATED_SEQUENTIAL_COLORMAPS.map((name) => ({ name }))
+      ];
     } else {
-      availableColormaps = CURATED_SEQUENTIAL_COLORMAPS.map(name => ({ name }));
+      availableColormaps = CURATED_SEQUENTIAL_COLORMAPS.map((name) => ({
+        name
+      }));
     }
   } else if (colormapType === 'diverging') {
     if (customColorMap) {
-      availableColormaps = [{ name: customColorMap }, ...CURATED_DIVERGING_COLORMAPS.map(name => ({ name }))];
+      availableColormaps = [
+        { name: customColorMap },
+        ...CURATED_DIVERGING_COLORMAPS.map((name) => ({ name }))
+      ];
     } else {
-      availableColormaps = CURATED_DIVERGING_COLORMAPS.map(name => ({ name }));
+      availableColormaps = CURATED_DIVERGING_COLORMAPS.map((name) => ({
+        name
+      }));
     }
   } else if (colormapType === 'rest') {
     availableColormaps = [{ name: selectedColorMap }];
@@ -105,17 +149,31 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
   return (
     <div className='colormap-options__container bg-white shadow-1 maxh-mobile-lg'>
-      <div className='display-flex flex-align-center text-gray-90 padding-2 font-heading-xs text-bold'><CollecticonDrop className='margin-right-1' /> Colormap options</div>
+      <div className='display-flex flex-align-center text-gray-90 padding-2 font-heading-xs text-bold'>
+        <CollecticonDrop className='margin-right-1' /> Colormap options
+      </div>
 
-      <div className='display-flex flex-align-center flex-justify border-top-1px border-bottom-1px border-base-lightest bg-base-lightest padding-2'>
-        <div className='display-flex flex-align-center' onClick={handleReverseToggle}>
-          <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1'>Reverse</label>
+      <div className='display-flex flex-align-center flex-column flex-justify border-top-1px border-bottom-1px border-base-lightest bg-base-lightest padding-2'>
+        <ColorRangeSlider min={min} max={max} onChange={({ min, max }) => console.log(`min = ${min}, max = ${max}`)} />
+        <div
+          className='display-flex flex-align-center width-full padding-top-1'
+          onClick={handleReverseToggle}
+        >
+          <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1'>
+            Reverse
+          </label>
+
           {isReversed ? (
             <Icon.ToggleOn className='text-primary' size={4} />
           ) : (
             <Icon.ToggleOff className='text-base-light' size={4} />
           )}
-          <input className='colormap-options__input' checked={isReversed} type='checkbox' readOnly />
+          <input
+            className='colormap-options__input'
+            checked={isReversed}
+            type='checkbox'
+            readOnly
+          />
         </div>
       </div>
 
@@ -125,13 +183,21 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
           return (
             <div
-              className={`colormap-options__item display-flex flex-align-center flex-justify padding-2 border-bottom-1px border-base-lightest radius-md ${selectedColorMap.toLowerCase() === name.toLowerCase() ? 'selected' : ''}`}
+              className={`colormap-options__item display-flex flex-align-center flex-justify padding-2 border-bottom-1px border-base-lightest radius-md ${
+                selectedColorMap.toLowerCase() === name.toLowerCase()
+                  ? 'selected'
+                  : ''
+              }`}
               key={name}
               onClick={() => handleColorMapSelect(name.toLowerCase())}
             >
               <div
                 className='colormap-options__preview display-flex border-1px border-base-lightest radius-md margin-right-2'
-                style={{ background: `linear-gradient(to right, ${previewColors.join(', ')})` }}
+                style={{
+                  background: `linear-gradient(to right, ${previewColors.join(
+                    ', '
+                  )})`
+                }}
               />
               <label className='colormap-options__label text-gray-90 font-heading-xs flex-1'>
                 {name}
@@ -143,7 +209,6 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
     </div>
   );
 }
-
 
 function normalizeColorMap(colorMap: string): string {
   return colorMap.replace(/_r$/, '');

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -202,6 +202,8 @@ export default function DataLayerCard(props: CardProps) {
                 className='colormap-options'
                 content={
                   <ColormapOptions
+                  min={min}
+                  max={max}
                     colorMap={colorMap}
                     setColorMap={setColorMap}
                   />

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { PrimitiveAtom } from 'jotai';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { LayerLegendCategorical, LayerLegendGradient } from 'veda';
+
 import {
   CollecticonCircleInformation,
   CollecticonEyeDisabled,
@@ -17,10 +18,11 @@ import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
 import { TipButton } from '$components/common/tip-button';
 import {
-  LayerCategoricalGraphic, LayerGradientColormapGraphic
+  LayerCategoricalGraphic,
+  LayerGradientColormapGraphic
 } from '$components/common/map/layer-legend';
 
-import { TimelineDataset } from '$components/exploration/types.d.ts';
+import { TimelineDataset, colorMapScale } from '$components/exploration/types.d.ts';
 import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 import { ParentDatasetTitle } from '$components/common/catalog/catalog-content';
 import { checkEnvFlag } from '$utils/utils';
@@ -35,6 +37,8 @@ interface CardProps {
   setVisible: any;
   colorMap: string | undefined;
   setColorMap: (colorMap: string) => void;
+  colorMapScale:colorMapScale | undefined;
+  setColorMapScale: (colorMapScale: colorMapScale) => void;
   onClickLayerInfo: () => void;
   datasetLegend: LayerLegendCategorical | LayerLegendGradient | undefined;
 }
@@ -104,7 +108,9 @@ const LegendColorMapTrigger = styled.div`
 `;
 
 // Hiding configurable map for now until Instances are ready to adapt it
-const showConfigurableColorMap = checkEnvFlag(process.env.SHOW_CONFIGURABLE_COLOR_MAP);
+const showConfigurableColorMap = checkEnvFlag(
+  process.env.SHOW_CONFIGURABLE_COLOR_MAP
+);
 
 export default function DataLayerCard(props: CardProps) {
   const {
@@ -114,6 +120,8 @@ export default function DataLayerCard(props: CardProps) {
     setVisible,
     colorMap,
     setColorMap,
+    colorMapScale,
+    setColorMapScale,
     datasetLegend,
     onClickLayerInfo
   } = props;
@@ -132,9 +140,16 @@ export default function DataLayerCard(props: CardProps) {
     }
   };
 
-  const showLoadingConfigurableCmapSkeleton = showConfigurableColorMap && dataset.status === 'loading' && datasetLegend?.type === 'gradient';
-  const showConfigurableCmap = showConfigurableColorMap && dataset.status === 'success' && datasetLegend?.type === 'gradient';
-  const showNonConfigurableCmap = !showConfigurableColorMap && datasetLegend?.type === 'gradient';
+  const showLoadingConfigurableCmapSkeleton =
+    showConfigurableColorMap &&
+    dataset.status === 'loading' &&
+    datasetLegend?.type === 'gradient';
+  const showConfigurableCmap =
+    showConfigurableColorMap &&
+    dataset.status === 'success' &&
+    datasetLegend?.type === 'gradient';
+  const showNonConfigurableCmap =
+    !showConfigurableColorMap && datasetLegend?.type === 'gradient';
 
   return (
     <>
@@ -158,7 +173,10 @@ export default function DataLayerCard(props: CardProps) {
                 onPointerDownCapture={(e) => e.stopPropagation()}
                 onClick={onClickLayerInfo}
               >
-                <CollecticonCircleInformation meaningful title='View dataset page' />
+                <CollecticonCircleInformation
+                  meaningful
+                  title='View dataset page'
+                />
               </TipButton>
               <TipButton
                 tipContent={isVisible ? 'Hide layer' : 'Show layer'}
@@ -168,9 +186,15 @@ export default function DataLayerCard(props: CardProps) {
                 onClick={() => setVisible((v) => !v)}
               >
                 {isVisible ? (
-                  <CollecticonEye meaningful title='Toggle dataset visibility' />
+                  <CollecticonEye
+                    meaningful
+                    title='Toggle dataset visibility'
+                  />
                 ) : (
-                  <CollecticonEyeDisabled meaningful title='Toggle dataset visibility' />
+                  <CollecticonEyeDisabled
+                    meaningful
+                    title='Toggle dataset visibility'
+                  />
                 )}
               </TipButton>
               <LayerMenuOptions datasetAtom={datasetAtom} />
@@ -182,51 +206,66 @@ export default function DataLayerCard(props: CardProps) {
           </DatasetMetricInfo>
         </DatasetCardInfo>
         {datasetLegend?.type === 'categorical' && (
-          <LayerCategoricalGraphic type='categorical' stops={datasetLegend.stops} />
+          <LayerCategoricalGraphic
+            type='categorical'
+            stops={datasetLegend.stops}
+          />
         )}
 
-          {/* Show a loading skeleton when the color map is not categorical and the dataset
+        {/* Show a loading skeleton when the color map is not categorical and the dataset
           status is 'loading'. This is because we color map sometimes might come from the titiler
           which could introduce a visual flash when going from the 'default' color map to the one
           configured in titiler */}
 
-          {showLoadingConfigurableCmapSkeleton && <div className='display-flex flex-align-center height-8'><LoadingSkeleton /></div>}
-          {showConfigurableCmap && (
-            <div className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md' ref={triggerRef}>
-              <LayerGradientColormapGraphic
-                min={min}
-                max={max}
-                colorMap={colorMap}
-              />
-              <Tippy
-                className='colormap-options'
-                content={
-                  <ColormapOptions
+        {showLoadingConfigurableCmapSkeleton && (
+          <div className='display-flex flex-align-center height-8'>
+            <LoadingSkeleton />
+          </div>
+        )}
+        {showConfigurableCmap && (
+          <div
+            className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md'
+            ref={triggerRef}
+          >
+            <LayerGradientColormapGraphic
+              min={min}
+              max={max}
+              colorMap={colorMap}
+            />
+            <Tippy
+              className='colormap-options'
+              content={
+                <ColormapOptions
                   min={min}
                   max={max}
-                    colorMap={colorMap}
-                    setColorMap={setColorMap}
-                  />
-                }
-                appendTo={() => document.body}
-                visible={isColorMapOpen}
-                interactive={true}
-                placement='top'
-                onClickOutside={(_, event) => handleClickOutside(event)}
+                  colorMap={colorMap}
+                  setColorMap={setColorMap}
+                  setColorMapScale={setColorMapScale}
+                  colorMapScale={colorMapScale}
+                />
+              }
+              appendTo={() => document.body}
+              visible={isColorMapOpen}
+              interactive={true}
+              placement='top'
+              onClickOutside={(_, event) => handleClickOutside(event)}
+            >
+              <LegendColorMapTrigger
+                className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05'
+                onClick={handleColorMapTriggerClick}
               >
-                <LegendColorMapTrigger className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05' onClick={handleColorMapTriggerClick}>
-                  <CollecticonChevronDownSmall />
-                </LegendColorMapTrigger>
-              </Tippy>
-            </div>
-          )}
-        {showNonConfigurableCmap &&
+                <CollecticonChevronDownSmall />
+              </LegendColorMapTrigger>
+            </Tippy>
+          </div>
+        )}
+        {showNonConfigurableCmap && (
           <LayerGradientColormapGraphic
             min={min}
             max={max}
             colorMap={colorMap}
-          />}
-
+          />
+        )}
       </DatasetInfo>
     </>
   );

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -33,7 +33,8 @@ import {
   useTimelineDatasetAtom,
   useTimelineDatasetColormap,
   useTimelineDatasetSettings,
-  useTimelineDatasetVisibility
+  useTimelineDatasetVisibility,
+  useTimelineDatasetColormapScale
 } from '$components/exploration/atoms/hooks';
 import {
   useAnalysisController,
@@ -103,6 +104,7 @@ export function DatasetListItem(props: DatasetListItemProps) {
 
   const [isVisible, setVisible] = useTimelineDatasetVisibility(datasetAtom);
   const [colorMap, setColorMap] = useTimelineDatasetColormap(datasetAtom);
+  const [colorMapScale, setColorMapScale]=useTimelineDatasetColormapScale(datasetAtom);
   const [modalLayerInfo, setModalLayerInfo] = React.useState<LayerInfoModalData>();
   const [, setSetting] = useTimelineDatasetSettings(datasetAtom);
 
@@ -209,7 +211,7 @@ export function DatasetListItem(props: DatasetListItemProps) {
         <DatasetHeader>
           <DatasetHeaderInner>
             <div style={{width: '100%'}} onPointerDown={onDragging}>
-              <DataLayerCard dataset={dataset} datasetAtom={datasetAtom} colorMap={colorMap} setColorMap={setColorMap} isVisible={isVisible} setVisible={setVisible} datasetLegend={datasetLegend} onClickLayerInfo={onClickLayerInfo} />
+              <DataLayerCard dataset={dataset} datasetAtom={datasetAtom} colorMap={colorMap} colorMapScale={colorMapScale} setColorMap={setColorMap} setColorMapScale={setColorMapScale} isVisible={isVisible} setVisible={setVisible} datasetLegend={datasetLegend} onClickLayerInfo={onClickLayerInfo} />
             </div>
             {modalLayerInfo && (
               <LayerInfoModal

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -22,7 +22,7 @@ interface LayerProps {
 
 export function Layer(props: LayerProps) {
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
-  const { isVisible, opacity, colorMap } = dataset.settings;
+  const { isVisible, opacity, colorMap, scale } = dataset.settings;
 
   // The date needs to match the dataset's time density.
   const relevantDate = useMemo(
@@ -40,7 +40,6 @@ export function Layer(props: LayerProps) {
     };
     return resolveConfigFunctions(dataset.data, bag);
   }, [dataset, relevantDate]);
-
   switch (dataset.data.type) {
     case 'vector':
       return (
@@ -72,6 +71,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
         />
       );
     case 'cmr':
@@ -88,6 +88,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
         />
       );
     case 'raster':
@@ -105,6 +106,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
         />
       );
     default:

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -95,7 +95,10 @@ export interface DatasetData extends EnhancedDatasetLayer {
   timeDensity: TimeDensity;
   domain: Date[];
 }
-
+export interface colorMapScale {
+  min: number;
+  max: number;
+}
 export interface DatasetSettings {
   // Whether or not the layer should be shown on the map.
   isVisible?: boolean;
@@ -105,6 +108,8 @@ export interface DatasetSettings {
   analysisMetrics?: DataMetric[];
   // Active colormap of the layer.
   colorMap?: string;
+  // Active colormap scale
+  scale?: colorMapScale;
 }
 
 // Any sort of meta information the dataset like:


### PR DESCRIPTION
**Related Ticket:** https://github.com/orgs/NASA-IMPACT/projects/17/views/6?pane=issue&itemId=74631613&issue=NASA-IMPACT%7Cveda-ui%7C1102

### Description of Changes
Creation and implementation of new range slider component. 

### Notes & Questions About Changes
-There is a identified bug that while dragging the slider thumbs you can drag the entire panel up and down influencing the parent component position. 
-Additional functionality: If input field is left empty and clicked outside of the default _min_ or _max_ should auto populate the field. 

### Validation / Testing
Navigate to a data exploration and add a layer to the timeline. 
- **Layers:**
    - Confirm that **min** and **max** are accurate to value in the layer legend view. 
    - Switch to another layer with different value confirm that the min and max in the range slider are accurate. 
    - Select a layer with a min value less than 0 (net ecosystem exchange) you should see a middle marker that represents the center of the current gradient values. 
- **Slider:**
    - You should not be able to drag the min slider past the max slider, or the max slider past the min slider. 
- **Text Inputs:**
    - You should be able to type in a value greater or lower than the min max of the layer but then be shown with the error message _Please enter a value between {min} and {max}_ no change to the slider range or the map. 
    - After selecting a different max that is less than the layers absolute maximum with either slider or input, if you enter in a value in the min text input that is greater than the newly selected max you should be presented with an error message _Please enter a value less than {max}_ 
    - After selecting a different min that is larger than the layers absolute minimum with either slider or input, if you enter in a value in the max text input that is greater than the newly selected max you should be presented with an error message _Please enter a value larger than {min}_