### PR TITLE
fix: Add secondary footer content to footer config

### DIFF
--- a/app/scripts/components/common/page-footer/index.tsx
+++ b/app/scripts/components/common/page-footer/index.tsx
@@ -117,13 +117,12 @@ export default function PageFooter({
               <a id='logo-container-link' href='#'>
                 {logoSvg as JSX.Element}
                 <span className='footer-text'>
-                  NASA EarthData 2024 • v0.17.0
-                  {/* {version} */}
+                  {secondarySection.division} • {secondarySection.version}
                 </span>
               </a>
             </div>
             <div className='grid-col-4 footer-text grid-gap-6 flex-justify-end'>
-              <span>NASA Official: </span>
+              <span>{secondarySection.title}: </span>
               <a
                 key={secondarySection.type}
                 href={`mailto:${secondarySection.to}`}
@@ -132,7 +131,7 @@ export default function PageFooter({
                   className='margin-right-1 width-205 height-auto position-relative'
                   id='mail_icon'
                 />
-                {secondarySection.title}
+                {secondarySection.name}
               </a>
             </div>
           </div>

--- a/app/scripts/components/common/page-header/default-config.ts
+++ b/app/scripts/components/common/page-header/default-config.ts
@@ -71,10 +71,12 @@ let defaultSubNavItems: (
 
 const defaultFooterSettings = {
   secondarySection: {
-    id: 'email test',
-    title: 'email test',
-    to: '/data-catalog',
-    type: 'Email'
+    division: 'NASA EarthData 2024',
+    version: 'BETA VERSION',
+    title: 'NASA Official',
+    name: 'Manil Maskey',
+    to: 'test@example.com',
+    type: 'email'
   },
   returnToTop: true
 };

--- a/mock/veda.config.js
+++ b/mock/veda.config.js
@@ -1,8 +1,5 @@
 const dotEnvConfig = require('dotenv').config();
 const { parsed: config } = dotEnvConfig;
-function checkEnvFlag(value) {
-  return (value ?? '').toLowerCase() === 'true';
-}
 
 let mainNavItems = [
   {
@@ -53,9 +50,11 @@ let mainNavItems = [
 
 let footerSettings = {
   secondarySection: {
-    id: 'stories',
-    title: 'email test',
-    to: '/data-catalog',
+    division: 'NASA EarthData 2024',
+    version: process.env.APP_VERSION ?? 'BETA VERSION',
+    title: 'NASA Official',
+    name: 'Manil Maskey',
+    to: 'test@example.com',
     type: 'email'
   },
   returnToTop: true

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -285,19 +285,25 @@ declare module 'veda' {
     to: string;
     type: 'internalLink';
   }
+
   interface ExternalNavLink {
     id: string;
     title: string;
     href: string;
     type: 'externalLink';
   }
+
   type NavLinkItem = ExternalNavLink | InternalNavLink;
+
   export interface SecondarySection {
-    id: string;
+    division: string;
+    version: string;
     title: string;
+    name: string;
     to: string;
     type: string;
   }
+
   export interface FooterSettings {
     secondarySection: SecondarySection;
     returnToTop: boolean;


### PR DESCRIPTION
I am adding some more fields to the secondary section in the footer section, in order to have any text content configurable: Added `division`, `version`, and `name`, repurposed `title`. 

I'd be curious to know how other instances might use and configure the footer, this could better inform naming decisions (e.g. `division`?). 