### PR TITLE
[1156] Expose a Veda UI EnvConfigProvider for providing env variables

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -37,7 +37,7 @@ import {
 } from '$components/exploration/data-utils-no-faux-module';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
 import { ProjectionOptions, VedaDatum, DatasetData } from '$types/veda';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 export const mapHeight = '32rem';
 const Carto = styled.div`
@@ -185,7 +185,7 @@ function MapBlock(props: MapBlockProps) {
 
   const [layers, setLayers] = useState<VizDataset[]>(layersToFetch);
 
-  const { envApiStacEndpoint } = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint } = useContext(EnvConfigContext);
 
   useReconcileWithStacMetadata(layers, setLayers, envApiStacEndpoint);
 

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -185,9 +185,9 @@ function MapBlock(props: MapBlockProps) {
 
   const [layers, setLayers] = useState<VizDataset[]>(layersToFetch);
 
-  const config = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint } = useContext(VedauiConfigContext);
 
-  useReconcileWithStacMetadata(layers, setLayers, config.envApiStacEndpoint);
+  useReconcileWithStacMetadata(layers, setLayers, envApiStacEndpoint);
 
   const selectedDatetime: Date | undefined = dateTime
     ? utcString2userTzDate(dateTime)

--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useContext } from 'react';
 import styled from 'styled-components';
 import { MapboxOptions } from 'mapbox-gl';
 import * as dateFns from 'date-fns';
@@ -11,10 +11,7 @@ import { Basemap } from '../map/style-generators/basemap';
 import { LayerLegend, LayerLegendContainer } from '../map/layer-legend';
 import MapCoordsControl from '../map/controls/coords';
 import MapMessage from '../map/map-message';
-import {
-  formatCompareDate,
-  formatSingleDate,
-} from '../map/utils';
+import { formatCompareDate, formatSingleDate } from '../map/utils';
 import {
   BasemapId,
   DEFAULT_MAP_STYLE_URL
@@ -34,9 +31,13 @@ import {
   DatasetStatus
 } from '$components/exploration/types.d.ts';
 
-import { reconcileDatasets, getDatasetLayers } from '$components/exploration/data-utils-no-faux-module';
+import {
+  reconcileDatasets,
+  getDatasetLayers
+} from '$components/exploration/data-utils-no-faux-module';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
 import { ProjectionOptions, VedaDatum, DatasetData } from '$types/veda';
+import { VedauiConfigContext } from '$context/config-context';
 
 export const mapHeight = '32rem';
 const Carto = styled.div`
@@ -125,7 +126,10 @@ interface MapBlockProps {
   layerId: string;
 }
 
-const getDataLayer = (layerIndex: number, layers: VizDataset[] | undefined): (VizDatasetSuccess | null) => {
+const getDataLayer = (
+  layerIndex: number,
+  layers: VizDataset[] | undefined
+): VizDatasetSuccess | null => {
   if (!layers || layers.length <= layerIndex) return null;
   const layer = layers[layerIndex];
   // @NOTE: What to do when data returns ERROR
@@ -177,16 +181,18 @@ function MapBlock(props: MapBlockProps) {
       totalLayers = [...totalLayers, compareMapStaticData];
     }
     return totalLayers;
-  },[layerId]);
+  }, [layerId]);
 
   const [layers, setLayers] = useState<VizDataset[]>(layersToFetch);
 
-  useReconcileWithStacMetadata(layers, setLayers);
+  const config = useContext(VedauiConfigContext);
 
-  const selectedDatetime: (Date | undefined) = dateTime
+  useReconcileWithStacMetadata(layers, setLayers, config.envApiStacEndpoint);
+
+  const selectedDatetime: Date | undefined = dateTime
     ? utcString2userTzDate(dateTime)
     : undefined;
-  const selectedCompareDatetime: (Date | undefined) = compareDateTime
+  const selectedCompareDatetime: Date | undefined = compareDateTime
     ? utcString2userTzDate(compareDateTime)
     : undefined;
 
