### PR TITLE
Pre-select AOIs that have the "selected" prop set to true

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
@@ -102,7 +102,7 @@ function CustomAoI({
     return () => {
       map.off('draw.selectionchange', onSelChange);
     };
-  }, [map, selectedForEditing]);
+  }, [selectedForEditing]);
 
   const resetAoisOnMap = useCallback(() => {
     const mbDraw = map?._drawControl;

--- a/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
@@ -89,7 +89,14 @@ function CustomAoI({
     const mbDraw = map?._drawControl;
     if (!mbDraw) return;
     const aoiSelectedFor = selectedForEditing ? SIMPLE_SELECT : STATIC_MODE;
-    mbDraw.changeMode(aoiSelectedFor);
+    const selectedFeatures = features.filter(f => f.selected);
+
+    if (selectedFeatures.length > 0) {
+      const selectedIds = selectedFeatures.map(f => f.id);
+      mbDraw.changeMode(aoiSelectedFor, {
+        featureIds: selectedIds
+      });
+    }
     const onSelChange = () => forceUpdate(Date.now());
     map.on('draw.selectionchange', onSelChange);
     return () => {


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/950 https://github.com/US-GHG-Center/veda-config-ghg/issues/406

### Description of Changes
The fix make sures that selected AOIs persist across page reloads. Previously when an AOI was selected, the selection was lost after a page reload (visually, the polygon was de-selected). The fix checks for existing AOI selections on load and adjusts the mode accordingly.

We also started to enhance the documentation and tests around AOI behavior (thanks to @AliceR): https://github.com/NASA-IMPACT/veda-ui/issues/1207

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
1. Draw a polygon
2. Once you finish drawing, see that the AOI is selected
3. Reload the page
4. Verify that the AOI is still selected
5. Choose a preselected area (one of the state presets)
6. Reload the page and verify that it remains un-selectable