### PR TITLE
Hide new USWDS footer behind feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -14,3 +14,5 @@ GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f
 
 SHOW_CONFIGURABLE_COLOR_MAP = 'TRUE'
 
+# Enables the refactor page footer component that uses the USWDS design system
+ENABLE_USWDS_PAGE_FOOTER = 'TRUE'

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -11,8 +11,11 @@ import styled from 'styled-components';
 import { Outlet } from 'react-router';
 import { reveal } from '@devseed-ui/animation';
 import { getBannerFromVedaConfig, getCookieConsentFromVedaConfig } from 'veda';
+
 import MetaTags from '../meta-tags';
-import PageFooter from '../page-footer/index';
+import PageFooter from '../page-footer';
+import PageFooterLegacy from '../page-footer-legacy';
+
 const Banner = React.lazy(() => import('../banner'));
 const CookieConsent = React.lazy(() => import('../cookie-consent'));
 
@@ -26,9 +29,11 @@ import {
   mainNavItems,
   subNavItems
 } from '$components/common/page-header/default-config';
+import { checkEnvFlag } from '$utils/utils';
 
 const appTitle = process.env.APP_TITLE;
 const appDescription = process.env.APP_DESCRIPTION;
+const isUSWDSEnabled = checkEnvFlag(process.env.ENABLE_USWDS_PAGE_FOOTER);
 
 export const PAGE_BODY_ID = 'pagebody';
 
@@ -98,7 +103,11 @@ function LayoutRoot(props: { children?: ReactNode }) {
           />
         )}
       </PageBody>
-      <PageFooter hideFooter />
+      {isUSWDSEnabled ? (
+        <PageFooter />
+      ) : (
+        <PageFooterLegacy hideFooter={hideFooter} />
+      )}
     </Page>
   );
 }

--- a/app/scripts/components/common/page-footer-legacy.js
+++ b/app/scripts/components/common/page-footer-legacy.js
@@ -109,7 +109,7 @@ const InfoList = styled.dl`
   }
 `;
 
-function PageFooter(props) {
+function PageFooterLegacy(props) {
   const nowDate = new Date();
 
   return (
@@ -174,8 +174,8 @@ function PageFooter(props) {
   );
 }
 
-export default PageFooter;
+export default PageFooterLegacy;
 
-PageFooter.propTypes = {
+PageFooterLegacy.propTypes = {
   isHidden: T.bool
 };

--- a/app/scripts/components/common/page-footer/index.tsx
+++ b/app/scripts/components/common/page-footer/index.tsx
@@ -7,10 +7,9 @@ import {
   USWDSFooterNav,
   USWDSLogo
 } from '$components/common/uswds';
-export default function PageFooter(hideFooter) {
+export default function PageFooter() {
   return (
     <>
-      {/* //commenting out hidefooter functionality for inflight work{!hideFooter && ( */}
       <USWDSFooter
         size='slim'
         // returnToTop={returnToTop}
@@ -41,7 +40,6 @@ export default function PageFooter(hideFooter) {
           />
         }
       />
-      {/*  )} */}
     </>
   );
 }


### PR DESCRIPTION
Hej @snmln ! Thanks for setting up the feature branch and foundations for the new footer component! 
I renamed the old footer to PageFooterLegacy, that way we can use the regular import path for our new footer component. Also added a .env var that allows us to switch between old and new footer implementations easily. 