@@ -210,8 +216,14 @@ function MapBlock(props: MapBlockProps) {
 
   const [, setProjection] = useState(projectionStart);
 
-  const baseDataLayer: (VizDatasetSuccess | null) = useMemo(() => getDataLayer(0, layers), [layers]);
-  const compareDataLayer: (VizDatasetSuccess | null) = useMemo(() => getDataLayer(1, layers), [layers]);
+  const baseDataLayer: VizDatasetSuccess | null = useMemo(
+    () => getDataLayer(0, layers),
+    [layers]
+  );
+  const compareDataLayer: VizDatasetSuccess | null = useMemo(
+    () => getDataLayer(1, layers),
+    [layers]
+  );
 
   const baseTimeDensity = baseDataLayer?.data.timeDensity;
   const compareTimeDensity = compareDataLayer?.data.timeDensity;
@@ -262,9 +274,16 @@ function MapBlock(props: MapBlockProps) {
     if (compareLabel) return compareLabel as string;
     // Use label function from originalData.Compare
     else if (baseDataLayer?.data.compare?.mapLabel) {
-      if (typeof baseDataLayer.data.compare.mapLabel === 'string') return baseDataLayer.data.compare.mapLabel;
-      const labelFn = baseDataLayer.data.compare.mapLabel as (unknown) => string;
-      return labelFn({dateFns, datetime: selectedDatetime, compareDatetime: compareToDate });
+      if (typeof baseDataLayer.data.compare.mapLabel === 'string')
+        return baseDataLayer.data.compare.mapLabel;
+      const labelFn = baseDataLayer.data.compare.mapLabel as (
+        unknown
+      ) => string;
+      return labelFn({
+        dateFns,
+        datetime: selectedDatetime,
+        compareDatetime: compareToDate
+      });
     }
 
     // Default to date comparison.
@@ -356,13 +375,13 @@ function MapBlock(props: MapBlockProps) {
           <Compare>
             <Basemap basemapStyleId={mapBasemapId} />
             {compareDataLayer && (
-                <Layer
-                  key={compareDataLayer.data.id}
-                  id={`compare-${compareDataLayer.data.id}`}
-                  dataset={compareDataLayer}
-                  selectedDay={selectedCompareDatetime}
-                />
-              )}
+              <Layer
+                key={compareDataLayer.data.id}
+                id={`compare-${compareDataLayer.data.id}`}
+                dataset={compareDataLayer}
+                selectedDay={selectedCompareDatetime}
+              />
+            )}
           </Compare>
         )}
       </Map>

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -52,7 +52,7 @@ import {
   formatSingleDate,
   reconcileVizDataset
 } from '$components/common/map/utils';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 type ResolvedScrollyMapLayer = {
   vizDataset: VizDatasetSuccess;
@@ -260,7 +260,7 @@ const MAP_OPTIONS = {
 function Scrollytelling(props) {
   const { children } = props;
 
-  const { envApiStacEndpoint } = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint } = useContext(EnvConfigContext);
 
   const { isHeaderHidden, headerHeight, wrapperHeight } =
     useSlidingStickyHeaderProps();

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -1,6 +1,8 @@
 import React, {
-  Children, ReactElement,
+  Children,
+  ReactElement,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -33,12 +35,24 @@ import { useSlidingStickyHeaderProps } from '$components/common/layout-root/useS
 import { HEADER_TRANSITION_DURATION } from '$utils/use-sliding-sticky-header';
 import { Basemap } from '$components/common/map/style-generators/basemap';
 import Map from '$components/common/map';
-import { LayerLegend, LayerLegendContainer } from '$components/common/map/layer-legend';
+import {
+  LayerLegend,
+  LayerLegendContainer
+} from '$components/common/map/layer-legend';
 import { Layer } from '$components/exploration/components/map/layer';
 import { MapLoading } from '$components/common/loading-skeleton';
-import { DatasetData, DatasetStatus, VizDataset, VizDatasetSuccess } from '$components/exploration/types.d.ts';
+import {
+  DatasetData,
+  DatasetStatus,
+  VizDataset,
+  VizDatasetSuccess
+} from '$components/exploration/types.d.ts';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
-import { formatSingleDate, reconcileVizDataset } from '$components/common/map/utils';
+import {
+  formatSingleDate,
+  reconcileVizDataset
+} from '$components/common/map/utils';
+import { VedauiConfigContext } from '$context/config-context';
 
 type ResolvedScrollyMapLayer = {
   vizDataset: VizDatasetSuccess;
@@ -125,10 +139,10 @@ function getChapterLayerKey(ch: ScrollyChapter) {
  *
  * @param {array} chList List of chapters with related layers.
  */
-function useMapLayersFromChapters(chList: ScrollyChapter[]): [
-  ResolvedScrollyMapLayer[],
-  string[]
-] {
+function useMapLayersFromChapters(
+  chList: ScrollyChapter[],
+  envApiStacEndpoint: string
+): [ResolvedScrollyMapLayer[], string[]] {
   // The layers are unique based on the dataset, layer id and datetime.
   // First we filter out any scrollytelling block that doesn't have layer.
   const uniqueChapterLayers = useMemo(() => {
@@ -141,7 +155,6 @@ function useMapLayersFromChapters(chList: ScrollyChapter[]): [
       }, {});
 
     return Object.values(unique);
-
   }, [chList]);
 
   // Create an array of datasetId & layerId pairs which we can easily validate when creating
@@ -149,31 +162,37 @@ function useMapLayersFromChapters(chList: ScrollyChapter[]): [
   const uniqueLayerRefs = useMemo(() => {
     return uniqueChapterLayers.map(({ datasetId, layerId }) => ({
       datasetId,
-      layerId,
+      layerId
     }));
   }, [uniqueChapterLayers]);
 
   // Validate that all layers are defined in the configuration.
   // They must be defined in the configuration otherwise it is not possible to load them.
-  const reconciledVizDatasets = uniqueLayerRefs.map(({ datasetId, layerId }) => {
-    const layers = datasets[datasetId]?.data.layers;
+  const reconciledVizDatasets = uniqueLayerRefs.map(
+    ({ datasetId, layerId }) => {
+      const layers = datasets[datasetId]?.data.layers;
 
-    const layer = layers?.find(
-      (l) => l.id === layerId
-    ) as DatasetData | null;
+      const layer = layers?.find((l) => l.id === layerId) as DatasetData | null;
 
-    if (!layer) {
-      throw new Error(
-        `Layer [${layerId}] not found in dataset [${datasetId}]`
-      );
+      if (!layer) {
+        throw new Error(
+          `Layer [${layerId}] not found in dataset [${datasetId}]`
+        );
+      }
+
+      return reconcileVizDataset(layer);
     }
+  );
 
-    return reconcileVizDataset(layer);
-  });
+  const [resolvedDatasetsWithStac, setResolvedDatasetsWithStac] = useState<
+    VizDataset[]
+  >([]);
 
-  const [resolvedDatasetsWithStac, setResolvedDatasetsWithStac] = useState<VizDataset[]>([]);
-
-  useReconcileWithStacMetadata(reconciledVizDatasets, setResolvedDatasetsWithStac);
+  useReconcileWithStacMetadata(
+    reconciledVizDatasets,
+    setResolvedDatasetsWithStac,
+    envApiStacEndpoint
+  );
 
   // Each resolved layer will be an object with:
   // layer: The resolved layerData
@@ -241,6 +260,8 @@ const MAP_OPTIONS = {
 function Scrollytelling(props) {
   const { children } = props;
 
+  const config = useContext(VedauiConfigContext);
+
   const { isHeaderHidden, headerHeight, wrapperHeight } =
     useSlidingStickyHeaderProps();
 
@@ -250,13 +271,16 @@ function Scrollytelling(props) {
   // Extract the props from the chapters.
   const chapterProps = useChapterPropsFromChildren(children);
 
-  const [resolvedLayers, resolvedStatus] =
-    useMapLayersFromChapters(chapterProps);
+  const [resolvedLayers, resolvedStatus] = useMapLayersFromChapters(
+    chapterProps,
+    config.envApiStacEndpoint
+  );
 
   const [activeChapter, setActiveChapter] = useState<ScrollyChapter | null>(
     null
   );
-  const [projection, setProjection] = useState<ProjectionOptions>(projectionDefault);
+  const [projection, setProjection] =
+    useState<ProjectionOptions>(projectionDefault);
 
   // All layers must be loaded, resolved, and added to the map before we
   // initialize scrollama. This is needed because in a scrollytelling map we
@@ -334,9 +358,12 @@ function Scrollytelling(props) {
     : // Otherwise it's the full header height.
       wrapperHeight;
 
-  const activeChapterLayerData = activeChapterLayer ? activeChapterLayer.vizDataset.data : null;
+  const activeChapterLayerData = activeChapterLayer
+    ? activeChapterLayer.vizDataset.data
+    : null;
 
-  const { description, id, name, legend, timeDensity } = activeChapterLayerData ?? {};
+  const { description, id, name, legend, timeDensity } =
+    activeChapterLayerData ?? {};
 
   return (
     <>
@@ -438,7 +465,7 @@ function Scrollytelling(props) {
                     ...vizDataset,
                     settings: {
                       opacity: 100,
-                      isVisible: !isHidden,
+                      isVisible: !isHidden
                     }
                   }}
                   selectedDay={runtimeData.datetime ?? new Date()}

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -260,7 +260,7 @@ const MAP_OPTIONS = {
 function Scrollytelling(props) {
   const { children } = props;
 
-  const config = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint } = useContext(VedauiConfigContext);
 
   const { isHeaderHidden, headerHeight, wrapperHeight } =
     useSlidingStickyHeaderProps();
@@ -273,7 +273,7 @@ function Scrollytelling(props) {
 
   const [resolvedLayers, resolvedStatus] = useMapLayersFromChapters(
     chapterProps,
-    config.envApiStacEndpoint
+    envApiStacEndpoint
   );
 
   const [activeChapter, setActiveChapter] = useState<ScrollyChapter | null>(

--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -5,9 +5,9 @@ import { useControl } from 'react-map-gl';
 import { getZoomFromBbox } from '$components/common/map/utils';
 
 export default function GeocoderControl({
-  mapboxToken
+  envMapboxToken
 }: {
-  mapboxToken: string;
+  envMapboxToken: string;
 }) {
   const handleGeocoderResult = useCallback(
     (map, geocoder) =>
@@ -27,7 +27,7 @@ export default function GeocoderControl({
   useControl(
     ({ map }) => {
       const geocoder = new MapboxGeocoder({
-        accessToken: mapboxToken,
+        accessToken: envMapboxToken,
         marker: false,
         collapsed: true,
         // Because of Mapbox issue: https://github.com/mapbox/mapbox-gl-js/issues/12565

--- a/app/scripts/components/common/map/controls/geocoder.tsx
+++ b/app/scripts/components/common/map/controls/geocoder.tsx
@@ -1,26 +1,33 @@
 import { useCallback } from 'react';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
 
-
 import { useControl } from 'react-map-gl';
 import { getZoomFromBbox } from '$components/common/map/utils';
 
-export default function GeocoderControl() {
-  const handleGeocoderResult = useCallback((map, geocoder) => ({ result }) => {
-    geocoder.clear();
-    geocoder._inputEl.blur();
-    // Pass arbiturary number for zoom if there is no bbox
-    const zoom = result.bbox? getZoomFromBbox(result.bbox): 14;
-    map.flyTo({
-      center: result.center,
-      zoom
-    });
-  }, []);
+export default function GeocoderControl({
+  mapboxToken
+}: {
+  mapboxToken: string;
+}) {
+  const handleGeocoderResult = useCallback(
+    (map, geocoder) =>
+      ({ result }) => {
+        geocoder.clear();
+        geocoder._inputEl.blur();
+        // Pass arbiturary number for zoom if there is no bbox
+        const zoom = result.bbox ? getZoomFromBbox(result.bbox) : 14;
+        map.flyTo({
+          center: result.center,
+          zoom
+        });
+      },
+    []
+  );
 
   useControl(
     ({ map }) => {
       const geocoder = new MapboxGeocoder({
-        accessToken: process.env.MAPBOX_TOKEN,
+        accessToken: mapboxToken,
         marker: false,
         collapsed: true,
         // Because of Mapbox issue: https://github.com/mapbox/mapbox-gl-js/issues/12565

--- a/app/scripts/components/common/map/controls/map-options/basemap.ts
+++ b/app/scripts/components/common/map/controls/map-options/basemap.ts
@@ -9,35 +9,36 @@
 
 export const BASE_STYLE_PATH = 'https://api.mapbox.com/styles/v1/covid-nasa';
 
-export const getStyleUrl = (mapboxId: string) =>
-  `${BASE_STYLE_PATH}/${mapboxId}?access_token=${process.env.MAPBOX_TOKEN}`;
+export const getStyleUrl = (mapboxId: string, mapboxToken: string) =>
+  `${BASE_STYLE_PATH}/${mapboxId}?access_token=${mapboxToken}`;
 
-export const BASEMAP_STYLES = [
-  {
-    id: 'satellite',
-    label: 'Satellite',
-    mapboxId: 'cldu1cb8f00ds01p6gi583w1m',
-    thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1cb8f00ds01p6gi583w1m/static/-9.14,38.7,10.5,0/480x320?access_token=${process.env.MAPBOX_TOKEN}`
-  },
-  {
-    id: 'dark',
-    label: 'Default dark',
-    mapboxId: 'cldu14gii006801mgq3dn1jpd',
-    thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/dark-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${process.env.MAPBOX_TOKEN}`
-  },
-  {
-    id: 'light',
-    label: 'Default light',
-    mapboxId: 'cldu0tceb000701qnrl7p9woh',
-    thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/light-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${process.env.MAPBOX_TOKEN}`
-  },
-  {
-    id: 'topo',
-    label: 'Topo',
-    mapboxId: 'cldu1yayu00au01qqrbdahb3m',
-    thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1yayu00au01qqrbdahb3m/static/-9.14,38.7,10.5,0/480x320?access_token=${process.env.MAPBOX_TOKEN}`
-  }
-] as const;
+export const getBasemapStyles = (mapboxToken: string | undefined) =>
+  [
+    {
+      id: 'satellite',
+      label: 'Satellite',
+      mapboxId: 'cldu1cb8f00ds01p6gi583w1m',
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1cb8f00ds01p6gi583w1m/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+    },
+    {
+      id: 'dark',
+      label: 'Default dark',
+      mapboxId: 'cldu14gii006801mgq3dn1jpd',
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/dark-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+    },
+    {
+      id: 'light',
+      label: 'Default light',
+      mapboxId: 'cldu0tceb000701qnrl7p9woh',
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/light-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+    },
+    {
+      id: 'topo',
+      label: 'Topo',
+      mapboxId: 'cldu1yayu00au01qqrbdahb3m',
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1yayu00au01qqrbdahb3m/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+    }
+  ] as const;
 
 export const BASEMAP_ID_DEFAULT = 'satellite';
 
@@ -59,8 +60,8 @@ export const GROUPS_BY_OPTION: Record<Option, string[]> = {
   ]
 };
 
-export type Basemap = typeof BASEMAP_STYLES[number];
+export type Basemap = ReturnType<typeof getBasemapStyles>[number];
 
-export type BasemapId = typeof BASEMAP_STYLES[number]['id'];
+export type BasemapId = Basemap['id'];
 
 export type Option = 'labels' | 'boundaries';

--- a/app/scripts/components/common/map/controls/map-options/basemap.ts
+++ b/app/scripts/components/common/map/controls/map-options/basemap.ts
@@ -9,34 +9,34 @@
 
 export const BASE_STYLE_PATH = 'https://api.mapbox.com/styles/v1/covid-nasa';
 
-export const getStyleUrl = (mapboxId: string, mapboxToken: string) =>
-  `${BASE_STYLE_PATH}/${mapboxId}?access_token=${mapboxToken}`;
+export const getStyleUrl = (mapboxId: string, envMapboxToken: string) =>
+  `${BASE_STYLE_PATH}/${mapboxId}?access_token=${envMapboxToken}`;
 
-export const getBasemapStyles = (mapboxToken: string | undefined) =>
+export const getBasemapStyles = (envMapboxToken: string | undefined) =>
   [
     {
       id: 'satellite',
       label: 'Satellite',
       mapboxId: 'cldu1cb8f00ds01p6gi583w1m',
-      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1cb8f00ds01p6gi583w1m/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1cb8f00ds01p6gi583w1m/static/-9.14,38.7,10.5,0/480x320?access_token=${envMapboxToken}`
     },
     {
       id: 'dark',
       label: 'Default dark',
       mapboxId: 'cldu14gii006801mgq3dn1jpd',
-      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/dark-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/dark-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${envMapboxToken}`
     },
     {
       id: 'light',
       label: 'Default light',
       mapboxId: 'cldu0tceb000701qnrl7p9woh',
-      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/light-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/mapbox/light-v10/static/-9.14,38.7,10.5,0/480x320?access_token=${envMapboxToken}`
     },
     {
       id: 'topo',
       label: 'Topo',
       mapboxId: 'cldu1yayu00au01qqrbdahb3m',
-      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1yayu00au01qqrbdahb3m/static/-9.14,38.7,10.5,0/480x320?access_token=${mapboxToken}`
+      thumbnailUrl: `https://api.mapbox.com/styles/v1/covid-nasa/cldu1yayu00au01qqrbdahb3m/static/-9.14,38.7,10.5,0/480x320?access_token=${envMapboxToken}`
     }
   ] as const;
 

--- a/app/scripts/components/common/map/controls/map-options/index.tsx
+++ b/app/scripts/components/common/map/controls/map-options/index.tsx
@@ -20,7 +20,7 @@ import {
 } from './projection-items';
 import { MapOptionsProps } from './types';
 import { projectionsList } from './projections';
-import { BASEMAP_STYLES } from './basemap';
+import { getBasemapStyles } from './basemap';
 
 import { SelectorButton } from '$components/common/map/style/button';
 
@@ -110,8 +110,11 @@ function MapOptions(props: MapOptionsProps) {
     onBasemapStyleIdChange,
     labelsOption,
     boundariesOption,
-    onOptionChange
+    onOptionChange,
+    mapboxToken
   } = props;
+
+  const basemapStyles = getBasemapStyles(mapboxToken);
 
   return (
     <MapOptionsDropdown
@@ -137,7 +140,7 @@ function MapOptions(props: MapOptionsProps) {
           </ContentGroupHeader>
           <ContentGroupBody>
             <DropMenu as='ol'>
-              {BASEMAP_STYLES.map((basemap) => (
+              {basemapStyles.map((basemap) => (
                 <li key={basemap.id}>
                   <DropMenuItem
                     href='#'

--- a/app/scripts/components/common/map/controls/map-options/index.tsx
+++ b/app/scripts/components/common/map/controls/map-options/index.tsx
@@ -111,10 +111,10 @@ function MapOptions(props: MapOptionsProps) {
     labelsOption,
     boundariesOption,
     onOptionChange,
-    mapboxToken
+    envMapboxToken
   } = props;
 
-  const basemapStyles = getBasemapStyles(mapboxToken);
+  const basemapStyles = getBasemapStyles(envMapboxToken);
 
   return (
     <MapOptionsDropdown

--- a/app/scripts/components/common/map/controls/map-options/types.ts
+++ b/app/scripts/components/common/map/controls/map-options/types.ts
@@ -9,7 +9,7 @@ export interface MapOptionsProps {
   labelsOption?: boolean;
   boundariesOption?: boolean;
   onOptionChange?: (option: Option, value: boolean) => void;
-  mapboxToken: string;
+  envMapboxToken: string;
 }
 
 export interface ProjectionConicOptions {

--- a/app/scripts/components/common/map/controls/map-options/types.ts
+++ b/app/scripts/components/common/map/controls/map-options/types.ts
@@ -9,6 +9,7 @@ export interface MapOptionsProps {
   labelsOption?: boolean;
   boundariesOption?: boolean;
   onOptionChange?: (option: Option, value: boolean) => void;
+  mapboxToken: string;
 }
 
 export interface ProjectionConicOptions {

--- a/app/scripts/components/common/map/map-component.tsx
+++ b/app/scripts/components/common/map/map-component.tsx
@@ -35,7 +35,7 @@ export default function MapComponent({
   onMapLoad?: () => void;
   interactive?: boolean;
 }) {
-  const config = useContext(VedauiConfigContext);
+  const { envMapboxToken } = useContext(VedauiConfigContext);
 
   const { initialViewState, setInitialViewState, mainId, comparedId } =
     useMapsContext();
@@ -78,7 +78,7 @@ export default function MapComponent({
     <ReactMapGlMap
       id={id}
       ref={mapRef}
-      mapboxAccessToken={config.mapboxToken}
+      mapboxAccessToken={envMapboxToken}
       dragRotate={false}
       touchPitch={false}
       pitchWithRotate={false}

--- a/app/scripts/components/common/map/map-component.tsx
+++ b/app/scripts/components/common/map/map-component.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, ReactElement, useMemo, Ref } from 'react';
+import React, {
+  useCallback,
+  ReactElement,
+  useMemo,
+  Ref,
+  useContext
+} from 'react';
 import ReactMapGlMap, { LngLatBoundsLike, MapRef } from 'react-map-gl';
 import { debounce } from 'lodash';
 import useMapStyle from './hooks/use-map-style';
@@ -7,6 +13,7 @@ import { convertProjectionToMapbox } from './controls/map-options/projections';
 import { ProjectionOptions } from '$types/veda';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
+import { VedauiConfigContext } from '$context/config-context';
 
 const maxMapBounds: LngLatBoundsLike = [
   [-540, -90], // SW
@@ -28,6 +35,8 @@ export default function MapComponent({
   onMapLoad?: () => void;
   interactive?: boolean;
 }) {
+  const config = useContext(VedauiConfigContext);
+
   const { initialViewState, setInitialViewState, mainId, comparedId } =
     useMapsContext();
   const { style } = useMapStyle();
@@ -69,7 +78,7 @@ export default function MapComponent({
     <ReactMapGlMap
       id={id}
       ref={mapRef}
-      mapboxAccessToken={process.env.MAPBOX_TOKEN}
+      mapboxAccessToken={config.mapboxToken}
       dragRotate={false}
       touchPitch={false}
       pitchWithRotate={false}

--- a/app/scripts/components/common/map/map-component.tsx
+++ b/app/scripts/components/common/map/map-component.tsx
@@ -13,7 +13,7 @@ import { convertProjectionToMapbox } from './controls/map-options/projections';
 import { ProjectionOptions } from '$types/veda';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import 'mapbox-gl-compare/dist/mapbox-gl-compare.css';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 const maxMapBounds: LngLatBoundsLike = [
   [-540, -90], // SW
@@ -35,7 +35,7 @@ export default function MapComponent({
   onMapLoad?: () => void;
   interactive?: boolean;
 }) {
-  const { envMapboxToken } = useContext(VedauiConfigContext);
+  const { envMapboxToken } = useContext(EnvConfigContext);
 
   const { initialViewState, setInitialViewState, mainId, comparedId } =
     useMapsContext();

--- a/app/scripts/components/common/map/style-generators/basemap.tsx
+++ b/app/scripts/components/common/map/style-generators/basemap.tsx
@@ -9,7 +9,7 @@ import {
 } from '../controls/map-options/basemap';
 import { ExtendedLayer } from '../types';
 import useMapStyle from '../hooks/use-map-style';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 interface BasemapProps {
   basemapStyleId?: BasemapId;
@@ -33,7 +33,7 @@ export function Basemap({
   labelsOption = true,
   boundariesOption = true
 }: BasemapProps) {
-  const { envMapboxToken } = useContext(VedauiConfigContext);
+  const { envMapboxToken } = useContext(EnvConfigContext);
   const { updateStyle } = useMapStyle();
   const [baseStyle, setBaseStyle] = useState<Style | undefined>(undefined);
 

--- a/app/scripts/components/common/map/style-generators/basemap.tsx
+++ b/app/scripts/components/common/map/style-generators/basemap.tsx
@@ -33,13 +33,13 @@ export function Basemap({
   labelsOption = true,
   boundariesOption = true
 }: BasemapProps) {
-  const config = useContext(VedauiConfigContext);
+  const { envMapboxToken } = useContext(VedauiConfigContext);
   const { updateStyle } = useMapStyle();
   const [baseStyle, setBaseStyle] = useState<Style | undefined>(undefined);
 
   const basemapStyles = useMemo(
-    () => getBasemapStyles(config.mapboxToken),
-    [config.mapboxToken]
+    () => getBasemapStyles(envMapboxToken),
+    [envMapboxToken]
   );
 
   const { data: styleJson } = useQuery(
@@ -50,7 +50,7 @@ export function Basemap({
         : basemapStyles[0].mapboxId;
 
       try {
-        const url = getStyleUrl(mapboxId, config.mapboxToken);
+        const url = getStyleUrl(mapboxId, envMapboxToken);
         const styleRaw = await fetch(url, { signal });
         const styleJson = await styleRaw.json();
         return styleJson;

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -63,6 +63,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     stacApiEndpoint,
     tileApiEndpoint,
     colorMap,
+    envApiStacEndpoint,
+    envApiRasterEndpoint
   } = props;
 
   const { current: mapInstance } = useMaps();
@@ -73,10 +75,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   const minZoom = zoomExtent?.[0] ?? 0;
   const generatorId = `raster-timeseries-${id}`;
 
-  const stacApiEndpointToUse =
-    stacApiEndpoint ?? process.env.API_STAC_ENDPOINT ?? '';
-  const tileApiEndpointToUse =
-    tileApiEndpoint ?? process.env.API_RASTER_ENDPOINT ?? '';
+  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint ?? '';
+  const tileApiEndpointToUse = tileApiEndpoint ?? envApiRasterEndpoint ?? '';
 
   // Status tracking.
   // A raster timeseries layer has a base layer and may have markers.
@@ -270,7 +270,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             controller
           });
           const mosaicUrl = responseData.links[1].href;
-          setMosaicUrl(mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad'));
+          setMosaicUrl(
+            mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad')
+          );
         } catch (error) {
           // @NOTE: conditional logic TO BE REMOVED once new BE endpoints have moved to prod... Fallback on old request url if new endpoints error with nonexistance...
           if (error.request) {
@@ -284,10 +286,14 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
             const mosaicUrl = responseData.links[1].href;
             setMosaicUrl(mosaicUrl);
           } else {
-              LOG &&
+            LOG &&
               /* eslint-disable-next-line no-console */
-              console.log('Titiler /register %cEndpoint error', 'color: red;', error);
-              throw error;
+              console.log(
+                'Titiler /register %cEndpoint error',
+                'color: red;',
+                error
+              );
+            throw error;
           }
         }
 
@@ -361,7 +367,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           {
             assets: 'cog_default',
             ...(sourceParams ?? {}),
-            ...colorMap &&  {colormap_name: colorMap}
+            ...(colorMap && { colormap_name: colorMap })
           },
           // Temporary solution to pass different tile parameters for hls data
           {

--- a/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/vector-timeseries.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import qs from 'qs';
-import {
-  AnyLayer,
-  AnySourceImpl,
-  VectorSourceImpl
-} from 'mapbox-gl';
+import { AnyLayer, AnySourceImpl, VectorSourceImpl } from 'mapbox-gl';
 import { useTheme } from 'styled-components';
 import endOfDay from 'date-fns/endOfDay';
 import startOfDay from 'date-fns/startOfDay';
@@ -15,21 +11,14 @@ import { Feature } from 'geojson';
 
 import { BaseGeneratorParams } from '../types';
 import useMapStyle from '../hooks/use-map-style';
-import {
-  requestQuickCache
-} from '../utils';
+import { requestQuickCache } from '../utils';
 import useFitBbox from '../hooks/use-fit-bbox';
 import useLayerInteraction from '../hooks/use-layer-interaction';
 import { MARKER_LAYOUT } from '../hooks/use-custom-marker';
 import useMaps from '../hooks/use-maps';
 import useGeneratorParams from '../hooks/use-generator-params';
 
-import {
-  ActionStatus,
-  S_FAILED,
-  S_LOADING,
-  S_SUCCEEDED
-} from '$utils/status';
+import { ActionStatus, S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 import { userTzDate2utcString } from '$utils/date';
 
 export interface VectorTimeseriesProps extends BaseGeneratorParams {
@@ -42,8 +31,8 @@ export interface VectorTimeseriesProps extends BaseGeneratorParams {
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   isPositionSet?: boolean;
   stacApiEndpoint?: string;
+  envApiStacEndpoint: string;
 }
-
 
 export function VectorTimeseries(props: VectorTimeseriesProps) {
   const {
@@ -57,7 +46,8 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
     isPositionSet,
     hidden,
     opacity,
-    stacApiEndpoint
+    stacApiEndpoint,
+    envApiStacEndpoint
   } = props;
 
   const { current: mapInstance } = useMaps();
@@ -68,11 +58,10 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
   const [featuresBbox, setFeaturesBbox] =
     useState<[number, number, number, number]>();
 
-    const [minZoom, maxZoom] = zoomExtent ?? [0, 20];
+  const [minZoom, maxZoom] = zoomExtent ?? [0, 20];
   const generatorId = `vector-timeseries-${id}`;
 
-  const stacApiEndpointToUse =
-    stacApiEndpoint ?? process.env.API_STAC_ENDPOINT ?? '';
+  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint ?? '';
 
   //
   // Get the tiles url
@@ -119,7 +108,6 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
     };
   }, [id, stacCol, stacApiEndpointToUse, onStatusChange]);
 
-
   //
   // Generate Mapbox GL layers and sources for vector timeseries
   //
@@ -157,7 +145,7 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
         source: id,
         'source-layer': 'default',
         paint: {
-          'line-opacity':  hidden ? 0 : vectorOpacity,
+          'line-opacity': hidden ? 0 : vectorOpacity,
           'line-opacity-transition': {
             duration: 320
           },
@@ -186,7 +174,7 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
         source: id,
         'source-layer': 'default',
         paint: {
-          'line-opacity':  hidden ? 0 : vectorOpacity,
+          'line-opacity': hidden ? 0 : vectorOpacity,
           'line-opacity-transition': {
             duration: 320
           },
@@ -213,11 +201,11 @@ export function VectorTimeseries(props: VectorTimeseriesProps) {
         source: id,
         'source-layer': 'default',
         paint: {
-          'fill-opacity':  hidden ? 0 : Math.min(vectorOpacity, 0.8),
+          'fill-opacity': hidden ? 0 : Math.min(vectorOpacity, 0.8),
           'fill-opacity-transition': {
             duration: 320
           },
-          'fill-color': theme.color?.infographicB,
+          'fill-color': theme.color?.infographicB
         },
         filter: ['==', '$type', 'Polygon'],
         minzoom: minZoom,

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -12,14 +12,27 @@ export function ZarrTimeseries(props: BaseTimeseriesProps) {
     date,
     onStatusChange,
     sourceParams,
+    envApiStacEndpoint
   } = props;
 
-  const stacApiEndpointToUse = stacApiEndpoint?? process.env.API_STAC_ENDPOINT;
-  const assetUrl = useZarr({id, stacCol, stacApiEndpointToUse, date, onStatusChange});
+  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint;
+  const assetUrl = useZarr({
+    id,
+    stacCol,
+    stacApiEndpointToUse,
+    date,
+    onStatusChange
+  });
   const tileParams = {
     url: assetUrl,
     datetime: date,
-    ...sourceParams,
+    ...sourceParams
   };
-  return <RasterPaintLayer {...props} tileParams={tileParams} generatorPrefix='zarr-timeseries' />;
+  return (
+    <RasterPaintLayer
+      {...props}
+      tileParams={tileParams}
+      generatorPrefix='zarr-timeseries'
+    />
+  );
 }

--- a/app/scripts/components/common/map/types.d.ts
+++ b/app/scripts/components/common/map/types.d.ts
@@ -54,6 +54,8 @@ export interface BaseTimeseriesProps extends BaseGeneratorParams {
   zoomExtent?: number[];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   colorMap?: string;
+  envApiStacEndpoint: string;
+  envApiRasterEndpoint: string;
 }
 
 // export interface ZarrTimeseriesProps extends BaseTimeseriesProps {
@@ -63,6 +65,7 @@ export interface BaseTimeseriesProps extends BaseGeneratorParams {
 export interface RasterTimeseriesProps extends BaseTimeseriesProps {
   bounds?: number[];
   isPositionSet?: boolean;
+  envApiStacEndpoint: string;
 }
 
 interface AssetUrlReplacement {

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -61,7 +61,9 @@ async function getDatasetAssets(
   );
   return {
     assets: searchReqRes.data.features.map((o) => ({
-      date: utcString2userTzDate(o.properties.start_datetime || o.properties.datetime),
+      date: utcString2userTzDate(
+        o.properties.start_datetime || o.properties.datetime
+      ),
       url: o.assets[assets].href
     }))
   };
@@ -76,6 +78,8 @@ interface TimeseriesRequesterParams {
   queryClient: QueryClient;
   concurrencyManager: ConcurrencyManagerInstance;
   onProgress: (data: TimelineDatasetAnalysis) => void;
+  envApiRasterEndpoint: string;
+  envApiStacEndpoint: string;
 }
 
 /**
@@ -90,6 +94,8 @@ export async function requestDatasetTimeseriesData({
   dataset,
   queryClient,
   concurrencyManager,
+  envApiRasterEndpoint,
+  envApiStacEndpoint,
   onProgress
 }: TimeseriesRequesterParams): Promise<TimelineDatasetAnalysis> {
   const datasetData = dataset.data;
@@ -129,7 +135,7 @@ export async function requestDatasetTimeseriesData({
   });
 
   const stacApiEndpointToUse =
-    datasetData.stacApiEndpoint ?? process.env.API_STAC_ENDPOINT ?? '';
+    datasetData.stacApiEndpoint ?? envApiStacEndpoint ?? '';
 
   try {
     const layerInfoFromSTAC = await concurrencyManager.queue(
@@ -200,7 +206,7 @@ export async function requestDatasetTimeseriesData({
     let loaded = 0; //new Array(assets.length).fill(0);
 
     const tileEndpointToUse =
-      datasetData.tileApiEndpoint ?? process.env.API_RASTER_ENDPOINT ?? '';
+      datasetData.tileApiEndpoint ?? envApiRasterEndpoint ?? '';
 
     const analysisParams = datasetData.analysis?.sourceParams ?? {};
 

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -150,9 +150,9 @@ export function ExplorationMap(props: ExplorationMapProps) {
           }
         />
         <AnalysisMessageControl />
-        <GeocoderControl mapboxToken={envMapboxToken} />
+        <GeocoderControl envMapboxToken={envMapboxToken} />
         <MapOptionsControl
-          mapboxToken={envMapboxToken}
+          envMapboxToken={envMapboxToken}
           projection={projection}
           onProjectionChange={setProjection}
           basemapStyleId={mapBasemapId}

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -26,7 +26,7 @@ import { usePreviousValue } from '$utils/use-effect-previous';
 import { ExtendedStyle } from '$components/common/map/styles';
 import DrawControl from '$components/common/map/controls/aoi';
 import CustomAoIControl from '$components/common/map/controls/aoi/custom-aoi-control';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 interface ExplorationMapProps {
   datasets: TimelineDataset[];
@@ -37,7 +37,7 @@ interface ExplorationMapProps {
 
 export function ExplorationMap(props: ExplorationMapProps) {
   const { envApiStacEndpoint, envMapboxToken } =
-    useContext(VedauiConfigContext);
+    useContext(EnvConfigContext);
 
   const { datasets, setDatasets, selectedDay, selectedCompareDay } = props;
 

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useContext, useEffect, useState } from 'react';
 
 import { ProjectionOptions } from 'veda';
 import { useReconcileWithStacMetadata } from '../../hooks/use-stac-metadata-datasets';
@@ -26,6 +26,7 @@ import { usePreviousValue } from '$utils/use-effect-previous';
 import { ExtendedStyle } from '$components/common/map/styles';
 import DrawControl from '$components/common/map/controls/aoi';
 import CustomAoIControl from '$components/common/map/controls/aoi/custom-aoi-control';
+import { VedauiConfigContext } from '$context/config-context';
 
 interface ExplorationMapProps {
   datasets: TimelineDataset[];
@@ -35,6 +36,8 @@ interface ExplorationMapProps {
 }
 
 export function ExplorationMap(props: ExplorationMapProps) {
+  const { envApiStacEndpoint, mapboxToken } = useContext(VedauiConfigContext);
+
   const { datasets, setDatasets, selectedDay, selectedCompareDay } = props;
 
   const [projection, setProjection] =
@@ -48,7 +51,7 @@ export function ExplorationMap(props: ExplorationMapProps) {
     onOptionChange
   } = useBasemap();
 
-  useReconcileWithStacMetadata(datasets, setDatasets);
+  useReconcileWithStacMetadata(datasets, setDatasets, envApiStacEndpoint);
 
   // Different datasets may have a different default projection.
   // When datasets are selected the first time, we set the map projection to the
@@ -85,8 +88,7 @@ export function ExplorationMap(props: ExplorationMapProps) {
   // eslint-disable-next-line fp/no-mutating-methods
   const loadedDatasets = datasets
     .filter(
-      (d): d is TimelineDatasetSuccess =>
-        d.status === DatasetStatus.SUCCESS
+      (d): d is TimelineDatasetSuccess => d.status === DatasetStatus.SUCCESS
     )
     .slice()
     .reverse();
@@ -147,8 +149,9 @@ export function ExplorationMap(props: ExplorationMapProps) {
           }
         />
         <AnalysisMessageControl />
-        <GeocoderControl />
+        <GeocoderControl mapboxToken={mapboxToken} />
         <MapOptionsControl
+          mapboxToken={mapboxToken}
           projection={projection}
           onProjectionChange={setProjection}
           basemapStyleId={mapBasemapId}

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -36,7 +36,8 @@ interface ExplorationMapProps {
 }
 
 export function ExplorationMap(props: ExplorationMapProps) {
-  const { envApiStacEndpoint, mapboxToken } = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint, envMapboxToken } =
+    useContext(VedauiConfigContext);
 
   const { datasets, setDatasets, selectedDay, selectedCompareDay } = props;
 
@@ -149,9 +150,9 @@ export function ExplorationMap(props: ExplorationMapProps) {
           }
         />
         <AnalysisMessageControl />
-        <GeocoderControl mapboxToken={mapboxToken} />
+        <GeocoderControl mapboxToken={envMapboxToken} />
         <MapOptionsControl
-          mapboxToken={mapboxToken}
+          mapboxToken={envMapboxToken}
           projection={projection}
           onProjectionChange={setProjection}
           basemapStyleId={mapBasemapId}

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -11,7 +11,7 @@ import { VectorTimeseries } from '$components/common/map/style-generators/vector
 import { ZarrTimeseries } from '$components/common/map/style-generators/zarr-timeseries';
 import { CMRTimeseries } from '$components/common/map/style-generators/cmr-timeseries';
 import { ActionStatus } from '$utils/status';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 interface LayerProps {
   id: string;
@@ -23,7 +23,7 @@ interface LayerProps {
 
 export function Layer(props: LayerProps) {
   const { envApiStacEndpoint, envApiRasterEndpoint } =
-    useContext(VedauiConfigContext);
+    useContext(EnvConfigContext);
 
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
   const { isVisible, opacity, colorMap } = dataset.settings;

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -22,7 +22,8 @@ interface LayerProps {
 }
 
 export function Layer(props: LayerProps) {
-  const config = useContext(VedauiConfigContext);
+  const { envApiStacEndpoint, envApiRasterEndpoint } =
+    useContext(VedauiConfigContext);
 
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
   const { isVisible, opacity, colorMap } = dataset.settings;
@@ -58,7 +59,7 @@ export function Layer(props: LayerProps) {
           hidden={!isVisible}
           opacity={opacity}
           onStatusChange={onStatusChange}
-          envApiStacEndpoint={config.envApiStacEndpoint}
+          envApiStacEndpoint={envApiStacEndpoint}
         />
       );
     case 'zarr':
@@ -76,8 +77,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          envApiStacEndpoint={config.envApiStacEndpoint}
-          envApiRasterEndpoint={config.envApiRasterEndpoint}
+          envApiStacEndpoint={envApiStacEndpoint}
+          envApiRasterEndpoint={envApiRasterEndpoint}
         />
       );
     case 'cmr':
@@ -94,8 +95,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          envApiStacEndpoint={config.envApiStacEndpoint}
-          envApiRasterEndpoint={config.envApiRasterEndpoint}
+          envApiStacEndpoint={envApiStacEndpoint}
+          envApiRasterEndpoint={envApiRasterEndpoint}
         />
       );
     case 'raster':
@@ -113,8 +114,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          envApiStacEndpoint={config.envApiStacEndpoint}
-          envApiRasterEndpoint={config.envApiRasterEndpoint}
+          envApiStacEndpoint={envApiStacEndpoint}
+          envApiRasterEndpoint={envApiRasterEndpoint}
         />
       );
     default:

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 // Avoid error: node_modules/date-fns/esm/index.js does not export 'default'
 import * as dateFns from 'date-fns';
 
@@ -11,6 +11,7 @@ import { VectorTimeseries } from '$components/common/map/style-generators/vector
 import { ZarrTimeseries } from '$components/common/map/style-generators/zarr-timeseries';
 import { CMRTimeseries } from '$components/common/map/style-generators/cmr-timeseries';
 import { ActionStatus } from '$utils/status';
+import { VedauiConfigContext } from '$context/config-context';
 
 interface LayerProps {
   id: string;
@@ -21,6 +22,8 @@ interface LayerProps {
 }
 
 export function Layer(props: LayerProps) {
+  const config = useContext(VedauiConfigContext);
+
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
   const { isVisible, opacity, colorMap } = dataset.settings;
 
@@ -55,6 +58,7 @@ export function Layer(props: LayerProps) {
           hidden={!isVisible}
           opacity={opacity}
           onStatusChange={onStatusChange}
+          envApiStacEndpoint={config.envApiStacEndpoint}
         />
       );
     case 'zarr':
@@ -72,6 +76,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          envApiStacEndpoint={config.envApiStacEndpoint}
+          envApiRasterEndpoint={config.envApiRasterEndpoint}
         />
       );
     case 'cmr':
@@ -88,6 +94,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          envApiStacEndpoint={config.envApiStacEndpoint}
+          envApiRasterEndpoint={config.envApiRasterEndpoint}
         />
       );
     case 'raster':
@@ -105,6 +113,8 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          envApiStacEndpoint={config.envApiStacEndpoint}
+          envApiRasterEndpoint={config.envApiRasterEndpoint}
         />
       );
     default:

--- a/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
+++ b/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
@@ -72,7 +72,8 @@ export function useAnalysisDataRequest({
 }) {
   const queryClient = useQueryClient();
 
-  const config = useContext(VedauiConfigContext);
+  const { envApiRasterEndpoint, envApiStacEndpoint } =
+    useContext(VedauiConfigContext);
 
   const selectedInterval = useAtomValue(selectedIntervalAtom);
   const { features } = useAois();
@@ -131,8 +132,8 @@ export function useAnalysisDataRequest({
         dataset,
         queryClient,
         concurrencyManager: analysisConcurrencyManager,
-        envApiRasterEndpoint: config.envApiRasterEndpoint,
-        envApiStacEndpoint: config.envApiStacEndpoint,
+        envApiRasterEndpoint,
+        envApiStacEndpoint,
         onProgress: (data) => {
           setAnalysis(data);
         }

--- a/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
+++ b/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useContext } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { FeatureCollection, Polygon } from 'geojson';
 import { PrimitiveAtom, useAtom, useAtomValue } from 'jotai';
@@ -15,6 +15,7 @@ import {
 } from '../types.d.ts';
 import { MAX_QUERY_NUM } from '../constants';
 import useAois from '$components/common/map/controls/hooks/use-aois';
+import { VedauiConfigContext } from '$context/config-context';
 
 export function useAnalysisController() {
   const [controller, setController] = useAtom(analysisControllerAtom);
@@ -70,6 +71,8 @@ export function useAnalysisDataRequest({
   datasetAtom: PrimitiveAtom<TimelineDataset>;
 }) {
   const queryClient = useQueryClient();
+
+  const config = useContext(VedauiConfigContext);
 
   const selectedInterval = useAtomValue(selectedIntervalAtom);
   const { features } = useAois();
@@ -128,6 +131,8 @@ export function useAnalysisDataRequest({
         dataset,
         queryClient,
         concurrencyManager: analysisConcurrencyManager,
+        envApiRasterEndpoint: config.envApiRasterEndpoint,
+        envApiStacEndpoint: config.envApiStacEndpoint,
         onProgress: (data) => {
           setAnalysis(data);
         }

--- a/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
+++ b/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
@@ -15,7 +15,7 @@ import {
 } from '../types.d.ts';
 import { MAX_QUERY_NUM } from '../constants';
 import useAois from '$components/common/map/controls/hooks/use-aois';
-import { VedauiConfigContext } from '$context/config-context';
+import { EnvConfigContext } from '$context/env-config';
 
 export function useAnalysisController() {
   const [controller, setController] = useAtom(analysisControllerAtom);
@@ -73,7 +73,7 @@ export function useAnalysisDataRequest({
   const queryClient = useQueryClient();
 
   const { envApiRasterEndpoint, envApiStacEndpoint } =
-    useContext(VedauiConfigContext);
+    useContext(EnvConfigContext);
 
   const selectedInterval = useAtomValue(selectedIntervalAtom);
   const { features } = useAois();

--- a/app/scripts/context/config-context.tsx
+++ b/app/scripts/context/config-context.tsx
@@ -1,0 +1,27 @@
+import React, { createContext } from 'react';
+
+interface VedauiConfig {
+  mapboxToken: string;
+  envApiStacEndpoint: string;
+  envApiRasterEndpoint: string;
+}
+
+export const VedauiConfigContext = createContext<VedauiConfig>({
+  mapboxToken: '',
+  envApiStacEndpoint: '',
+  envApiRasterEndpoint: ''
+});
+
+export function VedauiConfigProvider({
+  config,
+  children
+}: {
+  config: VedauiConfig;
+  children: any;
+}) {
+  return (
+    <VedauiConfigContext.Provider value={config}>
+      {children}
+    </VedauiConfigContext.Provider>
+  );
+}

--- a/app/scripts/context/config-context.tsx
+++ b/app/scripts/context/config-context.tsx
@@ -1,13 +1,13 @@
 import React, { createContext } from 'react';
 
 interface VedauiConfig {
-  mapboxToken: string;
+  envMapboxToken: string;
   envApiStacEndpoint: string;
   envApiRasterEndpoint: string;
 }
 
 export const VedauiConfigContext = createContext<VedauiConfig>({
-  mapboxToken: '',
+  envMapboxToken: '',
   envApiStacEndpoint: '',
   envApiRasterEndpoint: ''
 });

--- a/app/scripts/context/env-config.tsx
+++ b/app/scripts/context/env-config.tsx
@@ -1,27 +1,27 @@
 import React, { createContext } from 'react';
 
-interface VedauiConfig {
+interface EnvConfig {
   envMapboxToken: string;
   envApiStacEndpoint: string;
   envApiRasterEndpoint: string;
 }
 
-export const VedauiConfigContext = createContext<VedauiConfig>({
+export const EnvConfigContext = createContext<EnvConfig>({
   envMapboxToken: '',
   envApiStacEndpoint: '',
   envApiRasterEndpoint: ''
 });
 
-export function VedauiConfigProvider({
+export function EnvConfigProvider({
   config,
   children
 }: {
-  config: VedauiConfig;
+  config: EnvConfig;
   children: any;
 }) {
   return (
-    <VedauiConfigContext.Provider value={config}>
+    <EnvConfigContext.Provider value={config}>
       {children}
-    </VedauiConfigContext.Provider>
+    </EnvConfigContext.Provider>
   );
 }

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -18,12 +18,17 @@ import StoriesHubContent from '$components/stories/hub/hub-content';
 import { useFiltersWithQS } from '$components/common/catalog/controls/hooks/use-filters-with-query';
 import PageHeader from '$components/common/page-header';
 import LogoContainer from '$components/common/page-header/logo-container';
-import type { NavItem, InternalNavLink, NavItemType } from '$components/common/page-header/types';
+import type {
+  NavItem,
+  InternalNavLink,
+  NavItemType
+} from '$components/common/page-header/types';
 
 import ExplorationAndAnalysis from '$components/exploration';
 import useTimelineDatasetAtom from '$components/exploration/hooks/use-timeline-dataset-atom';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
 import { DatasetSelectorModal } from '$components/exploration/components/dataset-selector-modal';
+import { VedauiConfigProvider } from '$context/config-context';
 
 // Adding .last property to array
 /* eslint-disable-next-line fp/no-mutating-methods */
@@ -56,6 +61,7 @@ export {
   PageHero,
   PageHeader,
   ReactQueryProvider,
+  VedauiConfigProvider,
   StoriesHubContent,
   LogoContainer,
   ExplorationAndAnalysis,

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -28,7 +28,7 @@ import ExplorationAndAnalysis from '$components/exploration';
 import useTimelineDatasetAtom from '$components/exploration/hooks/use-timeline-dataset-atom';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
 import { DatasetSelectorModal } from '$components/exploration/components/dataset-selector-modal';
-import { VedauiConfigProvider } from '$context/config-context';
+import { EnvConfigProvider } from '$context/env-config';
 
 // Adding .last property to array
 /* eslint-disable-next-line fp/no-mutating-methods */
@@ -61,7 +61,7 @@ export {
   PageHero,
   PageHeader,
   ReactQueryProvider,
-  VedauiConfigProvider,
+  EnvConfigProvider,
   StoriesHubContent,
   LogoContainer,
   ExplorationAndAnalysis,

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -49,12 +49,24 @@ import {
   STORIES_PATH,
   EXPLORATION_PATH
 } from '$utils/routes';
+import { VedauiConfigProvider } from '$context/config-context';
 
 const composingComponents = [
   // Add contexts here.
   ErrorBoundary,
   ReactQueryProvider,
-  LayoutRootContextProvider
+  LayoutRootContextProvider,
+  ({ children }) => (
+    <VedauiConfigProvider
+      config={{
+        mapboxToken: process.env.MAPBOX_TOKEN ?? '',
+        envApiStacEndpoint: process.env.API_STAC_ENDPOINT ?? '',
+        envApiRasterEndpoint: process.env.API_RASTER_ENDPOINT ?? ''
+      }}
+    >
+      {children}
+    </VedauiConfigProvider>
+  )
 ];
 
 function ScrollTop() {

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -59,7 +59,7 @@ const composingComponents = [
   ({ children }) => (
     <VedauiConfigProvider
       config={{
-        mapboxToken: process.env.MAPBOX_TOKEN ?? '',
+        envMapboxToken: process.env.MAPBOX_TOKEN ?? '',
         envApiStacEndpoint: process.env.API_STAC_ENDPOINT ?? '',
         envApiRasterEndpoint: process.env.API_RASTER_ENDPOINT ?? ''
       }}

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -49,7 +49,7 @@ import {
   STORIES_PATH,
   EXPLORATION_PATH
 } from '$utils/routes';
-import { VedauiConfigProvider } from '$context/config-context';
+import { EnvConfigProvider } from '$context/env-config';
 
 const composingComponents = [
   // Add contexts here.
@@ -57,7 +57,7 @@ const composingComponents = [
   ReactQueryProvider,
   LayoutRootContextProvider,
   ({ children }) => (
-    <VedauiConfigProvider
+    <EnvConfigProvider
       config={{
         envMapboxToken: process.env.MAPBOX_TOKEN ?? '',
         envApiStacEndpoint: process.env.API_STAC_ENDPOINT ?? '',
@@ -65,7 +65,7 @@ const composingComponents = [
       }}
     >
       {children}
-    </VedauiConfigProvider>
+    </EnvConfigProvider>
   )
 ];
 


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1166

### Problem

We need a way for future Next.js instances using veda-ui components to pass their environment variables to the library

[The previous PR](https://github.com/NASA-IMPACT/veda-ui/pull/1252) tried to pass env variables as props to our components. However, this might be difficult to maintain and to scale as new environment variables will be added.

This PR introduces a centralized config place through a new `VedauiConfigProvider` context to allow devs to configure all environment variables in one place via a config object.

### Description of Changes

**Veda-UI changes**

- Created `VedauiConfigProvider` context provider
- Currently supports these configuration options:
  - `mapboxToken` ( `MAPBOX_TOKEN`)
  - `apiRasterEndpoint` (`API_RASTER_ENDPOINT`)
  - `apiStacEndpoint` (from `API_STAC_ENDPOINT`)
- Refactored internal components to consume the environment variables from this context

**Next.js ([PR here](https://github.com/developmentseed/next-veda-ui/pull/13)):**

- Imported and used the new provider
- ℹ️ In Next.js, environment variables should be named according to the Next.js naming standards so that they can be applied e.g `MAPBOX_TOKEN` should be `NEXT_PUBLIC_MAPBOX_TOKEN` etc. 

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

Test that the correct env variables are applied when using the library in Next.js
