### PR TITLE
Escape special characters in regex expression

### DIFF
--- a/app/scripts/components/common/text-highlight.tsx
+++ b/app/scripts/components/common/text-highlight.tsx
@@ -22,7 +22,9 @@ export default function TextHighlight(props: TextHighlightProps) {
 
   // Highlight is done index based because it has to take case insensitive
   // searches into account.
-  const regex = new RegExp(value, 'ig');
+  const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(escapedValue, 'ig');
+
   /* eslint-disable-next-line prefer-const */
   let highlighted: ReactNode[] = [];
   let workingIdx = 0;


### PR DESCRIPTION
Fix #1059

**Related Ticket:** #1059

### Description of Changes
We added a regex pattern to escape special characters. It is used in the text highlight function, to indicate search results as we type.

### Notes & Questions About Changes
Collaboration with @dzole0311 and github co-pilot 🤓

### Validation / Testing

- Go to Dataset Catalog
- Type `emissions (` in the search bar
- It should display corresponding results
