### PR TITLE
fix: Update mappings to system tokens instead of theme tokens

### DIFF
--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -18,5 +18,7 @@
     'desktop': false
   ),
   $theme-font-type-serif: baseFontFamily,
-  $theme-font-type-sans: baseFontFamily
+  $theme-font-type-sans: baseFontFamily,
+  $theme-color-base-darkest: 'gray-cool-80',
+  $theme-color-base-ink: 'gray-cool-90'
 );

--- a/app/scripts/styles/_veda-ui-theme-vars.scss
+++ b/app/scripts/styles/_veda-ui-theme-vars.scss
@@ -3,7 +3,7 @@
 @use 'uswds-core/src/styles/functions/units' as spacing;
 
 /*********** VEDAUI THEME PALETTE ***********/
-// These map to the veda defined styles between https://www.figma.com/design/5mclPTReHcRIzKbJm8YA6a/VEDA---USWDS?node-id=139-14&node-type=canvas&t=7Qa02mMKUgBy5Qho-0
+// These references map to the veda defined styles between https://www.figma.com/design/5mclPTReHcRIzKbJm8YA6a/VEDA---USWDS?node-id=139-14&node-type=canvas&t=7Qa02mMKUgBy5Qho-0
 // and uswds found at https://designsystem.digital.gov/design-tokens/
 
 // TYPOGRAPHY
@@ -20,12 +20,12 @@ $veda-uswds-fontweight-bold: utils.font-weight('bold');
 $veda-uswds-fontweight-semibold: utils.font-weight('semibold');
 
 // COLORS
-$veda-uswds-color-primary-darker: utils.color('primary-darker');
-$veda-uswds-color-secondary: utils.color('secondary');
-$veda-uswds-color-base-dark: utils.color('base-dark');
-$veda-uswds-color-base-darkest: utils.color('base-darkest');
-$veda-uswds-color-base-light: utils.color('base-light');
-$veda-uswds-color-base-ink: utils.color('ink');
+$veda-uswds-color-primary-darker: utils.color('blue-warm-80v');
+$veda-uswds-color-secondary: utils.color('red-50');
+$veda-uswds-color-base-dark: utils.color('gray-cool-60');
+$veda-uswds-color-base-darkest: utils.color('gray-cool-80'); // re-mapped, theme-token 'base-darkest' originally mapped to 'gray-90'
+$veda-uswds-color-base-light: utils.color('gray-cool-30');
+$veda-uswds-color-base-ink: utils.color('gray-cool-90'); // re-mapped, theme-token 'ink' originally mapped to 'gray-90'
 
 // SPACING
 $veda-uswds-spacing-5: spacing.units(0.5);


### PR DESCRIPTION
### Description of Changes
I've updated our sass variable references to map directly to system tokens instead of theme tokens because of what was discussed during USWDS sync today to match the mappings in the [figma](https://www.figma.com/design/5mclPTReHcRIzKbJm8YA6a/VEDA---USWDS?node-id=139-14&node-type=canvas&t=cCPonU2ATOcjfhjr-0). But i'm indifferent to these changes and have no strong opinions to whether or not they map to the theme or system tokens.

That is because whether our references map to the [theme](https://designsystem.digital.gov/design-tokens/color/theme-tokens/) or [system](https://designsystem.digital.gov/design-tokens/color/system-tokens/) tokens, it is the same outcome. BUT we do need to know what theme tokens are RE-MAPPED to different system token values instead of their defaults because we should still make that update in the settings file.

For example, if our reference of theme `base-darkest` is re-mapped to a different system token value - any components used out of the box from USWDS that uses theme token color `base-darkest` should also be re-mapped. And then because we forward `@forward 'uswds-theme';` in the `theme-vars` file, it would get that update in time. Which is why i'm indifferent to these changes.

Any strong opinions / thoughts about this @hanbyul-here @dzole0311 @AliceR ? cc @faustoperez 

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
