### PR TITLE
Set data catalog filters to be closed by default

### DIFF
--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -214,7 +214,7 @@ function CatalogContent({
         allSelected={selectedFilters}
         exclusiveSourceSelected={exclusiveSourceSelected}
         customTopOffset={isSelectable ? 50 : 0}
-        openByDefault={isSelectable ? false : true}
+        openByDefault={false}
         pathname={pathname}
       />
       <Catalog>


### PR DESCRIPTION
**Related Ticket:**  https://github.com/US-GHG-Center/ghgc-architecture/issues/391

### Description of Changes

With this change the data catalog filters controls are initially displayed in a closed state when the page loads.

### Notes & Questions About Changes

This affects two pages: Data Catalog and Exploration.

### Validation / Testing

Visit the following URLs (on localhost), all of them should display the filter controls closed on page load:

- [Data Catalog page, no filter option selected](http://localhost:9000/data-catalog)
- [Data Catalog page, filter options are selected](http://localhost:9000/data-catalog?taxonomy=%7B%22Topics%22%3A%5B%22burn-severity%22%5D%2C%22Source%22%3A%5B%22cmip-6%22%2C%22epa%22%5D%7D)
- [Exploration page, no filter option selected](http://localhost:9000/exploration)
- [Exploration page, a filter option is selected](http://localhost:9000/exploration?datasets=%5B%5D&taxonomy=%7B%22Topics%22%3A%5B%22climate-model%22%5D%7D)

