### PR TITLE
fix: Polygon simplification on E&A page

### DIFF
--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.test.ts
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.test.ts
@@ -1,0 +1,195 @@
+import { Feature, MultiPolygon, Polygon } from '@turf/helpers';
+import {
+  getNumPoints,
+  validateGeometryType,
+  extractPolygonsFromGeojson,
+  validateFeatureCount,
+  removePolygonHoles,
+  simplifyFeatures,
+  getAoiAppropriateFeatures,
+  PolygonGeojson,
+  eachFeatureMaxPointNum,
+  maxPolygonNum,
+  INVALID_GEOMETRY_ERROR,
+  TOO_MANY_POLYGON_ERROR
+} from './use-custom-aoi';
+
+// Mock data
+const mockPolygon: Feature<Polygon> = {
+  type: 'Feature',
+  geometry: {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [0, 0],
+        [1, 1],
+        [2, 2],
+        [0, 0]
+      ]
+    ]
+  },
+  properties: {}
+};
+
+const mockMultiPolygon: Feature<MultiPolygon> = {
+  type: 'Feature',
+  geometry: {
+    type: 'MultiPolygon',
+    coordinates: [
+      [
+        [
+          [0, 0],
+          [1, 1],
+          [2, 2],
+          [0, 0]
+        ]
+      ]
+    ]
+  },
+  properties: {}
+};
+
+const mockGeojson = {
+  type: 'FeatureCollection',
+  features: [mockPolygon, mockMultiPolygon]
+} as PolygonGeojson;
+
+describe('getNumPoints', () => {
+  it('should return the number of points in a polygon', () => {
+    const numPoints = getNumPoints(mockPolygon);
+    expect(numPoints).toBe(4);
+  });
+});
+
+describe('validateGeometryType', () => {
+  it('should validate that all features are polygons or multipolygons', () => {
+    const isValid = validateGeometryType(mockGeojson);
+    expect(isValid).toBe(true);
+  });
+
+  it('should return false for invalid geometry types', () => {
+    const invalidGeojson = {
+      ...mockGeojson,
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [0, 0] },
+          properties: {}
+        }
+      ]
+    };
+    // @ts-expect-error: testing invalid case
+    const isValid = validateGeometryType(invalidGeojson);
+    expect(isValid).toBe(false);
+  });
+});
+
+describe('extractPolygonsFromGeojson', () => {
+  it('should extract all polygons from GeoJSON, including from MultiPolygons', () => {
+    const polygons = extractPolygonsFromGeojson(mockGeojson);
+    expect(polygons).toHaveLength(2);
+    expect(polygons[0].geometry.type).toBe('Polygon');
+  });
+});
+
+describe('validateFeatureCount', () => {
+  it('should validate that the number of features is within the allowed limit', () => {
+    const isValid = validateFeatureCount([mockPolygon]);
+    expect(isValid).toBe(true);
+  });
+
+  it('should return false if feature count exceeds the limit', () => {
+    const tooManyFeatures = Array(maxPolygonNum + 1).fill(mockPolygon);
+    const isValid = validateFeatureCount(tooManyFeatures);
+    expect(isValid).toBe(false);
+  });
+});
+
+describe('removePolygonHoles', () => {
+  it('should remove holes from polygons and return warnings if holes are removed', () => {
+    const polygonWithHole = {
+      ...mockPolygon,
+      geometry: {
+        ...mockPolygon.geometry,
+        coordinates: [
+          [
+            [0, 0],
+            [1, 1],
+            [2, 2],
+            [0, 0]
+          ],
+          [
+            [0.1, 0.1],
+            [0.2, 0.2],
+            [0.3, 0.3],
+            [0.1, 0.1]
+          ]
+        ]
+      }
+    };
+    const { simplifiedFeatures, warnings } = removePolygonHoles([
+      polygonWithHole
+    ]);
+    expect(simplifiedFeatures[0].geometry.coordinates).toHaveLength(1);
+    expect(warnings).toContain(
+      'Polygons with rings are not supported and were simplified to remove them'
+    );
+  });
+});
+
+describe('simplifyFeatures', () => {
+  it('should simplify features to reduce the number of points if necessary', () => {
+    const largePolygon = {
+      ...mockPolygon,
+      geometry: {
+        ...mockPolygon.geometry,
+        coordinates: [
+          Array.from({ length: 600 }, (_, i) => [
+            Math.cos(i * ((2 * Math.PI) / 600)),
+            Math.sin(i * ((2 * Math.PI) / 600))
+          ]).concat([[1, 0]]) // Ensure the ring is closed
+        ]
+      }
+    };
+    const { simplifiedFeatures, warnings } = simplifyFeatures([largePolygon]);
+    expect(getNumPoints(simplifiedFeatures[0])).toBeLessThanOrEqual(
+      eachFeatureMaxPointNum
+    );
+    expect(warnings).toContainEqual(expect.stringContaining('simplified'));
+  });
+});
+
+describe('getAoiAppropriateFeatures', () => {
+  it('should process GeoJSON and return simplified features with warnings', () => {
+    const result = getAoiAppropriateFeatures(mockGeojson);
+    expect(result.simplifiedFeatures).toHaveLength(2);
+    expect(result.warnings).toEqual(expect.any(Array));
+  });
+
+  it('should throw an error if geometry type validation fails', () => {
+    const invalidGeojson = {
+      ...mockGeojson,
+      features: [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [0, 0] },
+          properties: {}
+        }
+      ]
+    };
+    // @ts-expect-error: testing invalid case
+    expect(() => getAoiAppropriateFeatures(invalidGeojson)).toThrow(
+      INVALID_GEOMETRY_ERROR
+    );
+  });
+
+  it('should throw an error if feature count exceeds the allowed limit', () => {
+    const tooManyFeatures = {
+      ...mockGeojson,
+      features: Array(maxPolygonNum + 1).fill(mockPolygon)
+    };
+    expect(() => getAoiAppropriateFeatures(tooManyFeatures)).toThrow(
+      TOO_MANY_POLYGON_ERROR
+    );
+  });
+});

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.test.ts
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.test.ts
@@ -11,7 +11,7 @@ import {
   eachFeatureMaxPointNum,
   maxPolygonNum,
   INVALID_GEOMETRY_ERROR,
-  TOO_MANY_POLYGON_ERROR
+  TOO_MANY_POLYGONS_ERROR
 } from './use-custom-aoi';
 
 // Mock data
