### PR TITLE
fix: detect Next.js environment and adjust the AOI preset file paths

### DIFF
--- a/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
+++ b/app/scripts/components/common/map/controls/hooks/use-preset-aoi.tsx
@@ -2,6 +2,7 @@ import { Feature, Polygon } from 'geojson';
 import { useCallback, useEffect, useState } from 'react';
 import axios from 'axios';
 import { getAoiAppropriateFeatures } from './use-custom-aoi';
+import { isNextJs } from '$utils/utils';
 
 function usePresetAOI(selectedState) {
   const [error, setError] = useState<string | null>('');
@@ -18,10 +19,9 @@ function usePresetAOI(selectedState) {
         // We're dynamically adjusting the base path based on the environment:
         // 1. If running in Next.js, omit "/public" from the path
         // 2. For legacy instances, we include "/public" as part of the path
-        const basePath =
-          typeof window !== 'undefined'
-            ? `/geo-data/states/`
-            : `${process.env.PUBLIC_URL ?? ''}/public/geo-data/states/`;
+        const basePath = isNextJs()
+          ? `/geo-data/states/`
+          : `${process.env.PUBLIC_URL ?? ''}/public/geo-data/states/`;
 
         const res = await axios.get(`${basePath}${selectedState}.geojson`, {
           signal: abortController.signal

--- a/app/scripts/utils/utils.ts
+++ b/app/scripts/utils/utils.ts
@@ -95,3 +95,11 @@ export function composeVisuallyDisabled(
 export function checkEnvFlag(value?: string): boolean {
   return (value ?? '').toLowerCase() === 'true';
 }
+
+/**
+ * Helper to detect if code is running in a Next.js environment
+ * by checking for Next.js-specific 'next' property on window.
+ * Will return false on server-side and in non-Next.js environments
+ * @returns boolean indicating if running in Next.js
+ */
+export const isNextJs = () => 'next' in window;


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1259
**Related Next.js PR for testing:** https://github.com/developmentseed/next-veda-ui/pull/23

### Description of Changes
- Added new `isNextJs()` util function to detect Next.js environments
- Adjust the AOI preset path to use the new util for setting the correct path to the assets
- Persist backwards compatibility for legacy instances that require the `/public/` path prefix
- Removed redundant comments

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
Please test in both repositories:

veda-ui:

1. Using the preview deployment, check that preset AOIs load correctly when selecting different states
2. Test locally to confirm the same functionality
3. Optional: Check in a legacy instance (e.g. GHG Center) that AOIs still load with the /public/ prefix

In next-veda-ui:

1. Using the [preview deployment](https://deploy-preview-23--veda-ui-next-test.netlify.app/exploration), check that preset AOIs load correctly when selecting different states
2. Test locally to confirm the same functionality works