### PR TITLE
Fix lint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,15 +40,7 @@
     "sourceType": "module" // Allows for the use of imports
   },
   "rules": {
-    "prettier/prettier": [
-      2,
-      {
-        "semi": true,
-        "singleQuote": true,
-        "jsxSingleQuote": true,
-        "parser": "flow"
-      }
-    ],
+    "prettier/prettier": 2,
     "inclusive-language/use-inclusive-words": 2,
     "semi": [2, "always"],
     "jsx-quotes": [2, "prefer-single"],
@@ -99,7 +91,12 @@
       "files": ["**/*.ts", "**/*.tsx"],
       "plugins": ["@typescript-eslint"],
       "rules": {
-        "prettier/prettier": 2,
+        "prettier/prettier": [
+          1,
+          {
+            "parser": "typescript"
+          }
+        ],
         "@typescript-eslint/no-unused-vars": 2,
         "@typescript-eslint/no-non-null-assertion": 0
       },

--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,7 @@
       "files": ["**/*.ts", "**/*.tsx"],
       "plugins": ["@typescript-eslint"],
       "rules": {
-        "prettier/prettier": 0,
+        "prettier/prettier": 2,
         "@typescript-eslint/no-unused-vars": 2,
         "@typescript-eslint/no-non-null-assertion": 0
       },


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
My local dev setup / code editor setup wasn't working with `format on save` and the specified rules in `.vscode/settings.json.sample`. I noticed that we have the prettier rules disabled for all .ts/.tsx files in our .eslint configuration. 
Additionally, we have the prettier rules specified in both the .prettierrc and the .eslintrc, which is redundant and confusing. 
I enabled the prettier rules for .ts/.tsx files and removed the redundancy. After that, I ran `yarn lint:scripts --fix` to automatically fix the lint issues across the codebase, now that we have the rules enabled. Unfortunately, it turns out that this will give a few more issues that needs attention. 
Before going deeper into fixing these, I want to ask the team:
- how have you worked with this configuration? It was set up like this for about 2 years, so maybe I am not seeing how to configure it correctly on my end?
- how would you like to go about this going forward? Clean up the configuration, fix the issues, or leave as is?
- it seems you arrived at a cleaner setup for [next-veda-ui](https://github.com/developmentseed/next-veda-ui/blob/main/.eslintrc.json), should we aim to get the same configuration here?
 
### Notes & Questions About Changes
Opened a draft for team discussion

### Validation / Testing
See if you can use formatOnSave to automatically correct the line indentation in your cloned codebase. Run `yarn lint` and check for errors.
