### PR TITLE
Remove minHeight prop

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -187,14 +187,17 @@ const CardLabel = styled.span`
 
 const CardFigure = styled(Figure)`
   order: -1;
-  background: ${themeVal('color.primary-100')};
+  width: 100%;
+  ${(props) => !props.isCoverOrFeatured && `aspect-ratio: 2/1;`}
+  background: ${(props) =>
+    props.src ? 'none' : props.theme.color['primary-100']};
 
   img {
     height: 100%;
     width: 100%;
     object-fit: cover;
     mix-blend-mode: multiply;
-    display: ${(props) => (props.src ? 'inline-block' : 'none')};
+    display: ${(props) => (props.src ? 'block' : 'none')};
   }
 `;
 
@@ -287,7 +290,7 @@ function CardComponent(props: CardComponentPropsType) {
     footerContent,
     hideExternalLinkBadge,
     onCardClickCapture,
-    onClick,
+    onClick
   } = props;
   // @TODO: This process is not necessary once all the instances adapt the linkProperties syntax
   // Consolidate them to use LinkProperties only
@@ -299,18 +302,29 @@ function CardComponent(props: CardComponentPropsType) {
     linkProperties = linkPropertiesProps;
   } else {
     const { linkTo } = props;
-    linkProperties = linkTo ? {
-      linkTo,
-      pathAttributeKeyName: 'to',
-      LinkElement: SmartLink
-    } : undefined;
+    linkProperties = linkTo
+      ? {
+          linkTo,
+          pathAttributeKeyName: 'to',
+          LinkElement: SmartLink
+        }
+      : undefined;
   }
 
-  const isExternalLink = linkProperties ? /^https?:\/\//.test(linkProperties.linkTo) : false;
+  const isExternalLink = linkProperties
+    ? /^https?:\/\//.test(linkProperties.linkTo)
+    : false;
 
   return (
     <ElementInteractive
-      {...(linkProperties ? {linkProps: {as: linkProperties.LinkElement, [linkProperties.pathAttributeKeyName]: linkProperties.linkTo}} : {})}
+      {...(linkProperties
+        ? {
+            linkProps: {
+              as: linkProperties.LinkElement,
+              [linkProperties.pathAttributeKeyName]: linkProperties.linkTo
+            }
+          }
+        : {})}
       as={CardItem}
       cardType={cardType}
       className={className}
@@ -358,7 +372,10 @@ function CardComponent(props: CardComponentPropsType) {
             </CardBody>
           )}
           {footerContent && <CardFooter>{footerContent}</CardFooter>}
-          <CardFigure src={imgSrc}>
+          <CardFigure
+            src={imgSrc}
+            isCoverOrFeatured={cardType === 'cover' || cardType === 'featured'}
+          >
             <img src={imgSrc} alt={imgAlt} loading='lazy' />
           </CardFigure>
         </>

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -188,7 +188,6 @@ const CardLabel = styled.span`
 const CardFigure = styled(Figure)`
   order: -1;
   background: ${themeVal('color.primary-100')};
-  min-height: ${variableGlsp(12)};
 
   img {
     height: 100%;

--- a/mock/stories/external-link-example.stories.mdx
+++ b/mock/stories/external-link-example.stories.mdx
@@ -3,12 +3,6 @@ featured: true
 id: 'external-link-test'
 name: External Link Test
 description: Story to test external link
-media:
-  src: ::file ./img-placeholder-6.jpg
-  alt: Generic placeholder by Unsplash
-  author:
-    name: Unsplash
-    url: https://unsplash.com/
 pubDate: 2023-02-09
 hideExternalLinkBadge: false
 taxonomy:


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1264

### Description of Changes
Removed minHeight prop to avoid undesired card behavior. The css prop was introduced here: https://github.com/NASA-IMPACT/veda-ui/pull/1244

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
1. Open the stories page where there are card components
2. Verify that the images in the cards no longer have a minHeight property
4. Verify that the card layout appears consistent and the image heights are reduced compared to the previous behavior on v10.0.0

Or see the Air Quality card here:

- Before: https://deploy-preview-1250--veda-ui.netlify.app/stories
- After: https://deploy-preview-1265--veda-ui.netlify.app/stories