@@ -189,7 +189,7 @@ describe('getAoiAppropriateFeatures', () => {
       features: Array(maxPolygonNum + 1).fill(mockPolygon)
     };
     expect(() => getAoiAppropriateFeatures(tooManyFeatures)).toThrow(
-      TOO_MANY_POLYGON_ERROR
+      TOO_MANY_POLYGONS_ERROR
     );
   });
 });

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
@@ -15,7 +15,7 @@ export const acceptExtensions = extensions.map((ext) => `.${ext}`).join(', ');
 
 export const INVALID_GEOMETRY_ERROR =
   'Wrong geometry type. Only polygons or multi polygons are accepted.';
-export const TOO_MANY_POLYGON_ERROR =
+export const TOO_MANY_POLYGONS_ERROR =
   'Only files with up to 200 polygons are accepted.';
 const RING_POLYGON_WARNING =
   'Polygons with rings are not supported and were simplified to remove them';
@@ -165,7 +165,7 @@ export function getAoiAppropriateFeatures(geojson: PolygonGeojson) {
   const features = extractPolygonsFromGeojson(geojson);
   const featureCountValidated = validateFeatureCount(features);
   if (!featureCountValidated) {
-    throw new Error(TOO_MANY_POLYGON_ERROR);
+    throw new Error(TOO_MANY_POLYGONS_ERROR);
   }
   const { simplifiedFeatures: noHolesFeatures, warnings: holeWarnings } =
     removePolygonHoles(features);

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
@@ -19,6 +19,8 @@ export const TOO_MANY_POLYGONS_ERROR =
   'Only files with up to 200 polygons are accepted.';
 const RING_POLYGON_WARNING =
   'Polygons with rings are not supported and were simplified to remove them';
+const TOLERANCE_ACCELERATOR = 1.5;
+
 export interface FileInfo {
   name: string;
   extension: string;
@@ -103,7 +105,7 @@ export function simplifyFeatures(features: Feature<Polygon>[]): {
         tolerance < maxTolerance
       ) {
         simplifiedFeature = simplify(simplifiedFeature, { tolerance });
-        tolerance *= 1.5;
+        tolerance *= TOLERANCE_ACCELERATOR;
       }
       return simplifiedFeature;
     }
@@ -141,7 +143,7 @@ export function simplifyFeatures(features: Feature<Polygon>[]): {
       (acc, f) => acc + getNumPoints(f),
       0
     );
-    tolerance = Math.min(tolerance * 1.5, 5);
+    tolerance = Math.min(tolerance * TOLERANCE_ACCELERATOR, 5);
   }
 
   if (originalTotalPoints !== totalPoints) {

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
@@ -53,7 +53,7 @@ function extractPolygonsFromGeojson(
 }
 
 function validateFeatureCount(features: Feature<Polygon>[]): boolean {
-  if (features.length > maxPolygonNum) return false;
+  return features.length <= maxPolygonNum;
 }
 
 function removePolygonHoles(features: Feature<Polygon>[]): {

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
@@ -7,7 +7,7 @@ import { multiPolygonToPolygons } from '../../utils';
 import { round } from '$utils/format';
 
 const extensions = ['geojson', 'json', 'zip'];
-const eachFeatureMaxPointNum = 1000;
+const eachFeatureMaxPointNum = 500;
 const maxTolerance = 5;
 const maxPolygonNum = 200;
 export const acceptExtensions = extensions.map((ext) => `.${ext}`).join(', ');
@@ -135,8 +135,8 @@ function simplifyFeatures(features: Feature<Polygon>[]): {
   );
 
   // Further Simplify features in case there are a lot of features
-  // to control the number of the total points
-  while (totalPoints > 50000 && tolerance < maxTolerance) {
+  // to control the number of the total points (10000 for now)
+  while (totalPoints > 10000 && tolerance < maxTolerance) {
     simplifiedFeatures.forEach((feature, i) => {
       simplifiedFeatures[i] = simplify(feature, { tolerance });
     });

--- a/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-custom-aoi.tsx
@@ -7,7 +7,9 @@ import { multiPolygonToPolygons } from '../../utils';
 import { round } from '$utils/format';
 
 const extensions = ['geojson', 'json', 'zip'];
-const eachFeatureMaxPointNum = 500;
+const eachFeatureMaxPointNum = 1000;
+const maxTolerance = 5;
+const maxPolygonNum = 200;
 export const acceptExtensions = extensions.map((ext) => `.${ext}`).join(', ');
 
 export interface FileInfo {
@@ -27,20 +29,21 @@ function getNumPoints(feature: Feature<Polygon>): number {
   }, 0);
 }
 
-export function getAoiAppropriateFeatures(geojson: PolygonGeojson) {
-  let warnings: string[] = [];
-
-  if (
-    geojson.features.some(
-      (feature) => !['MultiPolygon', 'Polygon'].includes(feature.geometry.type)
-    )
-  ) {
+function validateGeometryType(geojson: PolygonGeojson): void {
+  const hasInvalidGeometry = geojson.features.some(
+    (feature) => !['MultiPolygon', 'Polygon'].includes(feature.geometry.type)
+  );
+  if (hasInvalidGeometry) {
     throw new Error(
       'Wrong geometry type. Only polygons or multi polygons are accepted.'
     );
   }
+}
 
-  const features: Feature<Polygon>[] = geojson.features.reduce(
+function extractPolygonsFromGeojson(
+  geojson: PolygonGeojson
+): Feature<Polygon>[] {
+  return geojson.features.reduce(
     (acc: Feature<Polygon>[], feature: Feature<Polygon | MultiPolygon>) => {
       if (feature.geometry.type === 'MultiPolygon') {
         return acc.concat(
@@ -51,22 +54,20 @@ export function getAoiAppropriateFeatures(geojson: PolygonGeojson) {
     },
     []
   );
+}
 
-  if (features.length > 200) {
+function validateFeatureCount(features: Feature<Polygon>[]): void {
+  if (features.length > maxPolygonNum) {
     throw new Error('Only files with up to 200 polygons are accepted.');
   }
+}
 
-  // Simplify features;
-  const originalTotalFeaturePoints = features.reduce(
-    (acc, f) => acc + getNumPoints(f),
-    0
-  );
-  let numPoints = originalTotalFeaturePoints;
-  let tolerance = 0.001;
-
-  // Remove holes from polygons as they're not supported.
+function removePolygonHoles(features: Feature<Polygon>[]): {
+  simplifiedFeatures: Feature<Polygon>[];
+  warnings: string[];
+} {
   let polygonHasRings = false;
-  let simplifiedFeatures = features.map<Feature<Polygon>>((feature) => {
+  const simplifiedFeatures = features.map<Feature<Polygon>>((feature) => {
     if (feature.geometry.coordinates.length > 1) {
       polygonHasRings = true;
       return {
@@ -77,75 +78,102 @@ export function getAoiAppropriateFeatures(geojson: PolygonGeojson) {
         }
       };
     }
-
     return feature;
   });
 
-  if (polygonHasRings) {
-    warnings = [
-      ...warnings,
-      'Polygons with rings are not supported and were simplified to remove them'
-    ];
-  }
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const warnings = polygonHasRings
+    ? [
+        'Polygons with rings are not supported and were simplified to remove them'
+      ]
+    : [];
+  return { simplifiedFeatures, warnings };
+}
 
-  // Simplify each feature if needed to reduce point count to less than 50 points per feature
-  simplifiedFeatures = features.map((feature) => {
+function simplifyFeatures(features: Feature<Polygon>[]): {
+  simplifiedFeatures: Feature<Polygon>[];
+  warnings: string[];
+} {
+  const warnings: string[] = [];
+  let tolerance = 0.001;
+  // 1. Simplify each feature if needed to reduce point count to ${eachFeatureMaximumPointsNum}
+  const simplifiedFeatures = features.map((feature) => {
     const numPoints = getNumPoints(feature);
     if (numPoints > eachFeatureMaxPointNum) {
-      let tolerance = 0.001;
       let simplifiedFeature = feature;
-      // Continuously simplify the feature until it has less than or equal to 30 points
       while (
         getNumPoints(simplifiedFeature) > eachFeatureMaxPointNum &&
-        tolerance < 5
+        tolerance < maxTolerance
       ) {
         simplifiedFeature = simplify(simplifiedFeature, { tolerance });
-        tolerance *= 2; // Increase tolerance to simplify more aggressively if needed
+        tolerance *= 1.5;
       }
       return simplifiedFeature;
     }
     return feature;
   });
 
-  // Add a warning if any feature has been simplified to less than 30 points
-  const numberOfSimplifedFeatures = simplifiedFeatures.filter(
-    (feature, index) => {
-      return getNumPoints(feature) < getNumPoints(features[index]);
-    }
+  const simplifiedCount = simplifiedFeatures.filter(
+    (feature, index) => getNumPoints(feature) < getNumPoints(features[index])
   ).length;
 
-  if (numberOfSimplifedFeatures > 0) {
-    const featureWPrefix =
-      numberOfSimplifedFeatures === 1 ? 'feature was' : 'features were';
+  if (simplifiedCount > 0) {
+    const featureText = simplifiedCount === 1 ? 'feature was' : 'features were';
     // eslint-disable-next-line fp/no-mutating-methods
-    warnings = [
-      ...warnings,
-      `${numberOfSimplifedFeatures} ${featureWPrefix} simplified to have less than ${eachFeatureMaxPointNum} points.`
-    ];
+    warnings.push(
+      `${simplifiedCount} ${featureText} simplified to have less than ${eachFeatureMaxPointNum} points.`
+    );
   }
+
+  const originalTotalPoints = features.reduce(
+    (acc, f) => acc + getNumPoints(f),
+    0
+  );
+  let totalPoints = simplifiedFeatures.reduce(
+    (acc, f) => acc + getNumPoints(f),
+    0
+  );
 
   // Further Simplify features in case there are a lot of features
-  // so the sum of the points doesn't exceed 1000
-  while (numPoints > 5000 && tolerance < 5) {
-    simplifiedFeatures = simplifiedFeatures.map((feature) =>
-      simplify(feature, { tolerance })
+  // to control the number of the total points
+  while (totalPoints > 50000 && tolerance < maxTolerance) {
+    simplifiedFeatures.forEach((feature, i) => {
+      simplifiedFeatures[i] = simplify(feature, { tolerance });
+    });
+    totalPoints = simplifiedFeatures.reduce(
+      (acc, f) => acc + getNumPoints(f),
+      0
     );
-    numPoints = simplifiedFeatures.reduce((acc, f) => acc + getNumPoints(f), 0);
-    tolerance = Math.min(tolerance * 1.8, 5);
+    tolerance = Math.min(tolerance * 1.5, 5);
   }
 
-  if (originalTotalFeaturePoints !== numPoints) {
-    warnings = [
-      ...warnings,
+  if (originalTotalPoints !== totalPoints) {
+    // eslint-disable-next-line fp/no-mutating-methods
+    warnings.push(
       `The geometry has been simplified (${round(
-        (1 - numPoints / originalTotalFeaturePoints) * 100
+        (1 - totalPoints / originalTotalPoints) * 100
       )} % less).`
-    ];
+    );
   }
+
+  return { simplifiedFeatures, warnings };
+}
+
+export function getAoiAppropriateFeatures(geojson: PolygonGeojson) {
+  validateGeometryType(geojson);
+
+  const features = extractPolygonsFromGeojson(geojson);
+  validateFeatureCount(features);
+
+  const { simplifiedFeatures: noHolesFeatures, warnings: holeWarnings } =
+    removePolygonHoles(features);
+
+  const { simplifiedFeatures, warnings: simplificationWarnings } =
+    simplifyFeatures(noHolesFeatures);
 
   return {
     simplifiedFeatures,
-    warnings
+    warnings: [...holeWarnings, ...simplificationWarnings]
   };
 }
 
@@ -189,7 +217,6 @@ function useCustomAoI() {
           return;
         }
       }
-
       if (!geojson?.features?.length) {
         setError('Error uploading file: Invalid GeoJSON');
         return;


### PR DESCRIPTION
Close https://github.com/NASA-IMPACT/veda-ui/issues/1267, Close https://github.com/US-GHG-Center/veda-config-ghg/issues/648

### Description of Changes

Increased the limit of the number of each polygon.
Separated out a function that handles the aoi validation for an easy test and better readability.
Fix error handling.

### Notes & Questions About Changes

The number that I ended up with is an outcome of my experiment with our GHG endpoint, details are in : https://github.com/US-GHG-Center/veda-config-ghg/issues/648#issuecomment-2487390157

I think our current setup was more for multiple simple polygons - and this setup is more for 1 complicated polygon (which also hopefully covers the multiple simple polygons case.)

### Validation / Testing
We should test with GHG endpoint because of AWS setup there, I made a preview link : https://deploy-preview-664--ghg-demo.netlify.app/exploration
