### PR TITLE
1171 cookie consent clean up

### DIFF
--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from "react";
-import { Icon } from "@trussworks/react-uswds";
-import { USWDSBanner, USWDSBannerContent } from "$components/common/uswds/banner";
+import React, { useState } from 'react';
+import { Icon } from '@trussworks/react-uswds';
+import {
+  USWDSBanner,
+  USWDSBannerContent
+} from '$components/common/uswds/banner';
 
 const BANNER_KEY = 'dismissedBannerUrl';
 
@@ -12,53 +15,64 @@ function hasExpired(expiryDatetime) {
 
 enum BannerType {
   info = 'info',
-  warning ='warning'
+  warning = 'warning'
 }
 
 const infoTypeFlag = BannerType.info;
 interface BannerProps {
-  appTitle: string,
-  expires: Date,
-  url: string,
-  text: string,
-  type?: BannerType
+  appTitle: string;
+  expires: Date;
+  url: string;
+  text: string;
+  type?: BannerType;
 }
 
-export default function Banner({appTitle, expires, url, text, type = infoTypeFlag }: BannerProps) {
+export default function Banner({
+  appTitle,
+  expires,
+  url,
+  text,
+  type = infoTypeFlag
+}: BannerProps) {
 
   const showBanner = localStorage.getItem(BANNER_KEY) !== url;
-  const [isOpen, setIsOpen] = useState(showBanner && !(hasExpired(expires)));
+  const [isOpen, setIsOpen] = useState(showBanner && !hasExpired(expires));
 
-  function onClose () {
-    localStorage.setItem(
-      BANNER_KEY,
-      url
-    );
+  function onClose() {
+    localStorage.setItem(BANNER_KEY, url);
     setIsOpen(false);
   }
 
   return (
     <div>
-      {isOpen &&
-        (<div className='position-relative'>
-          <USWDSBanner aria-label={appTitle} className={type !== infoTypeFlag? 'bg-secondary-lighter': ''}>
+      {isOpen && (
+        <div className='position-relative'>
+          <USWDSBanner
+            aria-label={appTitle}
+            className={type !== infoTypeFlag ? 'bg-secondary-lighter' : ''}
+          >
             <a href={url} target='_blank' rel='noreferrer'>
-              <USWDSBannerContent className='padding-top-1 padding-bottom-1' isOpen={true}>
-                <p dangerouslySetInnerHTML={{ __html: text }} />
+              <USWDSBannerContent
+                className='padding-top-1 padding-bottom-1'
+                isOpen={true}
+              >
+                <div dangerouslySetInnerHTML={{ __html: text }} />
+
               </USWDSBannerContent>
             </a>
           </USWDSBanner>
           <div className='position-absolute top-0 right-0 margin-right-3 height-full display-flex'>
-              <button
+            <button
               className='usa-button usa-button--unstyled'
               type='button'
               aria-label='Close Banner'
               onClick={onClose}
-              >
-                <Icon.Close />
-              </button>
+            >
+              <Icon.Close />
+            </button>
           </div>
-         </div>)}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
+++ b/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
@@ -3,10 +3,9 @@ import '@testing-library/jest-dom';
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom'; // For testing
-
 import { createMemoryHistory } from 'history';
+import * as utils from './utils';
 
-import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
 import CookieConsent from './index';
 
 describe('Cookie consent form should render with correct content.', () => {
@@ -25,16 +24,36 @@ describe('Cookie consent form should render with correct content.', () => {
       pathname: 'localhost:3000/example/path'
     })
   }));
-
-  beforeEach(() => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  it('Check that session item is non existant prior to cookie consent render. Then confirm that cookie consent creates session item.', () => {
+    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBeNull();
     render(
       <MemoryRouter history={history}>
         <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
       </MemoryRouter>
     );
+    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBe(`true`);
+  });
+  it('Check that getcookie is only called once on render and session item is true', () => {
+    const spy = jest.spyOn(utils, 'getCookie');
+
+    render(
+      <MemoryRouter history={history}>
+        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      </MemoryRouter>
+    );
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBe(`true`);
   });
 
   it('Renders correct content', () => {
+    render(
+      <MemoryRouter history={history}>
+        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      </MemoryRouter>
+    );
     expect(
       screen.getByRole('link', { name: 'Privacy Policy' })
     ).toHaveAttribute('href', 'https://www.nasa.gov/privacy/#cookies');
@@ -52,32 +71,32 @@ describe('Cookie consent form should render with correct content.', () => {
     ).toBeInTheDocument();
   });
 
-  it('Check correct cookie initialization', () => {
-    const resultCookie = document.cookie;
-    expect(resultCookie).toBe(
-      `${COOKIE_CONSENT_KEY}={"responded":false,"answer":false}`
-    );
-  });
-  it('Check for session initialization', () => {
-    expect(sessionStorage.getItem(SESSION_KEY)).toBe(`true`);
-  });
-
   it('Check correct cookie content on Decline click', () => {
+    render(
+      <MemoryRouter history={history}>
+        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      </MemoryRouter>
+    );
     const button = screen.getByRole('button', { name: 'Decline Cookies' });
     fireEvent.click(button);
     const resultCookie = document.cookie;
     expect(resultCookie).toBe(
-      `${COOKIE_CONSENT_KEY}={"responded":true,"answer":false}`
+      `${utils.COOKIE_CONSENT_KEY}={"responded":true,"answer":false}`
     );
   });
 
   it('Check correct cookie content on Accept click', () => {
+    render(
+      <MemoryRouter history={history}>
+        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      </MemoryRouter>
+    );
     const button = screen.getByRole('button', { name: 'Accept Cookies' });
     fireEvent.click(button);
     const resultCookie = document.cookie;
 
     expect(resultCookie).toBe(
-      `${COOKIE_CONSENT_KEY}={"responded":true,"answer":true}`
+      `${utils.COOKIE_CONSENT_KEY}={"responded":true,"answer":true}`
     );
   });
 });

--- a/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
+++ b/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
@@ -4,14 +4,19 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom'; // For testing
 import { createMemoryHistory } from 'history';
-import * as utils from './utils';
 
+import * as utils from './utils';
 import CookieConsent from './index';
+const lodash = require('lodash');
 
 describe('Cookie consent form should render with correct content.', () => {
+  const setDisplayCookieConsent = jest.fn();
+  const setGoogleTagManager = jest.fn();
   const cookieData = {
     title: 'Cookie Consent',
-    copy: '<p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our <a href="https://www.nasa.gov/privacy/#cookies">Privacy Policy</a></p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies)'
+    copy: '<p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our <a href="https://www.nasa.gov/privacy/#cookies">Privacy Policy</a></p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies)',
+    setDisplayCookieConsent,
+    setGoogleTagManager
   };
 
   const onFormInteraction = jest.fn();
@@ -24,28 +29,14 @@ describe('Cookie consent form should render with correct content.', () => {
       pathname: 'localhost:3000/example/path'
     })
   }));
+
+  lodash.debounce = jest.fn((fn) => fn);
+
   afterEach(() => {
     jest.clearAllMocks();
-  });
-  it('Check that session item is non existant prior to cookie consent render. Then confirm that cookie consent creates session item.', () => {
-    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBeNull();
-    render(
-      <MemoryRouter history={history}>
-        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
-      </MemoryRouter>
-    );
-    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBe(`true`);
-  });
-  it('Check that getcookie is only called once on render and session item is true', () => {
-    const spy = jest.spyOn(utils, 'getCookie');
 
-    render(
-      <MemoryRouter history={history}>
-        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
-      </MemoryRouter>
-    );
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(sessionStorage.getItem(utils.SESSION_KEY)).toBe(`true`);
+    // Clear cookies after each test
+    document.cookie = `${utils.COOKIE_CONSENT_KEY}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
   });
 
   it('Renders correct content', () => {
@@ -91,8 +82,8 @@ describe('Cookie consent form should render with correct content.', () => {
         <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
       </MemoryRouter>
     );
-    const button = screen.getByRole('button', { name: 'Accept Cookies' });
-    fireEvent.click(button);
+    const acceptButton = screen.getByRole('button', { name: 'Accept Cookies' });
+    fireEvent.click(acceptButton);
     const resultCookie = document.cookie;
 
     expect(resultCookie).toBe(

--- a/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
+++ b/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import '@testing-library/jest-dom';
 
 import { render, screen, fireEvent } from '@testing-library/react';
-import { COOKIE_CONSENT_KEY } from './utils';
+import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
 import { CookieConsent } from './index';
 
 describe('Cookie consent form should render with correct content.', () => {
@@ -40,6 +40,9 @@ describe('Cookie consent form should render with correct content.', () => {
     expect(resultCookie).toBe(
       `${COOKIE_CONSENT_KEY}={"responded":false,"answer":false}`
     );
+  });
+  it('Check for session initialization', () => {
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe(`true`);
   });
 
   it('Check correct cookie content on Decline click', () => {

--- a/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
+++ b/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
@@ -7,7 +7,7 @@ import { MemoryRouter } from 'react-router-dom'; // For testing
 import { createMemoryHistory } from 'history';
 
 import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
-import { CookieConsent } from './index';
+import CookieConsent from './index';
 
 describe('Cookie consent form should render with correct content.', () => {
   const cookieData = {

--- a/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
+++ b/app/scripts/components/common/cookie-consent/cookieConsent.spec.js
@@ -2,6 +2,10 @@ import React from 'react';
 import '@testing-library/jest-dom';
 
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom'; // For testing
+
+import { createMemoryHistory } from 'history';
+
 import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
 import { CookieConsent } from './index';
 
@@ -10,12 +14,26 @@ describe('Cookie consent form should render with correct content.', () => {
     title: 'Cookie Consent',
     copy: '<p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our <a href="https://www.nasa.gov/privacy/#cookies">Privacy Policy</a></p>We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies)'
   };
+
   const onFormInteraction = jest.fn();
+
+  const history = createMemoryHistory({ initialEntries: ['/home'] });
+
+  jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useLocation: () => ({
+      pathname: 'localhost:3000/example/path'
+    })
+  }));
+
   beforeEach(() => {
     render(
-      <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      <MemoryRouter history={history}>
+        <CookieConsent {...cookieData} onFormInteraction={onFormInteraction} />
+      </MemoryRouter>
     );
   });
+
   it('Renders correct content', () => {
     expect(
       screen.getByRole('link', { name: 'Privacy Policy' })
@@ -36,7 +54,6 @@ describe('Cookie consent form should render with correct content.', () => {
 
   it('Check correct cookie initialization', () => {
     const resultCookie = document.cookie;
-
     expect(resultCookie).toBe(
       `${COOKIE_CONSENT_KEY}={"responded":false,"answer":false}`
     );

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -1,8 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import { Icon } from '@trussworks/react-uswds';
-import { useLocation } from 'react-router-dom';
 
-import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
+import {
+  COOKIE_CONSENT_KEY,
+  SESSION_KEY,
+
+  getCookie
+} from './utils';
 import {
   USWDSAlert,
   USWDSButton,
@@ -28,25 +32,6 @@ export const CookieConsent = ({
   sessionStart,
   setGoogleTagManager
 }: CookieConsentProps) => {
- const readCookie = (name) => {
-  const nameEQ = name + '=';
-  const attribute = document.cookie.split(';');
-  const cookie = attribute.find(cookie => cookie.trim().startsWith(nameEQ));
-  return cookie ? cookie.substring(nameEQ.length).trim() : null;
-};
-
-  const location = useLocation();
-
-  const getCookie = () => {
-    const cookie = readCookie(COOKIE_CONSENT_KEY);
-    if (cookie) {
-      const cookieContents = JSON.parse(cookie);
-      if (cookieContents.answer) setGoogleTagManager();
-      SetCookieConsentResponded(cookieContents.responded);
-      SetCookieConsentAnswer(cookieContents.answer);
-    }
-  };
-
   const [cookieConsentResponded, SetCookieConsentResponded] =
     useState<boolean>(false);
   const [cookieConsentAnswer, SetCookieConsentAnswer] =
@@ -66,6 +51,9 @@ export const CookieConsent = ({
     )}; path=/; expires=${closeConsent ? '0' : setCookieExpiration()}`;
   };
 
+  const currentURL =
+    typeof window !== 'undefined' ? window.location.href : null;
+
   const setSessionData = () => {
     if (typeof window !== 'undefined') {
       const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
@@ -77,12 +65,16 @@ export const CookieConsent = ({
   useEffect(() => {
     if (sessionStart !== 'true' && !cookieConsentResponded) {
       setSessionData();
-      getCookie();
+      getCookie(
+        SetCookieConsentResponded,
+        SetCookieConsentAnswer,
+        setGoogleTagManager
+      );
     }
     if (!cookieConsentResponded && closeConsent) {
       setCloseConsent(false);
     }
-  }, [location]);
+  }, [currentURL]);
   useEffect(() => {
     const cookieValue = {
       responded: cookieConsentResponded,
@@ -98,7 +90,7 @@ export const CookieConsent = ({
     closeConsent,
     getCookie,
     setSessionData,
-    location
+    currentURL
   ]);
 
   return (

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Icon } from '@trussworks/react-uswds';
+import { useLocation } from 'react-router-dom';
+
 import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
 import {
   USWDSAlert,
@@ -14,10 +16,6 @@ interface CookieConsentProps {
   copy?: string | undefined;
   sessionStart: string | undefined;
   setGoogleTagManager: () => void;
-}
-interface CookieConsentShape {
-  responded: boolean | undefined;
-  answer: boolean | undefined;
 }
 
 function addAttribute(copy) {
@@ -40,12 +38,15 @@ export const CookieConsent = ({
     }
     return null;
   };
+  const location = useLocation();
 
   const getCookie = () => {
+
     const cookie = readCookie(COOKIE_CONSENT_KEY);
     if (cookie) {
       const cookieContents = JSON.parse(cookie);
       if (cookieContents.answer) setGoogleTagManager();
+      !cookieContents.responded && setCloseConsent(true);
       SetCookieConsentResponded(cookieContents.responded);
       SetCookieConsentAnswer(cookieContents.answer);
     }
@@ -56,6 +57,7 @@ export const CookieConsent = ({
   const [cookieConsentAnswer, SetCookieConsentAnswer] =
     useState<boolean>(false);
   const [closeConsent, setCloseConsent] = useState<boolean>(false);
+
   //Setting expiration date for cookie to expire and re-ask user for consent.
   const setCookieExpiration = () => {
     const today = new Date();
@@ -80,7 +82,10 @@ export const CookieConsent = ({
       setSessionData();
       getCookie();
     }
-  }, []);
+    if (!cookieConsentResponded && closeConsent) {
+      setCloseConsent(false);
+    }
+  }, [location]);
   useEffect(() => {
     const cookieValue = {
       responded: cookieConsentResponded,
@@ -95,7 +100,8 @@ export const CookieConsent = ({
     cookieConsentAnswer,
     closeConsent,
     getCookie,
-    setSessionData
+    setSessionData,
+    location
   ]);
 
   return (

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -46,7 +46,6 @@ export const CookieConsent = ({
     if (cookie) {
       const cookieContents = JSON.parse(cookie);
       if (cookieContents.answer) setGoogleTagManager();
-      !cookieContents.responded && setCloseConsent(true);
       SetCookieConsentResponded(cookieContents.responded);
       SetCookieConsentAnswer(cookieContents.answer);
     }

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Icon } from '@trussworks/react-uswds';
-import { COOKIE_CONSENT_KEY } from './utils';
+import { COOKIE_CONSENT_KEY, SESSION_KEY } from './utils';
 import {
   USWDSAlert,
   USWDSButton,
@@ -12,22 +12,49 @@ import './index.scss';
 interface CookieConsentProps {
   title?: string | undefined;
   copy?: string | undefined;
-  onFormInteraction: () => void;
+  setGoogleTagManager: () => void;
+}
+interface CookieConsentShape {
+  responded: boolean;
+  answer: boolean;
 }
 
-function addAttribute (copy) {
+function addAttribute(copy) {
   return copy.replaceAll('<a', `<a target="_blank" rel="noopener" role="link"`);
 }
 
 export const CookieConsent = ({
   title,
   copy,
-  onFormInteraction
+  setGoogleTagManager
 }: CookieConsentProps) => {
-  const [cookieConsentResponded, SetCookieConsentResponded] =
-    useState<boolean>(false);
-  const [cookieConsentAnswer, SetCookieConsentAnswer] =
-    useState<boolean>(false);
+  const readCookie = (name) => {
+    const nameEQ = name + '=';
+    const attribute = document.cookie.split(';');
+    for (let i = 0; i < attribute.length; i++) {
+      let c = attribute[i];
+      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+    }
+    return null;
+  };
+
+  const getCookie = () => {
+    const cookie = readCookie(COOKIE_CONSENT_KEY);
+    if (cookie) {
+      const cookieContents: CookieConsentShape = JSON.parse(cookie);
+      if (cookieContents.answer) setGoogleTagManager();
+
+      return cookieContents;
+    }
+  };
+
+  const [cookieConsentResponded, SetCookieConsentResponded] = useState<boolean>(
+    getCookie()?.responded ?? false
+  );
+  const [cookieConsentAnswer, SetCookieConsentAnswer] = useState<boolean>(
+    getCookie()?.answer ?? false
+  );
   const [closeConsent, setCloseConsent] = useState<boolean>(false);
   //Setting expiration date for cookie to expire and re-ask user for consent.
   const setCookieExpiration = () => {
@@ -42,67 +69,96 @@ export const CookieConsent = ({
     )}; path=/; expires=${closeConsent ? '0' : setCookieExpiration()}`;
   };
 
+  const setSessionData = () => {
+    const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
+    if (!checkForSessionDate) {
+      window.sessionStorage.setItem(SESSION_KEY, 'true');
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   useEffect(() => {
-    const cookieValue = {
-      responded: cookieConsentResponded,
-      answer: cookieConsentAnswer
-    };
-    setCookie(cookieValue, closeConsent);
-    onFormInteraction();
-  // Ignoring setcookie for now sine it will make infinite rendering
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cookieConsentResponded, cookieConsentAnswer, closeConsent, onFormInteraction]);
+    setSessionData();
+    if (setSessionData()) {
+      const cookieValue = {
+        responded: cookieConsentResponded,
+        answer: cookieConsentAnswer
+      };
+      setCookie(cookieValue, closeConsent);
+    }
+    // Ignoring setcookie for now since it will make infinite rendering
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cookieConsentResponded,
+    cookieConsentAnswer,
+    closeConsent,
+    getCookie,
+    setSessionData
+  ]);
 
   return (
-    <div
-      id='cookie-consent'
-      className={`margin-0 tablet:margin-2 shadow-2 position-fixed z-top maxw-full tablet:maxw-tablet-lg animation--fade-out right-0 bottom-0 ${
-        cookieConsentResponded || closeConsent ? ' opacity-0 z-bottom pointer-events--none' : 'opacity-1 z-top'
-      }`}
-    >
-      <USWDSAlert
-        type='info'
-        heading={title && title}
-        headingLevel='h2'
-        noIcon={true}
-        className='radius-lg'
-      >
-        <USWDSButton
-          type='button '
-          className='width-3 height-3 padding-0 position-absolute right-2 top-2'
-          onClick={() => {
-            setCloseConsent(true);
-          }}
-          unstyled
-        >
-          <Icon.Close size={3} />
-        </USWDSButton>
+    <div>
+      {
+        //Adding debounce to conditional for animation out
+        setTimeout(() => {
+          !cookieConsentResponded;
+        }, 500) && (
+          <div
+            id='cookie-consent'
+            className={`margin-0 tablet:margin-2 shadow-2 position-fixed z-top maxw-full tablet:maxw-tablet-lg animation--fade-out right-0 bottom-0 ${
+              cookieConsentResponded || closeConsent
+                ? ' opacity-0 z-bottom pointer-events--none'
+                : 'opacity-1 z-top'
+            }`}
+          >
+            <USWDSAlert
+              type='info'
+              heading={title && title}
+              headingLevel='h2'
+              noIcon={true}
+              className='radius-lg'
+            >
+              <USWDSButton
+                type='button '
+                className='width-3 height-3 padding-0 position-absolute right-2 top-2'
+                onClick={() => {
+                  setCloseConsent(true);
+                }}
+                unstyled
+              >
+                <Icon.Close size={3} />
+              </USWDSButton>
 
-        {copy && (
-          <div dangerouslySetInnerHTML={{ __html: addAttribute(copy) }} />
-        )}
-        <USWDSButtonGroup className='padding-top-2'>
-          <USWDSButton
-            onClick={() => {
-              SetCookieConsentResponded(true);
-              SetCookieConsentAnswer(false);
-            }}
-            outline={true}
-            type='button'
-          >
-            Decline Cookies
-          </USWDSButton>
-          <USWDSButton
-            onClick={() => {
-              SetCookieConsentResponded(true);
-              SetCookieConsentAnswer(true);
-            }}
-            type='button'
-          >
-            Accept Cookies
-          </USWDSButton>
-        </USWDSButtonGroup>
-      </USWDSAlert>
+              {copy && (
+                <div dangerouslySetInnerHTML={{ __html: addAttribute(copy) }} />
+              )}
+              <USWDSButtonGroup className='padding-top-2'>
+                <USWDSButton
+                  onClick={() => {
+                    SetCookieConsentResponded(true);
+                    SetCookieConsentAnswer(false);
+                  }}
+                  outline={true}
+                  type='button'
+                >
+                  Decline Cookies
+                </USWDSButton>
+                <USWDSButton
+                  onClick={() => {
+                    SetCookieConsentResponded(true);
+                    SetCookieConsentAnswer(true);
+                  }}
+                  type='button'
+                >
+                  Accept Cookies
+                </USWDSButton>
+              </USWDSButtonGroup>
+            </USWDSAlert>
+          </div>
+        )
+      }
     </div>
   );
 };

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -12,6 +12,7 @@ import './index.scss';
 interface CookieConsentProps {
   title?: string | undefined;
   copy?: string | undefined;
+  sessionStart: string | undefined;
   setGoogleTagManager: () => void;
 }
 interface CookieConsentShape {
@@ -26,6 +27,7 @@ function addAttribute(copy) {
 export const CookieConsent = ({
   title,
   copy,
+  sessionStart,
   setGoogleTagManager
 }: CookieConsentProps) => {
   const readCookie = (name) => {
@@ -73,15 +75,12 @@ export const CookieConsent = ({
     const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
     if (!checkForSessionDate) {
       window.sessionStorage.setItem(SESSION_KEY, 'true');
-      return true;
-    } else {
-      return false;
     }
   };
 
   useEffect(() => {
     setSessionData();
-    if (setSessionData()) {
+    if (sessionStart == 'true') {
       const cookieValue = {
         responded: cookieConsentResponded,
         answer: cookieConsentAnswer

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -1,12 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Icon } from '@trussworks/react-uswds';
 
-import {
-  COOKIE_CONSENT_KEY,
-  SESSION_KEY,
-
-  getCookie
-} from './utils';
+import { COOKIE_CONSENT_KEY, SESSION_KEY, getCookie } from './utils';
 import {
   USWDSAlert,
   USWDSButton,
@@ -18,6 +13,7 @@ import './index.scss';
 interface CookieConsentProps {
   title?: string | undefined;
   copy?: string | undefined;
+  pathname: string;
   sessionStart: string | undefined;
   setGoogleTagManager: () => void;
 }
@@ -30,6 +26,7 @@ export const CookieConsent = ({
   title,
   copy,
   sessionStart,
+  pathname,
   setGoogleTagManager
 }: CookieConsentProps) => {
   const [cookieConsentResponded, SetCookieConsentResponded] =
@@ -51,9 +48,6 @@ export const CookieConsent = ({
     )}; path=/; expires=${closeConsent ? '0' : setCookieExpiration()}`;
   };
 
-  const currentURL =
-    typeof window !== 'undefined' ? window.location.href : null;
-
   const setSessionData = () => {
     if (typeof window !== 'undefined') {
       const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
@@ -62,6 +56,7 @@ export const CookieConsent = ({
       }
     }
   };
+
   useEffect(() => {
     if (sessionStart !== 'true' && !cookieConsentResponded) {
       setSessionData();
@@ -74,7 +69,10 @@ export const CookieConsent = ({
     if (!cookieConsentResponded && closeConsent) {
       setCloseConsent(false);
     }
-  }, [currentURL]);
+    // to Rerender on route change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname]);
+
   useEffect(() => {
     const cookieValue = {
       responded: cookieConsentResponded,
@@ -84,19 +82,12 @@ export const CookieConsent = ({
 
     // Ignoring setcookie for now since it will make infinite rendering
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    cookieConsentResponded,
-    cookieConsentAnswer,
-    closeConsent,
-    getCookie,
-    setSessionData,
-    currentURL
-  ]);
+  }, [cookieConsentResponded, cookieConsentAnswer, closeConsent]);
 
   return (
     <div>
       {
-        //Adding debounce to conditional for animation out
+        // Adding debounce to conditional for animation out
         setTimeout(() => {
           !cookieConsentResponded;
         }, 500) && (

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect } from 'react';
+import { debounce } from 'lodash';
 import { Icon } from '@trussworks/react-uswds';
 
-import { COOKIE_CONSENT_KEY, SESSION_KEY, getCookie } from './utils';
+import { setCookie, getCookie } from './utils';
 import {
   USWDSAlert,
   USWDSButton,
@@ -14,7 +15,7 @@ interface CookieConsentProps {
   title?: string | undefined;
   copy?: string | undefined;
   pathname: string;
-  sessionStart: string | undefined;
+  setDisplayCookieConsentForm: (boolean) => void;
   setGoogleTagManager: () => void;
 }
 
@@ -25,126 +26,128 @@ function addAttribute(copy) {
 export const CookieConsent = ({
   title,
   copy,
-  sessionStart,
   pathname,
+  setDisplayCookieConsentForm,
   setGoogleTagManager
 }: CookieConsentProps) => {
-  const [cookieConsentResponded, SetCookieConsentResponded] =
+  const [cookieConsentResponded, setCookieConsentResponded] =
     useState<boolean>(false);
-  const [cookieConsentAnswer, SetCookieConsentAnswer] =
+  // Debounce the setDisplayCookieConsentForm function
+  const debouncedSetCookieConsentResponded = debounce(
+    setCookieConsentResponded,
+    500
+  );
+
+  const [cookieConsentAnswer, setCookieConsentAnswer] =
     useState<boolean>(false);
   const [closeConsent, setCloseConsent] = useState<boolean>(false);
 
-  //Setting expiration date for cookie to expire and re-ask user for consent.
-  const setCookieExpiration = () => {
-    const today = new Date();
-    today.setMonth(today.getMonth() + 3);
-    return today.toUTCString();
-  };
-
-  const setCookie = (cookieValue, closeConsent) => {
-    document.cookie = `${COOKIE_CONSENT_KEY}=${JSON.stringify(
-      cookieValue
-    )}; path=/; expires=${closeConsent ? '0' : setCookieExpiration()}`;
-  };
-
-  const setSessionData = () => {
-    if (typeof window !== 'undefined') {
-      const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
-      if (!checkForSessionDate) {
-        window.sessionStorage.setItem(SESSION_KEY, 'true');
-      }
-    }
-  };
-
   useEffect(() => {
-    if (sessionStart !== 'true' && !cookieConsentResponded) {
-      setSessionData();
-      getCookie(
-        SetCookieConsentResponded,
-        SetCookieConsentAnswer,
-        setGoogleTagManager
-      );
-    }
-    if (!cookieConsentResponded && closeConsent) {
+    const cookieContents = getCookie();
+    if (cookieContents) {
+      if (!cookieContents.responded) {
+        setCloseConsent(false);
+        return;
+      }
+      cookieContents.answer && setGoogleTagManager();
+      setCookieConsentResponded(cookieContents.responded);
+      setCookieConsentAnswer(cookieContents.answer);
+      setDisplayCookieConsentForm(false);
+    } else {
       setCloseConsent(false);
     }
-    // to Rerender on route change
+    // Only run on the first render
+  }, [setGoogleTagManager, setDisplayCookieConsentForm]);
+
+  useEffect(() => {
+    if (!cookieConsentResponded) setCloseConsent(false);
+    // To render the component when user hasn't answered yet
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pathname]);
 
   useEffect(() => {
+    // When not responded, do nothing.
+    if (!cookieConsentResponded) return;
+    // When answer is accept cookie,
+    // 1. set up google manager
+    cookieConsentAnswer && setGoogleTagManager();
+    // 2. update the cookie value
     const cookieValue = {
       responded: cookieConsentResponded,
       answer: cookieConsentAnswer
     };
     setCookie(cookieValue, closeConsent);
-
-    // Ignoring setcookie for now since it will make infinite rendering
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [cookieConsentResponded, cookieConsentAnswer, closeConsent]);
+    // 3. Tell the layout that we don't have to render this consent form
+    // from the next render of layout.
+    setTimeout(() => {
+      setDisplayCookieConsentForm(false);
+    }, 500);
+  }, [
+    cookieConsentResponded,
+    cookieConsentAnswer,
+    closeConsent,
+    setDisplayCookieConsentForm,
+    setGoogleTagManager
+  ]);
 
   return (
     <div>
-      {
-        // Adding debounce to conditional for animation out
-        setTimeout(() => {
-          !cookieConsentResponded;
-        }, 500) && (
-          <div
-            id='cookie-consent'
-            className={`margin-0 tablet:margin-2 shadow-2 position-fixed z-top maxw-full tablet:maxw-tablet-lg animation--fade-out right-0 bottom-0 ${
-              cookieConsentResponded || closeConsent
-                ? ' opacity-0 z-bottom pointer-events--none'
-                : 'opacity-1 z-top'
-            }`}
+      {!cookieConsentResponded && (
+        <div
+          id='cookie-consent'
+          className={`margin-0 tablet:margin-2 shadow-2 position-fixed z-top maxw-full tablet:maxw-tablet-lg animation--fade-out right-0 bottom-0 ${
+            closeConsent
+              ? ' opacity-0 z-bottom pointer-events--none'
+              : 'opacity-1 z-top'
+          }`}
+        >
+          <USWDSAlert
+            type='info'
+            heading={title && title}
+            headingLevel='h2'
+            noIcon={true}
+            className='radius-lg'
           >
-            <USWDSAlert
-              type='info'
-              heading={title && title}
-              headingLevel='h2'
-              noIcon={true}
-              className='radius-lg'
+            <USWDSButton
+              type='button '
+              className='width-3 height-3 padding-0 position-absolute right-2 top-2'
+              onClick={() => {
+                setCloseConsent(true);
+              }}
+              unstyled
             >
+              <Icon.Close size={3} />
+            </USWDSButton>
+
+            {copy && (
+              <div dangerouslySetInnerHTML={{ __html: addAttribute(copy) }} />
+            )}
+            <USWDSButtonGroup className='padding-top-2'>
               <USWDSButton
-                type='button '
-                className='width-3 height-3 padding-0 position-absolute right-2 top-2'
                 onClick={() => {
+                  debouncedSetCookieConsentResponded(true);
+                  setCookieConsentAnswer(false);
                   setCloseConsent(true);
                 }}
-                unstyled
+                outline={true}
+                type='button'
               >
-                <Icon.Close size={3} />
+                Decline Cookies
               </USWDSButton>
-
-              {copy && (
-                <div dangerouslySetInnerHTML={{ __html: addAttribute(copy) }} />
-              )}
-              <USWDSButtonGroup className='padding-top-2'>
-                <USWDSButton
-                  onClick={() => {
-                    SetCookieConsentResponded(true);
-                    SetCookieConsentAnswer(false);
-                  }}
-                  outline={true}
-                  type='button'
-                >
-                  Decline Cookies
-                </USWDSButton>
-                <USWDSButton
-                  onClick={() => {
-                    SetCookieConsentResponded(true);
-                    SetCookieConsentAnswer(true);
-                  }}
-                  type='button'
-                >
-                  Accept Cookies
-                </USWDSButton>
-              </USWDSButtonGroup>
-            </USWDSAlert>
-          </div>
-        )
-      }
+              <USWDSButton
+                onClick={() => {
+                  debouncedSetCookieConsentResponded(true);
+                  setCookieConsentAnswer(true);
+                  setCloseConsent(true);
+                }}
+                type='button'
+              >
+                Accept Cookies
+              </USWDSButton>
+            </USWDSButtonGroup>
+          </USWDSAlert>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/scripts/components/common/cookie-consent/index.tsx
+++ b/app/scripts/components/common/cookie-consent/index.tsx
@@ -28,20 +28,16 @@ export const CookieConsent = ({
   sessionStart,
   setGoogleTagManager
 }: CookieConsentProps) => {
-  const readCookie = (name) => {
-    const nameEQ = name + '=';
-    const attribute = document.cookie.split(';');
-    for (let i = 0; i < attribute.length; i++) {
-      let c = attribute[i];
-      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-    }
-    return null;
-  };
+ const readCookie = (name) => {
+  const nameEQ = name + '=';
+  const attribute = document.cookie.split(';');
+  const cookie = attribute.find(cookie => cookie.trim().startsWith(nameEQ));
+  return cookie ? cookie.substring(nameEQ.length).trim() : null;
+};
+
   const location = useLocation();
 
   const getCookie = () => {
-
     const cookie = readCookie(COOKIE_CONSENT_KEY);
     if (cookie) {
       const cookieContents = JSON.parse(cookie);
@@ -71,9 +67,11 @@ export const CookieConsent = ({
   };
 
   const setSessionData = () => {
-    const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
-    if (!checkForSessionDate) {
-      window.sessionStorage.setItem(SESSION_KEY, 'true');
+    if (typeof window !== 'undefined') {
+      const checkForSessionDate = window.sessionStorage.getItem(SESSION_KEY);
+      if (!checkForSessionDate) {
+        window.sessionStorage.setItem(SESSION_KEY, 'true');
+      }
     }
   };
   useEffect(() => {
@@ -167,3 +165,5 @@ export const CookieConsent = ({
     </div>
   );
 };
+
+export default CookieConsent;

--- a/app/scripts/components/common/cookie-consent/utils.test.ts
+++ b/app/scripts/components/common/cookie-consent/utils.test.ts
@@ -1,0 +1,21 @@
+import { readCookie, COOKIE_CONSENT_KEY } from './utils';
+
+describe('onCookie', () => {
+  let cookieValue;
+  beforeEach(() => {
+    cookieValue = { responded: false, answer: false };
+    // Mutating docmument cookie property for test
+    // eslint-disable-next-line fp/no-mutating-methods
+    Object.defineProperty(window.document, 'cookie', {
+      writable: true,
+      value: `CookieConsent={"responded":true,"answer":false}; _somethingelse=GS1.1.17303800; ${COOKIE_CONSENT_KEY}=${JSON.stringify(
+        cookieValue
+      )}`
+    });
+  });
+
+  it('should parse cookie value correctly', () => {
+    const cookieJsonVal = readCookie(COOKIE_CONSENT_KEY);
+    expect(JSON.parse(cookieJsonVal)).toMatchObject(cookieValue);
+  });
+});

--- a/app/scripts/components/common/cookie-consent/utils.ts
+++ b/app/scripts/components/common/cookie-consent/utils.ts
@@ -1,2 +1,22 @@
 export const COOKIE_CONSENT_KEY = `veda--CookieConsent`;
 export const SESSION_KEY = `veda--NewSession`;
+
+export const getCookie = (
+  SetCookieConsentResponded,
+  SetCookieConsentAnswer,
+  setGoogleTagManager
+) => {
+  const cookie = readCookie(COOKIE_CONSENT_KEY);
+  if (cookie) {
+    const cookieContents = JSON.parse(cookie);
+    if (cookieContents.answer) setGoogleTagManager();
+    SetCookieConsentResponded(cookieContents.responded);
+    SetCookieConsentAnswer(cookieContents.answer);
+  }
+};
+const readCookie = (name) => {
+  const nameEQ = name + '=';
+  const attribute = document.cookie.split(';');
+  const cookie = attribute.find((cookie) => cookie.trim().startsWith(nameEQ));
+  return cookie ? cookie.substring(nameEQ.length).trim() : null;
+};

--- a/app/scripts/components/common/cookie-consent/utils.ts
+++ b/app/scripts/components/common/cookie-consent/utils.ts
@@ -10,16 +10,23 @@ export const readCookie = (name: string): string => {
   );
 };
 
-export const getCookie = (
-  SetCookieConsentResponded,
-  SetCookieConsentAnswer,
-  setGoogleTagManager
-) => {
+export const getCookie = () => {
   const cookie = readCookie(COOKIE_CONSENT_KEY);
   if (cookie) {
     const cookieContents = JSON.parse(cookie);
-    if (cookieContents.answer) setGoogleTagManager();
-    SetCookieConsentResponded(cookieContents.responded);
-    SetCookieConsentAnswer(cookieContents.answer);
+    return cookieContents;
   }
+};
+
+//Setting expiration date for cookie to expire and re-ask user for consent.
+export const setCookieExpiration = () => {
+  const today = new Date();
+  today.setMonth(today.getMonth() + 3);
+  return today.toUTCString();
+};
+
+export const setCookie = (cookieValue, closeConsent) => {
+  document.cookie = `${COOKIE_CONSENT_KEY}=${JSON.stringify(
+    cookieValue
+  )}; path=/; expires=${closeConsent ? '0' : setCookieExpiration()}`;
 };

--- a/app/scripts/components/common/cookie-consent/utils.ts
+++ b/app/scripts/components/common/cookie-consent/utils.ts
@@ -1,2 +1,2 @@
-export const NO_COOKIE = 'NO COOKIE';
 export const COOKIE_CONSENT_KEY = `veda--CookieConsent`;
+export const SESSION_KEY = `veda--NewSession`;

--- a/app/scripts/components/common/cookie-consent/utils.ts
+++ b/app/scripts/components/common/cookie-consent/utils.ts
@@ -1,6 +1,15 @@
 export const COOKIE_CONSENT_KEY = `veda--CookieConsent`;
 export const SESSION_KEY = `veda--NewSession`;
 
+export const readCookie = (name: string): string => {
+  // Get name followed by anything except a semicolon
+  const cookiestring = RegExp(name + '=[^;]+').exec(document.cookie);
+  // Return everything after the equal sign, or an empty string if the cookie name not found
+  return decodeURIComponent(
+    cookiestring ? cookiestring.toString().replace(/^[^=]+./, '') : ''
+  );
+};
+
 export const getCookie = (
   SetCookieConsentResponded,
   SetCookieConsentAnswer,
@@ -13,10 +22,4 @@ export const getCookie = (
     SetCookieConsentResponded(cookieContents.responded);
     SetCookieConsentAnswer(cookieContents.answer);
   }
-};
-const readCookie = (name) => {
-  const nameEQ = name + '=';
-  const attribute = document.cookie.split(';');
-  const cookie = attribute.find((cookie) => cookie.trim().startsWith(nameEQ));
-  return cookie ? cookie.substring(nameEQ.length).trim() : null;
 };

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -13,9 +13,6 @@ import { reveal } from '@devseed-ui/animation';
 import { getBannerFromVedaConfig, getCookieConsentFromVedaConfig } from 'veda';
 import MetaTags from '../meta-tags';
 import PageFooter from '../page-footer';
-// import Banner from '../banner';
-// import { CookieConsent } from '../cookie-consent';
-import { SESSION_KEY } from '../cookie-consent/utils';
 const Banner = React.lazy(() => import('../banner'));
 const CookieConsent = React.lazy(() => import('../cookie-consent'));
 
@@ -54,13 +51,13 @@ function LayoutRoot(props: { children?: ReactNode }) {
   const cookieConsentContent = getCookieConsentFromVedaConfig();
   const bannerContent = getBannerFromVedaConfig();
   const { children } = props;
-  const [sessionStart, setSesstionStart] = useState<string | undefined>();
-  const sessionItem = window.sessionStorage.getItem(SESSION_KEY);
+  const [displayCookieConsentForm, setDisplayCookieConsentForm] =
+    useState<boolean>(true);
   const { pathname } = useLocation();
 
   useEffect(() => {
+    // When there is no cookie consent form set up
     !cookieConsentContent && setGoogleTagManager();
-    sessionItem && setSesstionStart(sessionItem);
   }, []);
 
   const { title, thumbnail, description, hideFooter } =
@@ -92,10 +89,10 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
-        {cookieConsentContent && (
+        {cookieConsentContent && displayCookieConsentForm && (
           <CookieConsent
             {...cookieConsentContent}
-            sessionStart={sessionStart}
+            setDisplayCookieConsentForm={setDisplayCookieConsentForm}
             setGoogleTagManager={setGoogleTagManager}
             pathname={pathname}
           />

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -1,4 +1,10 @@
-import React, { ReactNode, useContext, useCallback, useEffect } from 'react';
+import React, {
+  ReactNode,
+  useContext,
+  useCallback,
+  useEffect,
+  useState
+} from 'react';
 import { Link } from 'react-router-dom';
 import { useDeepCompareEffect } from 'use-deep-compare';
 import styled from 'styled-components';
@@ -9,6 +15,7 @@ import MetaTags from '../meta-tags';
 import PageFooter from '../page-footer';
 import Banner from '../banner';
 import { CookieConsent } from '../cookie-consent';
+import { SESSION_KEY } from '../cookie-consent/utils';
 
 import { LayoutRootContext } from './context';
 
@@ -45,10 +52,11 @@ function LayoutRoot(props: { children?: ReactNode }) {
   const cookieConsentContent = getCookieConsentFromVedaConfig();
 
   const { children } = props;
-
+  const [sessionStart, setSesstionStart] = useState<string | undefined>();
+  const sessionItem = window.sessionStorage.getItem(SESSION_KEY);
   useEffect(() => {
-    // window.sessionStorage.setItem("sessionStart", "true");
     !cookieConsentContent && setGoogleTagManager();
+    sessionItem && setSesstionStart(sessionItem);
   }, []);
 
   const { title, thumbnail, description, banner, hideFooter } =
@@ -74,9 +82,10 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
-        {cookieConsentContent && (
+        {cookieConsentContent && !sessionStart && (
           <CookieConsent
             {...cookieConsentContent}
+            sessionStart={sessionStart}
             setGoogleTagManager={setGoogleTagManager}
           />
         )}

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -61,7 +61,6 @@ function LayoutRoot(props: { children?: ReactNode }) {
 
   const { title, thumbnail, description, banner, hideFooter } =
     useContext(LayoutRootContext);
-    console.log(bannerContent, 'banner: ', banner)
 
   const truncatedTitle =
     title?.length > 32 ? `${title.slice(0, 32)}...` : title;
@@ -83,7 +82,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
-        {cookieConsentContent && !sessionStart && (
+        {cookieConsentContent && (
           <CookieConsent
             {...cookieConsentContent}
             sessionStart={sessionStart}

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -10,7 +10,7 @@ import { useDeepCompareEffect } from 'use-deep-compare';
 import styled from 'styled-components';
 import { Outlet } from 'react-router';
 import { reveal } from '@devseed-ui/animation';
-import { getCookieConsentFromVedaConfig } from 'veda';
+import { getBannerFromVedaConfig, getCookieConsentFromVedaConfig } from 'veda';
 import MetaTags from '../meta-tags';
 import PageFooter from '../page-footer';
 import Banner from '../banner';
@@ -50,7 +50,7 @@ const PageBody = styled.div`
 
 function LayoutRoot(props: { children?: ReactNode }) {
   const cookieConsentContent = getCookieConsentFromVedaConfig();
-
+  const bannerContent = getBannerFromVedaConfig();
   const { children } = props;
   const [sessionStart, setSesstionStart] = useState<string | undefined>();
   const sessionItem = window.sessionStorage.getItem(SESSION_KEY);
@@ -61,6 +61,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
 
   const { title, thumbnail, description, banner, hideFooter } =
     useContext(LayoutRootContext);
+    console.log(bannerContent, 'banner: ', banner)
 
   const truncatedTitle =
     title?.length > 32 ? `${title.slice(0, 32)}...` : title;
@@ -73,7 +74,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
         description={description || appDescription}
         thumbnail={thumbnail}
       />
-      {banner && <Banner appTitle={title} {...banner} />}
+      {bannerContent && <Banner appTitle={bannerContent.title} {...bannerContent} />}
       <NavWrapper
         mainNavItems={mainNavItems}
         subNavItems={subNavItems}

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -13,9 +13,11 @@ import { reveal } from '@devseed-ui/animation';
 import { getBannerFromVedaConfig, getCookieConsentFromVedaConfig } from 'veda';
 import MetaTags from '../meta-tags';
 import PageFooter from '../page-footer';
-import Banner from '../banner';
-import { CookieConsent } from '../cookie-consent';
+// import Banner from '../banner';
+// import { CookieConsent } from '../cookie-consent';
 import { SESSION_KEY } from '../cookie-consent/utils';
+const Banner = React.lazy(() => import('../banner'));
+const CookieConsent = React.lazy(() => import('../cookie-consent'));
 
 import { LayoutRootContext } from './context';
 
@@ -73,7 +75,9 @@ function LayoutRoot(props: { children?: ReactNode }) {
         description={description || appDescription}
         thumbnail={thumbnail}
       />
-      {bannerContent && <Banner appTitle={bannerContent.title} {...bannerContent} />}
+      {bannerContent && (
+        <Banner appTitle={bannerContent.title} {...bannerContent} />
+      )}
       <NavWrapper
         mainNavItems={mainNavItems}
         subNavItems={subNavItems}

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -59,7 +59,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
     sessionItem && setSesstionStart(sessionItem);
   }, []);
 
-  const { title, thumbnail, description, banner, hideFooter } =
+  const { title, thumbnail, description, hideFooter } =
     useContext(LayoutRootContext);
 
   const truncatedTitle =

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -9,7 +9,6 @@ import MetaTags from '../meta-tags';
 import PageFooter from '../page-footer';
 import Banner from '../banner';
 import { CookieConsent } from '../cookie-consent';
-import { COOKIE_CONSENT_KEY, NO_COOKIE } from '../cookie-consent/utils';
 
 import { LayoutRootContext } from './context';
 
@@ -44,39 +43,11 @@ const PageBody = styled.div`
 
 function LayoutRoot(props: { children?: ReactNode }) {
   const cookieConsentContent = getCookieConsentFromVedaConfig();
-  const readCookie = (name) => {
-    const nameEQ = name + '=';
-    const attribute = document.cookie.split(';');
-    for (let i = 0; i < attribute.length; i++) {
-      let c = attribute[i];
-      while (c.charAt(0) == ' ') c = c.substring(1, c.length);
-      if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
-    }
-    return null;
-  };
 
-  const getCookie = () => {
-    const cookie = readCookie(COOKIE_CONSENT_KEY);
-    if (cookie) {
-      const cookieContents = JSON.parse(cookie);
-      if (cookieContents.answer) setGoogleTagManager();
-      return cookieContents;
-    }
-    return NO_COOKIE;
-  };
-
-  const showForm = () => {
-    const cookieContents = getCookie();
-    if (cookieContents === NO_COOKIE) {
-      return true;
-    } else {
-      return !cookieContents.responded;
-    }
-  };
   const { children } = props;
 
-
   useEffect(() => {
+    // window.sessionStorage.setItem("sessionStart", "true");
     !cookieConsentContent && setGoogleTagManager();
   }, []);
 
@@ -103,10 +74,10 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
-        {cookieConsentContent && showForm() && (
+        {cookieConsentContent && (
           <CookieConsent
             {...cookieConsentContent}
-            onFormInteraction={getCookie}
+            setGoogleTagManager={setGoogleTagManager}
           />
         )}
       </PageBody>

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -5,7 +5,7 @@ import React, {
   useEffect,
   useState
 } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useDeepCompareEffect } from 'use-deep-compare';
 import styled from 'styled-components';
 import { Outlet } from 'react-router';
@@ -56,6 +56,8 @@ function LayoutRoot(props: { children?: ReactNode }) {
   const { children } = props;
   const [sessionStart, setSesstionStart] = useState<string | undefined>();
   const sessionItem = window.sessionStorage.getItem(SESSION_KEY);
+  const { pathname } = useLocation();
+
   useEffect(() => {
     !cookieConsentContent && setGoogleTagManager();
     sessionItem && setSesstionStart(sessionItem);
@@ -81,7 +83,11 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <NavWrapper
         mainNavItems={mainNavItems}
         subNavItems={subNavItems}
-        logo={<Logo linkProperties={{LinkElement: Link, pathAttributeKeyName: 'to'}} />}
+        logo={
+          <Logo
+            linkProperties={{ LinkElement: Link, pathAttributeKeyName: 'to' }}
+          />
+        }
       />
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
@@ -91,6 +97,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
             {...cookieConsentContent}
             sessionStart={sessionStart}
             setGoogleTagManager={setGoogleTagManager}
+            pathname={pathname}
           />
         )}
       </PageBody>

--- a/docs/content/CONFIGURATION.md
+++ b/docs/content/CONFIGURATION.md
@@ -67,6 +67,19 @@ type?: BannerType
 | text | string | The text content to display in the banner. This can be an HTML string. | 'Read the new data insight on using EMIT and AVIRIS-3 for monitoring large methane emission events.' |
 | type | enum('info', 'warning') |The type of information delivered by the banner, which determines its background color. | 'info'|
 
+### Cookie Consent Form
+
+`cookieConsentForm` object allows you to display a site-wide Cookie Consent form that sits atop your application. To create a Cookie Consent form, you need to provide two attributes as outlined below. 
+
+```
+title: string,
+copy: string,
+``` 
+
+| Option | Type | Description| Example|
+|---|---|---|---|
+| title | string | 	The text content to display in the title of the cookie consent form. This can be an HTML string. | 'Cookie Consent'|
+| copy | string | The content of the Cookie Consent form, typically is a string that follows MDX documentation format. Allowing flexibility to link to different data management policy.  | 'To learn more about it, see our [Privacy Policy ]\(https://www.nasa.gov/privacy/#cookies)\'  |
 
 ## Meta files
 

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -264,6 +264,7 @@ declare module 'veda' {
   const infoTypeFlag = BannerType.info;
   interface BannerData {
     expires: Date;
+    title: string;
     url: string;
     text: string;
     type?: BannerType;

--- a/parcel-resolver-veda/index.js
+++ b/parcel-resolver-veda/index.js
@@ -86,9 +86,27 @@ function generateMdxDataObject(data) {
 function getCookieConsentForm(result) {
   if (!result.cookieConsentForm) return undefined;
   else {
-    const parsedCopy =  md.render(result.cookieConsentForm.copy)
+    const parsedCopy = md.render(result.cookieConsentForm.copy);
     const trimmedCopy = parsedCopy.replace(/(\r\n|\n|\r)/gm, '');
-    return JSON.stringify({ title: result.cookieConsentForm.title, copy: trimmedCopy});
+    return JSON.stringify({
+      title: result.cookieConsentForm.title,
+      copy: trimmedCopy
+    });
+  }
+}
+
+function getBannerContent(result) {
+  if (!result.banner) return undefined;
+  else {
+    const parsedCopy = md.render(result.banner.text);
+    const trimmedCopy = parsedCopy.replace(/(\r\n|\n|\r)/gm, '');
+    return JSON.stringify({
+      title: result.banner.title,
+      text: trimmedCopy,
+      url: result.banner.url,
+      expires: result.banner.expires,
+      type: result.banner.type
+    });
   }
 }
 
@@ -207,7 +225,7 @@ module.exports = new Resolver({
           )},
           strings: ${JSON.stringify(withDefaultStrings(result.strings))},
           booleans: ${JSON.stringify(withDefaultStrings(result.booleans))},
-          banner: ${JSON.stringify(result.banner)},
+          banner: ${getBannerContent(result)},
           navItems: ${JSON.stringify(result.navItems)},
           cookieConsentForm: ${getCookieConsentForm(result)}
         };


### PR DESCRIPTION
**Related Ticket:** https://github.com/orgs/NASA-IMPACT/projects/17/views/1?pane=issue&itemId=80952423&issue=NASA-IMPACT%7Cveda-ui%7C1171

### Description of Changes

- Relocating cookie retrieval, validation, and creation functionality from `layoutRoot` to `cookieConsentForm`
- Implementing `session item` to track when a session has begun for each individual user and only run validation and retrieval functionality on session start and when a response has not been recorded. 
- Adjusting Banner content to accept markdown in config props.  

### Notes & Questions About Changes

### Validation / Testing
Clear out all cookies in your local machine to do so: open `dev tools` -> navigate to `application tab`-> navigate to `cookies` in the left panel -> right click `clear`
- After clearing your existing site cookies, navigate to any page. Click on **Decline**. Navigate to another page and you should not see the cookie consent form component. 
- Clearing your existing site cookies again, navigate to any page. Click on **Accept**. Navigate to another page and you should not see the cookie consent form component. 
- Clearing your existing site cookies again, navigate to any page. Click on **X**. Navigate to another page and you should see the cookie consent form component rerendered. 