### PR TITLE
Adjusting rescale value for small/large numbers

### DIFF
--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -13,6 +13,7 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   colorMap?: string | undefined;
   tileParams: Record<string, any>;
   generatorPrefix?: string;
+  reScale?: { min: number; max: number };
 }
 
 export function RasterPaintLayer(props: RasterPaintLayerProps) {
@@ -24,16 +25,20 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     hidden,
     opacity,
     colorMap,
-    generatorPrefix = 'raster',
+    reScale,
+    generatorPrefix = 'raster'
   } = props;
-
   const { updateStyle } = useMapStyle();
   const [minZoom] = zoomExtent ?? [0, 20];
   const generatorId = `${generatorPrefix}-${id}`;
 
   const updatedTileParams = useMemo(() => {
-    return { ...tileParams, ...colorMap &&  {colormap_name: colorMap}};
-  }, [tileParams, colorMap]);
+    return {
+      ...tileParams,
+      ...(colorMap && { colormap_name: colorMap }),
+      ...(reScale && { reScale: Object.values(reScale) })
+    };
+  }, [tileParams, colorMap, reScale]);
 
   //
   // Generate Mapbox GL layers and sources for raster timeseries
@@ -47,7 +52,9 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
 
   useEffect(
     () => {
-      const tileParamsAsString = qs.stringify(updatedTileParams, { arrayFormat: 'comma' });
+      const tileParamsAsString = qs.stringify(updatedTileParams, {
+        arrayFormat: 'comma'
+      });
 
       const zarrSource: RasterSource = {
         type: 'raster',
@@ -63,8 +70,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
         paint: {
           'raster-opacity': hidden ? 0 : rasterOpacity,
           'raster-opacity-transition': {
-            duration: 320,
-          },
+            duration: 320
+          }
         },
         minzoom: minZoom,
         metadata: {
@@ -93,7 +100,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       tileApiEndpoint,
       haveTileParamsChanged,
       generatorParams,
-      colorMap
+      colorMap,
+      reScale
       // generatorParams includes hidden and opacity
       // hidden,
       // opacity,

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -497,6 +497,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   }, [
     mosaicUrl,
     colorMap,
+    reScale,
     points,
     minZoom,
     haveSourceParamsChanged,

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -63,6 +63,7 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     stacApiEndpoint,
     tileApiEndpoint,
     colorMap,
+    reScale,
     envApiStacEndpoint,
     envApiRasterEndpoint
   } = props;
@@ -367,7 +368,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           {
             assets: 'cog_default',
             ...(sourceParams ?? {}),
-            ...(colorMap && { colormap_name: colorMap })
+            ...(colorMap && { colormap_name: colorMap }),
+            ...(reScale && { rescale: Object.values(reScale) })
           },
           // Temporary solution to pass different tile parameters for hls data
           {

--- a/app/scripts/components/common/map/types.d.ts
+++ b/app/scripts/components/common/map/types.d.ts
@@ -54,6 +54,7 @@ export interface BaseTimeseriesProps extends BaseGeneratorParams {
   zoomExtent?: number[];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   colorMap?: string;
+  reScale?: { min: number; max: number };
   envApiStacEndpoint: string;
   envApiRasterEndpoint: string;
 }

--- a/app/scripts/components/common/uswds/index.tsx
+++ b/app/scripts/components/common/uswds/index.tsx
@@ -2,3 +2,4 @@ export { USWDSAlert } from './alert';
 export { USWDSButtonGroup, USWDSButton } from './button';
 export { USWDSLink } from './link';
 export { USWDSBanner, USWDSBannerContent } from './banner';
+export { USWDSTextInput, USWDSTextInputMask } from './input';

--- a/app/scripts/components/common/uswds/input.tsx
+++ b/app/scripts/components/common/uswds/input.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { TextInput, TextInputMask } from '@trussworks/react-uswds';
+
+export function USWDSTextInput(props) {
+  return <TextInput {...props} />;
+}
+
+export function USWDSTextInputMask(props) {
+  return <TextInputMask {...props} />;
+}

--- a/app/scripts/components/exploration/atoms/hooks.ts
+++ b/app/scripts/components/exploration/atoms/hooks.ts
@@ -170,3 +170,15 @@ export const useTimelineDatasetAnalysis = (
     )
   );
 };
+
+export function useTimelineDatasetColormapScale(
+  datasetAtom: PrimitiveAtom<TimelineDataset>
+) {
+  const colorMapScaleAtom = useMemo(() => {
+    return focusAtom(datasetAtom, (optic) =>
+      optic.prop('settings').prop('scale')
+    );
+  }, [datasetAtom]);
+
+  return useAtom(colorMapScaleAtom);
+}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/color-range-slider.scss
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/color-range-slider.scss
@@ -1,0 +1,71 @@
+/* Removing the default appearance */
+.thumb,
+.thumb::-webkit-slider-thumb {
+  touch-action: 'none';
+
+  -webkit-appearance: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.thumb {
+  pointer-events: none;
+}
+/* For Chrome browsers */
+.thumb::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  pointer-events: all;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border-radius: 50%;
+  border: 2px solid #1565ef;
+  border-width: 1px;
+  box-shadow: 0 0 0 1px #c6c6c6;
+  cursor: pointer;
+}
+
+/* For Firefox browsers */
+.thumb::-moz-range-thumb {
+  -webkit-appearance: none;
+  pointer-events: all;
+  width: 20px;
+  height: 20px;
+  background-color: #fff;
+  border-radius: 50%;
+  border: 2px solid #1565ef;
+  border-width: 1px;
+  box-shadow: 0 0 0 1px #c6c6c6;
+  cursor: pointer;
+}
+
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+/* Firefox */
+input[type='number'] {
+  -moz-appearance: textfield;
+}
+
+.tooltiptext {
+  background-color: #2c3e50;
+}
+
+.tooltipmin::after {
+  left: 10px;
+}
+
+.tooltipmax::after {
+  right: 10px;
+}
+
+.tooltiptext::after {
+  content: '';
+  position: absolute;
+  top: 95%;
+  border-width: 10px 10px 0px 10px;
+  border-style: solid;
+  border-color: #2c3e50 transparent;
+}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -88,12 +88,10 @@ describe('colorRangeSlider should render with correct display content', () => {
     const maxInput = screen.getByTestId('maxInput');
     const minInput = screen.getByTestId('minInput');
 
-    screen.debug();
-
     expect(screen.getByText('Rescale')).toBeInTheDocument();
     await waitFor(() => {
-      expect(minSlider).toHaveValue("-1.31e-7");
-      expect(maxSlider).toHaveValue("2.63e-7");
+      expect(minSlider).toHaveValue('-1.31e-7');
+      expect(maxSlider).toHaveValue('2.63e-7');
       expect(minInput).toHaveValue(-1.31e-7);
       expect(maxInput).toHaveValue(2.63e-7);
     });

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -67,7 +67,7 @@ describe('colorRangeSlider should render with correct content.', () => {
   });
 });
 
-describe('colorRangeSlider should render with correct display content.', () => {
+describe('colorRangeSlider should render with correct display content', () => {
   const colorRangeData = {
     min: -0.0000003,
     max: 0.0000003,

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+
+import { fireEvent, prettyDOM, render, screen } from '@testing-library/react';
+
+import { ColorRangeSlider } from './index';
+
+describe('colorRangeSlider should render with correct content.', () => {
+  const colorRangeData = {
+    min: 0,
+    max: 0.3,
+    colorMapScale: { max: 0.263, min: 0.131 },
+    setColorMapScale: jest.fn()
+  };
+
+  beforeEach(() => {
+    render(<ColorRangeSlider {...colorRangeData} />);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Renders correct content', () => {
+
+    const maxSlider = screen.getByTestId('maxSlider');
+    const minSlider = screen.getByTestId('minSlider');
+    const maxInput = screen.getByTestId('maxInput');
+    const minInput = screen.getByTestId('minInput');
+
+    expect(screen.getByText('Rescale')).toBeInTheDocument();
+    expect(minSlider).toHaveValue('0.131');
+    expect(minInput).toHaveValue('0.131');
+
+    expect(maxSlider).toHaveValue('0.263');
+    expect(maxInput).toHaveValue('0.263');
+    console.log(prettyDOM());
+
+  });
+
+  it('Shows error when number entered above max', () => {
+    const minInput = screen.getByTestId('minInput');
+
+    fireEvent.change(minInput, { target: { value: 0.29 } });
+    expect(
+      screen.getByText('Please enter a value less than 0.263')
+    ).toBeInTheDocument();
+  });
+  it('Shows error when number entered below min', () => {
+    const maxInput = screen.getByTestId('maxInput');
+
+    fireEvent.change(maxInput, { target: { value: -0.1 } });
+    expect(
+      screen.getByText('Please enter a value larger than 0.131')
+    ).toBeInTheDocument();
+  });
+  it('Shows error when number entered outside of min and max', () => {
+    const minInput = screen.getByTestId('minInput');
+
+    fireEvent.change(minInput, { target: { value: -0.1 } });
+    expect(
+      screen.getByText('Please enter a value between 0 and 0.3')
+    ).toBeInTheDocument();
+    const maxInput = screen.getByTestId('maxInput');
+
+    fireEvent.change(maxInput, { target: { value: 0.4 } });
+    expect(
+      screen.getByText('Please enter a value between 0 and 0.3')
+    ).toBeInTheDocument();
+  });
+});

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '@testing-library/jest-dom';
 
-import { fireEvent, prettyDOM, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { ColorRangeSlider } from './index';
 
@@ -20,21 +20,19 @@ describe('colorRangeSlider should render with correct content.', () => {
     jest.clearAllMocks();
   });
 
-  it('Renders correct content', () => {
-
+  it('Renders correct content', async () => {
     const maxSlider = screen.getByTestId('maxSlider');
     const minSlider = screen.getByTestId('minSlider');
     const maxInput = screen.getByTestId('maxInput');
     const minInput = screen.getByTestId('minInput');
 
     expect(screen.getByText('Rescale')).toBeInTheDocument();
-    expect(minSlider).toHaveValue('0.131');
-    expect(minInput).toHaveValue('0.131');
-
-    expect(maxSlider).toHaveValue('0.263');
-    expect(maxInput).toHaveValue('0.263');
-    console.log(prettyDOM());
-
+    await waitFor(() => {
+      expect(minSlider).toHaveValue('0.131');
+      expect(maxSlider).toHaveValue('0.263');
+      expect(minInput).toHaveValue(0.131);
+      expect(maxInput).toHaveValue(0.263);
+    });
   });
 
   it('Shows error when number entered above max', () => {
@@ -66,5 +64,38 @@ describe('colorRangeSlider should render with correct content.', () => {
     expect(
       screen.getByText('Please enter a value between 0 and 0.3')
     ).toBeInTheDocument();
+  });
+});
+
+describe('colorRangeSlider should render with correct display content.', () => {
+  const colorRangeData = {
+    min: -0.0000003,
+    max: 0.0000003,
+    colorMapScale: { max: 0.000000263, min: -0.000000131 },
+    setColorMapScale: jest.fn()
+  };
+
+  beforeEach(() => {
+    render(<ColorRangeSlider {...colorRangeData} />);
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Renders correct content', async () => {
+    const maxSlider = screen.getByTestId('maxSlider');
+    const minSlider = screen.getByTestId('minSlider');
+    const maxInput = screen.getByTestId('maxInput');
+    const minInput = screen.getByTestId('minInput');
+
+    screen.debug();
+
+    expect(screen.getByText('Rescale')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(minSlider).toHaveValue("-1.31e-7");
+      expect(maxSlider).toHaveValue("2.63e-7");
+      expect(minInput).toHaveValue(-1.31e-7);
+      expect(maxInput).toHaveValue(2.63e-7);
+    });
   });
 });

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -39,8 +39,8 @@ export function ColorRangeSlider({
 
   const [minVal, setMinVal] = useState(setDefaultMin);
   const [maxVal, setMaxVal] = useState(setDefaultMax);
-  const minValRef = useRef({ actual: setDefaultMin, display: '' });
-  const maxValRef = useRef({ actual: setDefaultMax, display: '' });
+  const minValRef = useRef({ actual: setDefaultMin, display: setDefaultMin });
+  const maxValRef = useRef({ actual: setDefaultMax, display: setDefaultMax });
   const [maxIsHovering, setMaxIsHovering] = useState(false);
   const [minIsHovering, setMinIsHovering] = useState(false);
   const digitCount = useRef<number>(1);

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -117,12 +117,12 @@ export function ColorRangeSlider({
     const minCharacterCount = minVal.toString().length + 1;
 
     let updatedDisplay;
-    maxCharacterCount <= 6
+    maxCharacterCount <= 7
       ? (updatedDisplay = maxVal)
       : (updatedDisplay = maxVal.toExponential());
     maxValRef.current.display = updatedDisplay;
 
-    minCharacterCount <= 6
+    minCharacterCount <= 7
       ? (updatedDisplay = minVal)
       : (updatedDisplay = minVal.toExponential());
     minValRef.current.display = updatedDisplay;

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -1,0 +1,326 @@
+import React, { useCallback, useEffect, useState, useRef } from 'react';
+
+import './color-range-slider.scss';
+import {
+  sterlizeNumber,
+  calculateStep,
+  rangeCalculation,
+  displayErrorMessage,
+  textInputClasses,
+  thumbPosition,
+  tooltiptextClasses
+} from './utils';
+
+import { colorMapScale } from '$components/exploration/types.d.ts';
+import { USWDSTextInput } from '$components/common/uswds';
+
+interface ColorrangeRangeSlideProps {
+  // Absolute minimum of color range
+  min: number;
+
+  // Absolute maximum of color range
+  max: number;
+
+  // Previously selected minimum and maximum of colorRangeScale
+  colorMapScale: colorMapScale | undefined;
+
+  // Update colorRangeScale
+  setColorMapScale: (colorMapScale: colorMapScale) => void;
+}
+
+export function ColorRangeSlider({
+  min,
+  max,
+  colorMapScale,
+  setColorMapScale
+}: ColorrangeRangeSlideProps) {
+
+  const setDefaultMin = colorMapScale?.min ? colorMapScale.min : min;
+  const setDefaultMax = colorMapScale?.max ? colorMapScale.max : max;
+
+  const [minVal, setMinVal] = useState(setDefaultMin);
+  const [maxVal, setMaxVal] = useState(setDefaultMax);
+  const minValRef = useRef({ actual: setDefaultMin, display: '' });
+  const maxValRef = useRef({ actual: setDefaultMax, display: '' });
+  const [maxIsHovering, setMaxIsHovering] = useState(false);
+  const [minIsHovering, setMinIsHovering] = useState(false);
+  const digitCount = useRef<number>(1);
+  const range = useRef<HTMLDivElement>(null);
+
+  const [fieldFocused, setFieldFocused] = useState(false);
+  const [inputError, setInputError] = useState({
+    min: false,
+    max: false,
+    largerThanMax: false,
+    lessThanMin: false
+  });
+
+  // Convert to percentage
+  const getPercent = useCallback(
+    (value) => ((value - min) * 100) / (max - min),
+    [min, max]
+  );
+
+  const resetErrorOnSlide = (value, slider) => {
+    if (value > min || value < max) {
+      slider === 'max'
+        ? setInputError({ ...inputError, max: false, lessThanMin: false })
+        : setInputError({ ...inputError, min: false, largerThanMax: false });
+    }
+  };
+
+  const minMaxBuffer = calculateStep(max, min, digitCount);
+
+  useEffect(() => {
+    let maxValPrevious;
+    let minValPrevious;
+    //checking that there are no current errors with inputs
+    if (Object.values(inputError).every((error) => !error)) {
+      //set the filled range bar on initial load
+      if (
+        colorMapScale &&
+        maxVal != maxValPrevious &&
+        minVal != minValPrevious
+      ) {
+        const minPercent = getPercent(minValRef.current.actual);
+        const maxPercent = getPercent(maxValRef.current.actual);
+
+        rangeCalculation(maxPercent, minPercent, range);
+
+        if (range.current)
+          range.current.style.left = `calc(${minPercent}% + ${
+            10 - minPercent * 0.2
+          }px)`;
+      } else {
+        //set the filled range bar if change to max slider
+        if (maxVal != maxValPrevious) {
+          maxValPrevious = maxVal;
+          const minPercent = getPercent(minValRef.current.actual);
+          const maxPercent = getPercent(maxVal);
+          rangeCalculation(maxPercent, minPercent, range);
+        }
+        //set the filled range bar if change to min slider
+        if (minVal != minValPrevious) {
+          minValPrevious = minVal;
+          const minPercent = getPercent(minVal);
+          const maxPercent = getPercent(maxValRef.current.actual);
+          rangeCalculation(maxPercent, minPercent, range);
+
+          if (range.current)
+            range.current.style.left = `calc(${minPercent}% + ${
+              10 - minPercent * 0.2
+            }px)`;
+        }
+      }
+    }
+
+    const maxCharacterCount = maxVal.toString().length + 1;
+    const minCharacterCount = minVal.toString().length + 1;
+
+    let updatedDisplay;
+    maxCharacterCount <= 6
+      ? (updatedDisplay = maxVal)
+      : (updatedDisplay = maxVal.toExponential());
+    maxValRef.current.display = updatedDisplay;
+
+    minCharacterCount <= 6
+      ? (updatedDisplay = minVal)
+      : (updatedDisplay = minVal.toExponential());
+    minValRef.current.display = updatedDisplay;
+    // determining if there is an initial colorMapeScale or if it is the default min and max
+    if (
+      !colorMapScale ||
+      (colorMapScale.max == max && colorMapScale.min == min)
+    ) {
+      setColorMapScale({ min: minVal, max: maxVal });
+    } else
+      setColorMapScale({
+        min: Number(minValRef.current.actual),
+        max: Number(maxValRef.current.actual)
+      }); /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [maxVal, minVal, getPercent, setColorMapScale, inputError, max, min]);
+
+  return (
+    <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
+      <form className='usa-form display-flex flex-row flex-justify flex-align-center padding-bottom-1'>
+        <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1 flex-1'>
+          Rescale
+        </label>
+        <div>
+          {minIsHovering && (
+            <div className='position-relative tooltipcontainer'>
+              <span className={`tooltiptext ${tooltiptextClasses} tooltipmin`}>
+                {sterlizeNumber(minValRef.current.actual, digitCount)}
+              </span>
+            </div>
+          )}
+
+          <USWDSTextInput
+            type='number'
+            id='range slider min'
+            name='min'
+            className={`${textInputClasses} ${
+              inputError.min || inputError.largerThanMax
+                ? 'border-secondary-vivid text-secondary-vivid'
+                : ' border-base-light'
+            }`}
+            value={
+              fieldFocused
+                ? minValRef.current.actual
+                : minValRef.current.display
+            }
+            placeholder={
+              fieldFocused
+                ? minValRef.current.actual
+                : minValRef.current.display
+            }
+            onMouseEnter={() => setMinIsHovering(true)}
+            onMouseLeave={() => setMinIsHovering(false)}
+            onFocus={() => setFieldFocused(true)}
+            onBlur={() => {
+              setFieldFocused(false);
+            }}
+            onChange={(event) => {
+              if (event.target.value != undefined) {
+                minValRef.current.actual =
+                  event.target.value === '' ? 0 : event.target.value;
+                const value = Number(event.target.value);
+
+                if (value > maxVal - minMaxBuffer)
+                  return setInputError({ ...inputError, largerThanMax: true });
+                if (value < min || value > max) {
+                  return setInputError({ ...inputError, min: true });
+                } else {
+                  setInputError({
+                    ...inputError,
+                    min: false,
+                    largerThanMax: false
+                  });
+                  const calculatedVal = Math.min(value, maxVal - minMaxBuffer);
+                  setMinVal(calculatedVal);
+                }
+              }
+            }}
+          />
+        </div>
+        <div className='position-relative container display-flex flex-align-center flex-justify-center padding-x-105'>
+          <input
+            type='range'
+            min={min}
+            max={max}
+            step={calculateStep(max, min, digitCount)}
+            value={minVal}
+            onChange={(event) => {
+              const value = Math.min(
+                Number(event.target.value),
+                maxVal - minMaxBuffer
+              );
+              resetErrorOnSlide(value, 'min');
+              setMinVal(value);
+              minValRef.current.actual = value;
+            }}
+            className={`thumb ${thumbPosition} z-index-30`}
+            style={{
+              zIndex: minVal >= max - 10 * minMaxBuffer ? '500' : '300'
+            }}
+          />
+          <input
+            type='range'
+            min={min}
+            max={max}
+            step={calculateStep(max, min, digitCount)}
+            value={maxVal}
+            onChange={(event) => {
+              const value = Math.max(
+                Number(event.target.value),
+                minVal + minMaxBuffer
+              );
+              resetErrorOnSlide(value, 'max');
+              setMaxVal(value);
+              maxValRef.current.actual = value;
+            }}
+            className={`thumb ${thumbPosition} z-400`}
+            style={{
+              zIndex: minVal <= max - 10 * minMaxBuffer ? '500' : '400'
+            }}
+          />
+          <div className='slider width-card position-relative height-3 display-flex flex-align-center'>
+            <div className='bg-base-lighter radius-md position-absolute height-05 z-100 width-full display-flex flex-align-center ' />
+            <div
+              ref={range}
+              className='bg-primary-vivid display-flex flex-align-center flex-justify-center radius-md position-absolute height-05 z-200'
+            >
+              {/* Show divergent map middle point */}
+              {min < 0 ? (
+                <div className='position-relative height-2 width-1px bg-primary-darker ' />
+              ) : null}
+            </div>
+          </div>
+        </div>
+        <div>
+          {maxIsHovering && (
+            <div className='position-relative tooltipcontainer'>
+              <span
+                className={`tooltiptext ${tooltiptextClasses} right-0 tooltipmax`}
+              >
+                {sterlizeNumber(maxValRef.current.actual, digitCount)}
+              </span>
+            </div>
+          )}
+          <USWDSTextInput
+            type='number'
+            data-validate-numerical='[0-9]*'
+            id='range slider max'
+            name='max'
+            className={`${textInputClasses} ${
+              inputError.max || inputError.lessThanMin
+                ? 'border-secondary-vivid text-secondary-vivid'
+                : ' border-base-light'
+            }`}
+            placeholder={
+              fieldFocused
+                ? maxValRef.current.actual
+                : maxValRef.current.display
+            }
+            value={
+              fieldFocused
+                ? maxValRef.current.actual
+                : maxValRef.current.display
+            }
+            onMouseEnter={() => setMaxIsHovering(true)}
+            onMouseLeave={() => setMaxIsHovering(false)}
+            onFocus={() => setFieldFocused(true)}
+            onBlur={() => {
+              setFieldFocused(false);
+            }}
+            onChange={(event) => {
+              if (event.target.value != undefined) {
+                maxValRef.current.actual =
+                  event.target.value === '' ? 0 : event.target.value;
+                const value = Number(event.target.value);
+
+                if (value < minVal + minMaxBuffer)
+                  return setInputError({ ...inputError, lessThanMin: true });
+
+                if (value < min || value > max) {
+                  return setInputError({ ...inputError, max: true });
+                } else {
+                  //unsetting error
+                  setInputError({
+                    ...inputError,
+                    max: false,
+                    lessThanMin: false
+                  });
+                  const calculatedVal = Math.max(value, minVal + minMaxBuffer);
+                  setMaxVal(calculatedVal);
+                }
+              }
+            }}
+          />
+        </div>
+      </form>
+
+      {displayErrorMessage(inputError, min, max, maxValRef, minValRef)}
+    </div>
+  );
+}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -34,7 +34,6 @@ export function ColorRangeSlider({
   colorMapScale,
   setColorMapScale
 }: ColorrangeRangeSlideProps) {
-
   const setDefaultMin = colorMapScale?.min ? colorMapScale.min : min;
   const setDefaultMax = colorMapScale?.max ? colorMapScale.max : max;
 
@@ -164,6 +163,7 @@ export function ColorRangeSlider({
                 ? 'border-secondary-vivid text-secondary-vivid'
                 : ' border-base-light'
             }`}
+            data-testid='minInput'
             value={
               fieldFocused
                 ? minValRef.current.actual
@@ -206,6 +206,7 @@ export function ColorRangeSlider({
         <div className='position-relative container display-flex flex-align-center flex-justify-center padding-x-105'>
           <input
             type='range'
+            data-testid='minSlider'
             min={min}
             max={max}
             step={calculateStep(max, min, digitCount)}
@@ -226,6 +227,7 @@ export function ColorRangeSlider({
           />
           <input
             type='range'
+            data-testid='maxSlider'
             min={min}
             max={max}
             step={calculateStep(max, min, digitCount)}
@@ -272,6 +274,7 @@ export function ColorRangeSlider({
             data-validate-numerical='[0-9]*'
             id='range slider max'
             name='max'
+            data-testid='maxInput'
             className={`${textInputClasses} ${
               inputError.max || inputError.lessThanMin
                 ? 'border-secondary-vivid text-secondary-vivid'

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+export const sterlizeNumber = (number, digitCount) => {
+  const fixedNum = Number(number).toFixed(digitCount.current);
+  return fixedNum;
+};
+
+export const textInputClasses =
+  'flex-1 radius-md height-3 font-size-3xs width-7 border-2px tooltip';
+export const thumbPosition = `position-absolute pointer-events width-card height-0 outline-0`;
+export const tooltiptextClasses =
+  'text-no-wrap text-white text-center radius-lg padding-x-105 padding-y-05 position-absolute z-1 bottom-205';
+export const calculateStep = (max, min, digitCount) => {
+  const numericDistance = max - min;
+  if (numericDistance >= 100) {
+    return 0.001;
+  } else {
+    let decimalPoints;
+    if (numericDistance.toString().includes('.')) {
+      decimalPoints = numericDistance.toString().split('.')[1].length || 0;
+    } else {
+      decimalPoints = numericDistance.toString().length || 0;
+    }
+    digitCount.current = decimalPoints + 2;
+
+    //adding a default buffer for granular control
+    return Math.pow(10, (decimalPoints + 2) * -1);
+  }
+};
+
+//Calculate the range
+
+export const rangeCalculation = (maxPercent, minPercent, range) => {
+  const thumbWidth = 20;
+  if (range.current) {
+    range.current.style.width = `calc(${
+      maxPercent - minPercent >= 100 ? 100 : maxPercent - minPercent
+    }% - ${(thumbWidth - minPercent * 0.2) * (maxPercent / 100)}px )`;
+  }
+  return;
+};
+
+export const displayErrorMessage = (
+  inputError,
+  min,
+  max,
+  maxValRef,
+  minValRef
+) => {
+  // error message for min input that is outside min max of color map
+
+  if (inputError.max || inputError.min) {
+    return (
+      <p className='text-secondary-vivid'>
+        Please enter a value between {min} and {max}
+      </p>
+    );
+  }
+  {
+    /* error message for max input that is less than current min */
+  }
+
+  if (inputError.largerThanMax) {
+    return (
+      <p className='text-secondary-vivid'>
+        Please enter a value less than {maxValRef.current.actual}
+      </p>
+    );
+  }
+  {
+    /* error message for min input that is larger than current max */
+  }
+
+  if (inputError.lessThanMin) {
+    return (
+      <p className='text-secondary-vivid'>
+        Please enter a value larger than {minValRef.current.actual}
+      </p>
+    );
+  }
+};

--- a/app/scripts/components/exploration/components/datasets/colormap-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/colormap-options.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Icon } from "@trussworks/react-uswds";
+import { Icon } from '@trussworks/react-uswds';
 import { CollecticonDrop } from '@devseed-ui/collecticons';
 import {
   sequentialColorMaps,
@@ -13,16 +13,26 @@ import { colorMapScale } from '$components/exploration/types.d.ts';
 export const DEFAULT_COLORMAP = 'viridis';
 
 const CURATED_SEQUENTIAL_COLORMAPS = [
-  'viridis', 'plasma', 'inferno', 'magma', 'cividis',
-  'purples', 'blues', 'reds', 'greens', 'oranges',
-  'ylgnbu', 'ylgn', 'gnbu'
+  'viridis',
+  'plasma',
+  'inferno',
+  'magma',
+  'cividis',
+  'purples',
+  'blues',
+  'reds',
+  'greens',
+  'oranges',
+  'ylgnbu',
+  'ylgn',
+  'gnbu'
 ];
 
-const CURATED_DIVERGING_COLORMAPS = [
-  'rdbu', 'rdylbu', 'bwr', 'coolwarm'
-];
+const CURATED_DIVERGING_COLORMAPS = ['rdbu', 'rdylbu', 'bwr', 'coolwarm'];
 
-export const classifyColormap = (colormapName: string): 'sequential' | 'diverging' | 'rest' | 'unknown' => {
+export const classifyColormap = (
+  colormapName: string
+): 'sequential' | 'diverging' | 'rest' | 'unknown' => {
   const baseName = normalizeColorMap(colormapName);
 
   if (sequentialColorMaps[baseName]) {
@@ -38,9 +48,16 @@ export const classifyColormap = (colormapName: string): 'sequential' | 'divergin
 interface ColormapOptionsProps {
   colorMap: string | undefined;
   setColorMap: (colorMap: string) => void;
+  min: number;
+  max: number;
+  setColorMapScale: (colorMapScale: colorMapScale) => void;
+  colorMapScale: colorMapScale | undefined;
 }
 
-export const getColormapColors = (colormapName: string, isReversed: boolean): string[] => {
+export const getColormapColors = (
+  colormapName: string,
+  isReversed: boolean
+): string[] => {
   const baseName = normalizeColorMap(colormapName);
   const colormapData =
     sequentialColorMaps[baseName] ||
@@ -54,10 +71,19 @@ export const getColormapColors = (colormapName: string, isReversed: boolean): st
     return `rgba(${r}, ${g}, ${b}, ${a})`;
   });
 
-  return isReversed ? colors.reduceRight((acc, color) => [...acc, color], []) : colors;
+  return isReversed
+    ? colors.reduceRight((acc, color) => [...acc, color], [])
+    : colors;
 };
 
-export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: ColormapOptionsProps) {
+export function ColormapOptions({
+  colorMap = DEFAULT_COLORMAP,
+  min,
+  max,
+  setColorMap,
+  setColorMapScale,
+  colorMapScale
+}: ColormapOptionsProps) {
   const initialIsReversed = colorMap.endsWith('_r');
   const initialColorMap = normalizeColorMap(colorMap);
 
@@ -68,9 +94,15 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
   const [customColorMap, setCustomColorMap] = useState<string | null>(null);
 
   useEffect(() => {
-    if (colormapType === 'sequential' && !CURATED_SEQUENTIAL_COLORMAPS.includes(selectedColorMap)) {
+    if (
+      colormapType === 'sequential' &&
+      !CURATED_SEQUENTIAL_COLORMAPS.includes(selectedColorMap)
+    ) {
       setCustomColorMap(selectedColorMap);
-    } else if (colormapType === 'diverging' && !CURATED_DIVERGING_COLORMAPS.includes(selectedColorMap)) {
+    } else if (
+      colormapType === 'diverging' &&
+      !CURATED_DIVERGING_COLORMAPS.includes(selectedColorMap)
+    ) {
       setCustomColorMap(selectedColorMap);
     }
   }, [selectedColorMap, colormapType]);
@@ -79,15 +111,25 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
   if (colormapType === 'sequential') {
     if (customColorMap) {
-      availableColormaps = [{ name: customColorMap }, ...CURATED_SEQUENTIAL_COLORMAPS.map(name => ({ name }))];
+      availableColormaps = [
+        { name: customColorMap },
+        ...CURATED_SEQUENTIAL_COLORMAPS.map((name) => ({ name }))
+      ];
     } else {
-      availableColormaps = CURATED_SEQUENTIAL_COLORMAPS.map(name => ({ name }));
+      availableColormaps = CURATED_SEQUENTIAL_COLORMAPS.map((name) => ({
+        name
+      }));
     }
   } else if (colormapType === 'diverging') {
     if (customColorMap) {
-      availableColormaps = [{ name: customColorMap }, ...CURATED_DIVERGING_COLORMAPS.map(name => ({ name }))];
+      availableColormaps = [
+        { name: customColorMap },
+        ...CURATED_DIVERGING_COLORMAPS.map((name) => ({ name }))
+      ];
     } else {
-      availableColormaps = CURATED_DIVERGING_COLORMAPS.map(name => ({ name }));
+      availableColormaps = CURATED_DIVERGING_COLORMAPS.map((name) => ({
+        name
+      }));
     }
   } else if (colormapType === 'rest') {
     availableColormaps = [{ name: selectedColorMap }];
@@ -133,7 +175,12 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
           ) : (
             <Icon.ToggleOff className='text-base-light' size={4} />
           )}
-          <input className='colormap-options__input' checked={isReversed} type='checkbox' readOnly />
+          <input
+            className='colormap-options__input'
+            checked={isReversed}
+            type='checkbox'
+            readOnly
+          />
         </div>
       </div>
 
@@ -143,13 +190,21 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
           return (
             <div
-              className={`colormap-options__item display-flex flex-align-center flex-justify padding-2 border-bottom-1px border-base-lightest radius-md ${selectedColorMap.toLowerCase() === name.toLowerCase() ? 'selected' : ''}`}
+              className={`colormap-options__item display-flex flex-align-center flex-justify padding-2 border-bottom-1px border-base-lightest radius-md ${
+                selectedColorMap.toLowerCase() === name.toLowerCase()
+                  ? 'selected'
+                  : ''
+              }`}
               key={name}
               onClick={() => handleColorMapSelect(name.toLowerCase())}
             >
               <div
                 className='colormap-options__preview display-flex border-1px border-base-lightest radius-md margin-right-2'
-                style={{ background: `linear-gradient(to right, ${previewColors.join(', ')})` }}
+                style={{
+                  background: `linear-gradient(to right, ${previewColors.join(
+                    ', '
+                  )})`
+                }}
               />
               <label className='colormap-options__label text-gray-90 font-heading-xs flex-1'>
                 {name}
@@ -161,7 +216,6 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
     </div>
   );
 }
-
 
 function normalizeColorMap(colorMap: string): string {
   return colorMap.replace(/_r$/, '');

--- a/app/scripts/components/exploration/components/datasets/colormap-options.tsx
+++ b/app/scripts/components/exploration/components/datasets/colormap-options.tsx
@@ -1,10 +1,15 @@
 import React, { useEffect, useState } from 'react';
 import { Icon } from "@trussworks/react-uswds";
 import { CollecticonDrop } from '@devseed-ui/collecticons';
-import { sequentialColorMaps, divergingColorMaps, restColorMaps } from './colorMaps';
+import {
+  sequentialColorMaps,
+  divergingColorMaps,
+  restColorMaps
+} from './colorMaps';
 
 import './colormap-options.scss';
-
+import { ColorRangeSlider } from './colorRangeSlider/index';
+import { colorMapScale } from '$components/exploration/types.d.ts';
 export const DEFAULT_COLORMAP = 'viridis';
 
 const CURATED_SEQUENTIAL_COLORMAPS = [
@@ -105,11 +110,24 @@ export function ColormapOptions({ colorMap = DEFAULT_COLORMAP, setColorMap}: Col
 
   return (
     <div className='colormap-options__container bg-white shadow-1 maxh-mobile-lg'>
-      <div className='display-flex flex-align-center text-gray-90 padding-2 font-heading-xs text-bold'><CollecticonDrop className='margin-right-1' /> Colormap options</div>
+      <div className='display-flex flex-align-center text-gray-90 padding-2 font-heading-xs text-bold'>
+        <CollecticonDrop className='margin-right-1' /> Colormap options
+      </div>
 
-      <div className='display-flex flex-align-center flex-justify border-top-1px border-bottom-1px border-base-lightest bg-base-lightest padding-2'>
-        <div className='display-flex flex-align-center' onClick={handleReverseToggle}>
-          <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1'>Reverse</label>
+      <div className='display-flex flex-align-center flex-column flex-justify border-top-1px border-bottom-1px border-base-lightest bg-base-lightest padding-2'>
+        <ColorRangeSlider
+          min={min}
+          max={max}
+          colorMapScale={colorMapScale}
+          setColorMapScale={setColorMapScale}
+        />
+        <div
+          className='display-flex flex-align-center width-full padding-top-1'
+          onClick={handleReverseToggle}
+        >
+          <label className='font-ui-3xs text-gray-90 text-semibold margin-right-1'>
+            Reverse
+          </label>
           {isReversed ? (
             <Icon.ToggleOn className='text-primary' size={4} />
           ) : (

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -17,7 +17,8 @@ import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
 import { TipButton } from '$components/common/tip-button';
 import {
-  LayerCategoricalGraphic, LayerGradientColormapGraphic
+  LayerCategoricalGraphic,
+  LayerGradientColormapGraphic
 } from '$components/common/map/layer-legend';
 
 import {
@@ -109,7 +110,9 @@ const LegendColorMapTrigger = styled.div`
 `;
 
 // Hiding configurable map for now until Instances are ready to adapt it
-const showConfigurableColorMap = checkEnvFlag(process.env.SHOW_CONFIGURABLE_COLOR_MAP);
+const showConfigurableColorMap = checkEnvFlag(
+  process.env.SHOW_CONFIGURABLE_COLOR_MAP
+);
 
 export default function DataLayerCard(props: CardProps) {
   const {
@@ -119,6 +122,8 @@ export default function DataLayerCard(props: CardProps) {
     setVisible,
     colorMap,
     setColorMap,
+    colorMapScale,
+    setColorMapScale,
     datasetLegend,
     onClickLayerInfo
   } = props;
@@ -137,9 +142,16 @@ export default function DataLayerCard(props: CardProps) {
     }
   };
 
-  const showLoadingConfigurableCmapSkeleton = showConfigurableColorMap && dataset.status === 'loading' && datasetLegend?.type === 'gradient';
-  const showConfigurableCmap = showConfigurableColorMap && dataset.status === 'success' && datasetLegend?.type === 'gradient';
-  const showNonConfigurableCmap = !showConfigurableColorMap && datasetLegend?.type === 'gradient';
+  const showLoadingConfigurableCmapSkeleton =
+    showConfigurableColorMap &&
+    dataset.status === 'loading' &&
+    datasetLegend?.type === 'gradient';
+  const showConfigurableCmap =
+    showConfigurableColorMap &&
+    dataset.status === 'success' &&
+    datasetLegend?.type === 'gradient';
+  const showNonConfigurableCmap =
+    !showConfigurableColorMap && datasetLegend?.type === 'gradient';
 
   return (
     <>
@@ -163,7 +175,10 @@ export default function DataLayerCard(props: CardProps) {
                 onPointerDownCapture={(e) => e.stopPropagation()}
                 onClick={onClickLayerInfo}
               >
-                <CollecticonCircleInformation meaningful title='View dataset page' />
+                <CollecticonCircleInformation
+                  meaningful
+                  title='View dataset page'
+                />
               </TipButton>
               <TipButton
                 tipContent={isVisible ? 'Hide layer' : 'Show layer'}
@@ -173,9 +188,15 @@ export default function DataLayerCard(props: CardProps) {
                 onClick={() => setVisible((v) => !v)}
               >
                 {isVisible ? (
-                  <CollecticonEye meaningful title='Toggle dataset visibility' />
+                  <CollecticonEye
+                    meaningful
+                    title='Toggle dataset visibility'
+                  />
                 ) : (
-                  <CollecticonEyeDisabled meaningful title='Toggle dataset visibility' />
+                  <CollecticonEyeDisabled
+                    meaningful
+                    title='Toggle dataset visibility'
+                  />
                 )}
               </TipButton>
               <LayerMenuOptions datasetAtom={datasetAtom} />
@@ -187,49 +208,66 @@ export default function DataLayerCard(props: CardProps) {
           </DatasetMetricInfo>
         </DatasetCardInfo>
         {datasetLegend?.type === 'categorical' && (
-          <LayerCategoricalGraphic type='categorical' stops={datasetLegend.stops} />
+          <LayerCategoricalGraphic
+            type='categorical'
+            stops={datasetLegend.stops}
+          />
         )}
 
-          {/* Show a loading skeleton when the color map is not categorical and the dataset
+        {/* Show a loading skeleton when the color map is not categorical and the dataset
           status is 'loading'. This is because we color map sometimes might come from the titiler
           which could introduce a visual flash when going from the 'default' color map to the one
           configured in titiler */}
 
-          {showLoadingConfigurableCmapSkeleton && <div className='display-flex flex-align-center height-8'><LoadingSkeleton /></div>}
-          {showConfigurableCmap && (
-            <div className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md' ref={triggerRef}>
-              <LayerGradientColormapGraphic
-                min={min}
-                max={max}
-                colorMap={colorMap}
-              />
-              <Tippy
-                className='colormap-options'
-                content={
-                  <ColormapOptions
-                    colorMap={colorMap}
-                    setColorMap={setColorMap}
-                  />
-                }
-                appendTo={() => document.body}
-                visible={isColorMapOpen}
-                interactive={true}
-                placement='top'
-                onClickOutside={(_, event) => handleClickOutside(event)}
+        {showLoadingConfigurableCmapSkeleton && (
+          <div className='display-flex flex-align-center height-8'>
+            <LoadingSkeleton />
+          </div>
+        )}
+        {showConfigurableCmap && (
+          <div
+            className='display-flex flex-align-center flex-justify margin-y-1 padding-left-1 border-bottom-1px border-base-lightest radius-md'
+            ref={triggerRef}
+          >
+            <LayerGradientColormapGraphic
+              min={min}
+              max={max}
+              colorMap={colorMap}
+            />
+            <Tippy
+              className='colormap-options'
+              content={
+                <ColormapOptions
+                  min={min}
+                  max={max}
+                  colorMap={colorMap}
+                  setColorMap={setColorMap}
+                  setColorMapScale={setColorMapScale}
+                  colorMapScale={colorMapScale}
+                />
+              }
+              appendTo={() => document.body}
+              visible={isColorMapOpen}
+              interactive={true}
+              placement='top'
+              onClickOutside={(_, event) => handleClickOutside(event)}
+            >
+              <LegendColorMapTrigger
+                className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05'
+                onClick={handleColorMapTriggerClick}
               >
-                <LegendColorMapTrigger className='display-flex flex-align-center flex-justify bg-base-lightest margin-left-1 padding-05' onClick={handleColorMapTriggerClick}>
-                  <CollecticonChevronDownSmall />
-                </LegendColorMapTrigger>
-              </Tippy>
-            </div>
-          )}
-        {showNonConfigurableCmap &&
+                <CollecticonChevronDownSmall />
+              </LegendColorMapTrigger>
+            </Tippy>
+          </div>
+        )}
+        {showNonConfigurableCmap && (
           <LayerGradientColormapGraphic
             min={min}
             max={max}
             colorMap={colorMap}
-          />}
-
+          />
+        )}
       </DatasetInfo>
     </>
   );

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -20,7 +20,10 @@ import {
   LayerCategoricalGraphic, LayerGradientColormapGraphic
 } from '$components/common/map/layer-legend';
 
-import { TimelineDataset } from '$components/exploration/types.d.ts';
+import {
+  TimelineDataset,
+  colorMapScale
+} from '$components/exploration/types.d.ts';
 import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 import { ParentDatasetTitle } from '$components/common/catalog/catalog-content';
 import { checkEnvFlag } from '$utils/utils';
@@ -35,6 +38,8 @@ interface CardProps {
   setVisible: any;
   colorMap: string | undefined;
   setColorMap: (colorMap: string) => void;
+  colorMapScale: colorMapScale | undefined;
+  setColorMapScale: (colorMapScale: colorMapScale) => void;
   onClickLayerInfo: () => void;
   datasetLegend: LayerLegendCategorical | LayerLegendGradient | undefined;
 }

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -105,7 +105,10 @@ export function DatasetListItem(props: DatasetListItemProps) {
 
   const [isVisible, setVisible] = useTimelineDatasetVisibility(datasetAtom);
   const [colorMap, setColorMap] = useTimelineDatasetColormap(datasetAtom);
-  const [modalLayerInfo, setModalLayerInfo] = React.useState<LayerInfoModalData>();
+  const [colorMapScale, setColorMapScale] =
+    useTimelineDatasetColormapScale(datasetAtom);
+  const [modalLayerInfo, setModalLayerInfo] =
+    React.useState<LayerInfoModalData>();
   const [, setSetting] = useTimelineDatasetSettings(datasetAtom);
 
   const queryClient = useQueryClient();
@@ -121,7 +124,10 @@ export function DatasetListItem(props: DatasetListItemProps) {
   }, [queryClient, datasetId]);
 
   const onClickLayerInfo = useCallback(() => {
-    const parentInfoDesc = findDatasetAttribute({datasetId: dataset.data.parentDataset.id, attr: 'infoDescription'});
+    const parentInfoDesc = findDatasetAttribute({
+      datasetId: dataset.data.parentDataset.id,
+      attr: 'infoDescription'
+    });
     const data: LayerInfoModalData = {
       name: dataset.data.name,
       description: dataset.data.description,
@@ -188,7 +194,6 @@ export function DatasetListItem(props: DatasetListItemProps) {
     [dataset]
   );
 
-
   const onDragging = (e) => {
     controls.start(e);
   };
@@ -210,8 +215,19 @@ export function DatasetListItem(props: DatasetListItemProps) {
       <DatasetItem>
         <DatasetHeader>
           <DatasetHeaderInner>
-            <div style={{width: '100%'}} onPointerDown={onDragging}>
-              <DataLayerCard dataset={dataset} datasetAtom={datasetAtom} colorMap={colorMap} setColorMap={setColorMap} isVisible={isVisible} setVisible={setVisible} datasetLegend={datasetLegend} onClickLayerInfo={onClickLayerInfo} />
+            <div style={{ width: '100%' }} onPointerDown={onDragging}>
+              <DataLayerCard
+                dataset={dataset}
+                datasetAtom={datasetAtom}
+                colorMap={colorMap}
+                colorMapScale={colorMapScale}
+                setColorMap={setColorMap}
+                setColorMapScale={setColorMapScale}
+                isVisible={isVisible}
+                setVisible={setVisible}
+                datasetLegend={datasetLegend}
+                onClickLayerInfo={onClickLayerInfo}
+              />
             </div>
             {modalLayerInfo && (
               <LayerInfoModal

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -35,7 +35,8 @@ import {
   useTimelineDatasetAtom,
   useTimelineDatasetColormap,
   useTimelineDatasetSettings,
-  useTimelineDatasetVisibility
+  useTimelineDatasetVisibility,
+  useTimelineDatasetColormapScale
 } from '$components/exploration/atoms/hooks';
 import {
   useAnalysisController,

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -26,7 +26,7 @@ export function Layer(props: LayerProps) {
     useContext(EnvConfigContext);
 
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
-  const { isVisible, opacity, colorMap } = dataset.settings;
+  const { isVisible, opacity, colorMap, scale } = dataset.settings;
 
   // The date needs to match the dataset's time density.
   const relevantDate = useMemo(

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -77,6 +77,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />
@@ -95,6 +96,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />
@@ -114,6 +116,7 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
+          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -105,6 +105,9 @@ export interface DatasetSettings {
   analysisMetrics?: DataMetric[];
   // Active colormap of the layer.
   colorMap?: string;
+  // Active colormap scale.
+
+  scale?: colorMapScale;
 }
 
 // Any sort of meta information the dataset like:

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -95,7 +95,10 @@ export interface DatasetData extends EnhancedDatasetLayer {
   timeDensity: TimeDensity;
   domain: Date[];
 }
-
+export interface colorMapScale {
+  min: number;
+  max: number;
+}
 export interface DatasetSettings {
   // Whether or not the layer should be shown on the map.
   isVisible?: boolean;


### PR DESCRIPTION
**Related Ticket:** https://github.com/orgs/NASA-IMPACT/projects/17?pane=issue&itemId=85258058&issue=NASA-IMPACT%7Cveda-ui%7C1226

### Description of Changes
- Adjusting the text input to be wider. 
- Cleaning out colorRangeSlider component, creating util file, creating initial tests. 
- Creating dynamic step calculation functionality

### Notes & Questions About Changes
When observing a value in either the max or min inputs if that value has a character count of 6 or greater the component will convert that number into scientific notation as a display value. 

### Validation / Testing
Run this branch on the veda-config code base, navigate to the E&A page and select the difference CO2 dataset. This is an extreme data set that should display all changes in this component. 
- Confirm that the middle range identifier is always at halfway mark. 
- Confirm that the numbers are displaying in scientific notation. 
