### PR TITLE
add a flag to see if mapboxgl draw is initialized

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/custom-aoi-control.tsx
@@ -79,15 +79,15 @@ function CustomAoI({
 
   const [selectedForEditing, setSelectedForEditing] = useAtom(selectedForEditingAtom);
 
-  const { onUpdate, isDrawing, setIsDrawing, features } = useAois();
+  const { drawToolInitialized, onUpdate, isDrawing, setIsDrawing, features } = useAois();
   const aoiDeleteAll = useSetAtom(aoiDeleteAllAtom);
 
   // Needed so that this component re-renders to when the draw selection changes
   // from feature to point.
   const [, forceUpdate] = useState(0);
   useEffect(() => {
-    const mbDraw = map?._drawControl;
-    if (!mbDraw) return;
+    if (!drawToolInitialized) return;
+    const mbDraw = map._drawControl;
     const aoiSelectedFor = selectedForEditing ? SIMPLE_SELECT : STATIC_MODE;
     const selectedFeatures = features.filter(f => f.selected);
 
@@ -102,7 +102,7 @@ function CustomAoI({
     return () => {
       map.off('draw.selectionchange', onSelChange);
     };
-  }, [selectedForEditing]);
+  }, [drawToolInitialized, selectedForEditing]);
 
   const resetAoisOnMap = useCallback(() => {
     const mbDraw = map?._drawControl;

--- a/app/scripts/components/common/map/controls/aoi/index.tsx
+++ b/app/scripts/components/common/map/controls/aoi/index.tsx
@@ -32,7 +32,7 @@ export default function DrawControl(props: DrawControlProps) {
   const theme = useTheme();
   const control = useRef<MapboxDraw>();
   const aoisFeatures = useAtomValue(aoisFeaturesAtom);
-  const { onUpdate, onDelete, onSelectionChange, onDrawModeChange } = useAois();
+  const { onDrawToolInitialized, onUpdate, onDelete, onSelectionChange, onDrawModeChange } = useAois();
 
   useControl<MapboxDraw>(
     () => {
@@ -56,6 +56,7 @@ export default function DrawControl(props: DrawControlProps) {
       map.on('draw.delete', onDelete);
       map.on('draw.selectionchange', onSelectionChange);
       map.on('draw.modechange', onDrawModeChange);
+      map.on('draw.actionable', onDrawToolInitialized);
       map.on('load', () => {
         control.current?.set({
           type: 'FeatureCollection',
@@ -69,6 +70,7 @@ export default function DrawControl(props: DrawControlProps) {
       map.off('draw.delete', onDelete);
       map.off('draw.selectionchange', onSelectionChange);
       map.off('draw.modechange', onDrawModeChange);
+      map.off('draw.actionable', onDrawToolInitialized);
     },
     {
       position: 'top-left'

--- a/app/scripts/components/common/map/controls/hooks/use-aois.ts
+++ b/app/scripts/components/common/map/controls/hooks/use-aois.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { Feature, Polygon } from 'geojson';
 import { toAoIid } from '../../utils';
 import {
@@ -15,6 +15,7 @@ export default function useAois() {
   const features = useAtomValue(aoisFeaturesAtom);
 
   const [isDrawing, setIsDrawing] = useAtom(isDrawingAtom);
+  const [drawToolInitialized, setDrawToolInitialized] = useState(false);
 
   const aoisUpdateGeometry = useSetAtom(aoisUpdateGeometryAtom);
   const update = useCallback(
@@ -33,6 +34,10 @@ export default function useAois() {
     },
     [update]
   );
+
+  const onDrawToolInitialized = () => {
+    setDrawToolInitialized(true);
+  };
 
   const aoiDelete = useSetAtom(aoisDeleteAtom);
   const onDelete = useCallback(
@@ -65,7 +70,9 @@ export default function useAois() {
     onDelete,
     onSelectionChange,
     onDrawModeChange,
+    onDrawToolInitialized,
     isDrawing,
+    drawToolInitialized,
     setIsDrawing
   };
 }


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes

This PR introduces `drawToolInitialized` state to `useAois` hook so it can be used to safely call the methods of mapboxdraw.


### Notes & Questions About Changes
While refactoring, we realized that just checking if map instance has mapboxgldraw instance is not enough - this still doesn't guarantee if the store of mapboxgl.draw was initiated (which is initiated after being added to map) or not, and most of methods will throw errors if the store is not initiated. 

I was wondering if there is anything that we can reliably say the mapboxgl draw store is initialized, and found the event that can be a better indicator of the store initialization - which is `draw.actionable `: https://github.com/mapbox/mapbox-gl-draw/blob/main/docs/API.md#drawactionable

This PR is not complete ex. `draw.actionable` is actually not about the initialization, it is more about what actions are currently available - so `setDrawToolInitialized` is getting called more than needed now. But just opening it to share the idea with the team members 


### Validation / Testing

This PR should not introduce any visible change to users (it should decrease the occadence that developers face on local environment) 

Also I won't work on this PR for the rest of the sprint, but just wanted to push the experiment since we just put a lot of workaround for this problem. 

I don't expect the review at this point, but just tagging the people who worked on AOI related problems recently @dzole0311 @AliceR @sandrahoang686 