### PR TITLE
Update condition to run playwright tests on release branches

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 60
     needs: prep
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/heads/release')
+    if: startsWith(github.head_ref, 'release')
 
     steps:
       - name: Checkout


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
We want to run the github playwright step only on branches whose name start with `release`.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
