### PR TITLE
Add tests for the AOI feature specification

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
+++ b/app/scripts/components/common/map/controls/aoi/preset-selector.tsx
@@ -88,7 +88,9 @@ const SelectorWrapper = styled.div`
   position: relative;
 `;
 
-const PresetSelect = styled.select`
+const PresetSelect = styled.select.attrs({
+    'data-testid': 'preset-selector'
+  })`
   max-width: 200px;
   height: ${selectorHeight};
   color: transparent;

--- a/app/scripts/components/exploration/components/map/analysis-message-control.tsx
+++ b/app/scripts/components/exploration/components/map/analysis-message-control.tsx
@@ -78,7 +78,9 @@ const MessageStatusIndicator = styled.div<MessageStatusIndicatorProps>`
     }
   }}
 `;
-const MessageContent = styled.div`
+const MessageContent = styled.div.attrs({
+    'data-testid': 'analysis-message'
+  })`
   line-height: 1.5rem;
   max-height: 1.5rem;
 

--- a/docs/development/SETUP.md
+++ b/docs/development/SETUP.md
@@ -62,6 +62,20 @@ VEDA-UI includes a GitHub action for checking TypeScript and lint errors. If you
 #### Pre-commit Hook
 Additionally, there's a pre-commit hook that performs the same error checks. This helps developers identify and address issues at an earlier stage. If you need to bypass the check (to make a local temporary commit etc.), include the `--no-verify`` flag in your commit command.
 
+### Testing
+
+## Unit tests
+
+`yarn test`
+
+## End-to-end tests
+Make sure the development server is running (`yarn serve`)
+
+`yarn test:e2e --ui`
+
+Alternatively, you can install the playwright extension for vs code (ms-playwright.playwright) and run the tests directly from there. It allows to run the tests in watch mode, open the browser or trace viewer, set breakpoints,... 
+Again, make sure that the development server is running (`yarn serve`).
+
 ## Deployment
 To prepare the app for deployment run:
 

--- a/test/playwright/pages/explorePage.ts
+++ b/test/playwright/pages/explorePage.ts
@@ -14,7 +14,7 @@ export default class ExplorePage {
     this.mapboxCanvas = this.page.getByLabel('Map', { exact: true });
     this.firstDatasetItem = this.page.getByRole('article');
     this.closeFeatureTourButton = this.page.getByRole('button', { name: 'Close feature tour' });
-    this.presetSelector = this.page.locator('#preset-selector');
+    this.presetSelector = this.page.getByTestId('preset-selector');
   }
 
   async closeFeatureTour() {

--- a/test/playwright/tests/exploreAoi.spec.ts
+++ b/test/playwright/tests/exploreAoi.spec.ts
@@ -23,33 +23,38 @@ test.describe('Area of Interest (AOI) Analysis', () => {
   );
 
   test('User selects a pre-defined AOI', async ({ page }) => {
-    // When I select the "Analyze an area" tool (Dropdown menu)
-    const toolbar = page.getByTestId('preset-selector');
-    // And choose one of the listed regions
-    await toolbar.selectOption('Hawaii');
+    await test.step('When I select the "Analyze an area" tool (Dropdown menu)', async () => {
+      const toolbar = page.getByTestId('preset-selector');
 
-    // Then map should display the selected area as the AOI
-    // const aoi = await page.$('selector-for-aoi'); // Adjust the selector as needed
-    // expect(aoi).not.toBeNull();
+      await test.step('And choose one of the listed regions', async () => {
+        toolbar.selectOption('Hawaii');
+      });
+    });
 
-    // // And the AOI should not be editable when clicking on it
-    // await page.click('selector-for-aoi'); // Adjust the selector as needed
-    // const isEditable = await page.$eval('selector-for-aoi', el => console.log(el)); // Adjust the selector as needed
-    // expect(isEditable).toBe(false);
+    await test.step('Then the map should display the selected area as the AOI', async () => {
+      // const aoi = await page.$('selector-for-aoi'); // Adjust the selector as needed
+      // expect(aoi).not.toBeNull();
 
-    // And the analysis message should display the size of the area
-    const analysisMessage = await page
-      .getByTestId('analysis-message')
-      .textContent()
+      await test.step('And the AOI should not be editable when clicking on it', async () => {
+        // await page.click('selector-for-aoi'); // Adjust the selector as needed
+        // const isEditable = await page.$eval('selector-for-aoi', el => console.log(el)); // Adjust the selector as needed
+        // expect(isEditable).toBe(false);
+      });
+    });
 
-    expect(analysisMessage).toContain('An area of 17 K km2 is selected.');
+    await expect(
+      page.getByTestId('analysis-message'),
+      'And the analysis message should display the size of the area'
+    ).toHaveText(/An area of 17 K km2/i);
 
-    // And the 'Delete all areas' button should be shown
-    const deleteButton = await page.$('text=Delete all areas');
-    expect(deleteButton).not.toBeNull();
+    await expect(
+      page.getByRole('button', { name: 'Delete all areas' }),
+      'And the "Delete all areas" button should be shown'
+    ).toBeVisible();
 
-    // And the 'Run analysis' button should be shown
-    const runButton = await page.$('text=Run analysis');
-    expect(runButton).not.toBeNull();
+    await expect(
+      page.getByRole('button', { name: 'Run analysis' }),
+      'And the "Run analysis" button should be shown'
+    ).toBeVisible();
   });
 });

