### PR TITLE
Add onClick for clearing filters for hub

### DIFF
--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -148,7 +148,7 @@ export default function HubContent(props: HubContentProps) {
           out of {allStories.length}.
         </span>
         {isFiltering && (
-          <Button {...ButtonLinkProps} size='small'>
+          <Button {...ButtonLinkProps} size='small' onClick={() => onAction(FilterActions.CLEAR)}>
             Clear filters <CollecticonXmarkSmall />
           </Button>
         )}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@developmentseed/veda-ui",
   "description": "Dashboard",
-  "version": "5.11.0",
+  "version": "5.11.2",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1292

_**NOTE:** A patch has already been cut with these changes from `hotfix/v5.11.2` branch which branched directly off of tag `v5.11.1`!! See diff [here](https://github.com/NASA-IMPACT/veda-ui/compare/v5.11.1...hotfix/v5.11.2?expand=1)._ 

Need to merge to `main` & bumping version here too so we can keep up to date with our actual release #s.

_**v5.11.2 Patch Release [here](https://github.com/NASA-IMPACT/veda-ui/releases/tag/v5.11.2)**_
_Test Pull Request for Patch Release [here](https://github.com/NASA-IMPACT/veda-ui/pull/1294)_

### Description of Changes
Fixes the bug explained in ticket by adding onClick.