### PR TITLE
fix(usePathname): prevent duplication of subpath in pathname

### DIFF
--- a/app/scripts/utils/use-pathname.ts
+++ b/app/scripts/utils/use-pathname.ts
@@ -13,14 +13,18 @@ import { useEffect, useState } from 'react';
  */
 export const usePathname = () => {
   const [pathname, setPathname] = useState(
-    typeof window !== 'undefined' ? window.location.pathname : ''
+    typeof window !== 'undefined'
+      ? window.location.pathname.replace(process.env.PUBLIC_URL ?? '', '')
+      : ''
   );
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
     const updatePathname = () => {
-      setPathname(window.location.pathname);
+      setPathname(
+        window.location.pathname.replace(process.env.PUBLIC_URL ?? '', '')
+      );
     };
 
     // Listen to popstate events (back/forward navigation)

--- a/app/scripts/utils/use-pathname.ts
+++ b/app/scripts/utils/use-pathname.ts
@@ -1,5 +1,20 @@
 import { useEffect, useState } from 'react';
 
+const appPathname = (() => {
+  try {
+    const publicUrl = process.env.PUBLIC_URL;
+    if (!publicUrl || typeof publicUrl !== 'string') return '';
+
+    // Use base URL fallback
+    const url = new URL(publicUrl, window.location.origin);
+
+    // Remove trailing slash if present
+    return url.pathname.replace(/\/$/, '');
+  } catch {
+    return '';
+  }
+})();
+
 /**
  * usePathname
  * *
@@ -14,7 +29,7 @@ import { useEffect, useState } from 'react';
 export const usePathname = () => {
   const [pathname, setPathname] = useState(
     typeof window !== 'undefined'
-      ? window.location.pathname.replace(process.env.PUBLIC_URL ?? '', '')
+      ? window.location.pathname.replace(appPathname, '')
       : ''
   );
 
@@ -22,9 +37,7 @@ export const usePathname = () => {
     if (typeof window === 'undefined') return;
 
     const updatePathname = () => {
-      setPathname(
-        window.location.pathname.replace(process.env.PUBLIC_URL ?? '', '')
-      );
+      setPathname(window.location.pathname.replace(appPathname, ''));
     };
 
     // Listen to popstate events (back/forward navigation)


### PR DESCRIPTION
**Related Ticket:** #1332

### Description of Changes

When using `usePathname()` hook, strip the application pathname to avoid duplicating it in generated links. 

### Validation / Testing

App is running from the root path:

- Make sure `PUBLIC_URL` is undefined in environment files
- Start the app with `yarn dev`, visit http://localhost:9000/data-catalog
- Clicking on the cards takes to the correct page

Apps is running from a subpath:

- Set `PUBLIC_URL=/subpath` in the environment file
- Start the app with `yarn dev`, visit http://localhost:9000/subpath/data-catalog
- Card links are correct