--- a/test/playwright/tests/exploreAoi.spec.ts
+++ b/test/playwright/tests/exploreAoi.spec.ts
@@ -32,13 +32,11 @@ test.describe('Area of Interest (AOI) Analysis', () => {
     });
 
     await test.step('Then the map should display the selected area as the AOI', async () => {
-      // const aoi = await page.$('selector-for-aoi'); // Adjust the selector as needed
-      // expect(aoi).not.toBeNull();
+      // How to check if the pre-defined AOI is created? Can we access the canvas, or methods of mbDraw?
 
       await test.step('And the AOI should not be editable when clicking on it', async () => {
-        // await page.click('selector-for-aoi'); // Adjust the selector as needed
-        // const isEditable = await page.$eval('selector-for-aoi', el => console.log(el)); // Adjust the selector as needed
-        // expect(isEditable).toBe(false);
+        // How to check that the drawing mode did not change for the AOI? 
+        // Can we access the canvas, or methods of mbDraw?
       });
     });
 
@@ -56,5 +54,25 @@ test.describe('Area of Interest (AOI) Analysis', () => {
       page.getByRole('button', { name: 'Run analysis' }),
       'And the "Run analysis" button should be shown'
     ).toBeVisible();
+  });
+
+  test('User draws AOI when pre-defined AOI exists', async ({ page }) => {
+    await test.step('Given that there is a pre-defined AOI on the map', async () => {
+      const toolbar = page.getByTestId('preset-selector');
+      await toolbar.selectOption('Hawaii');
+    });
+
+    await test.step('When I click on a pen tool to draw custom AOI', async () => {
+      await page.getByRole('button', { name: 'Draw AOI' }).click();
+    });
+
+    await test.step('Then the AOI from pre-defined AOIs should be deleted', async () => {
+      // How to check if the pre-defined AOI is deleted? Can we access the canvas, or methods of mbDraw?
+    });
+
+    await test.step('And the pre-defined selector should be reset and display the placeholder text', async () => {
+      const toolbar = page.getByTestId('preset-selector');
+      expect(toolbar).toHaveValue('Analyze an area');
+    });
   });
 });

--- a/test/playwright/tests/exploreAoi.spec.ts
+++ b/test/playwright/tests/exploreAoi.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '../pages/basePage';
+
+test.describe('Area of Interest (AOI) Analysis', () => {
+  test.beforeEach(
+    async ({ page, explorePage, consentBanner, datasetSelectorComponent }) => {
+      let pageErrorCalled = false;
+      // Log all uncaught errors to the terminal to be visible in trace
+      page.on('pageerror', (exception) => {
+        console.log(`Uncaught exception: "${JSON.stringify(exception)}"`);
+        pageErrorCalled = true;
+      });
+
+      const mapboxResponsePromise = page.waitForResponse(
+        /api\.mapbox.com\/v4\/mapbox\.mapbox-streets-v8/i
+      );
+
+      // Given that I am on the map view (explore page)
+      await page.goto('/exploration');
+      await consentBanner.acceptButton.click();
+      await datasetSelectorComponent.addFirstDataset();
+      await explorePage.closeFeatureTour();
+    }
+  );
+
+  test('User selects a pre-defined AOI', async ({ page }) => {
+    // When I select the "Analyze an area" tool (Dropdown menu)
+    const toolbar = page.getByTestId('preset-selector');
+    // And choose one of the listed regions
+    await toolbar.selectOption('Hawaii');
+
+    // Then map should display the selected area as the AOI
+    // const aoi = await page.$('selector-for-aoi'); // Adjust the selector as needed
+    // expect(aoi).not.toBeNull();
+
+    // // And the AOI should not be editable when clicking on it
+    // await page.click('selector-for-aoi'); // Adjust the selector as needed
+    // const isEditable = await page.$eval('selector-for-aoi', el => console.log(el)); // Adjust the selector as needed
+    // expect(isEditable).toBe(false);
+
+    // And the analysis message should display the size of the area
+    const analysisMessage = await page
+      .getByTestId('analysis-message')
+      .textContent()
+
+    expect(analysisMessage).toContain('An area of 17 K km2 is selected.');
+
+    // And the 'Delete all areas' button should be shown
+    const deleteButton = await page.$('text=Delete all areas');
+    expect(deleteButton).not.toBeNull();
+
+    // And the 'Run analysis' button should be shown
+    const runButton = await page.$('text=Run analysis');
+    expect(runButton).not.toBeNull();
+  });
+});


### PR DESCRIPTION
**Related Ticket:** #1207

### Description of Changes
So far, added a first test for the scenario "User selects a pre-defined AOI". I'm adding some `data-testid` properties to relevant dom elements in order to select them in the test.

Also, added some documentation on how to run the tests. @hanbyul-here if you want to try that on your machine, and let me know if it works? 

### Notes & Questions About Changes
more tests to be added

### Validation / Testing
Follow the instructions added to the SETUP.md guide to run the tests locally. See if they pass!
