### PR TITLE
fix: Menu Drop down

### DIFF
--- a/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
+++ b/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
@@ -12,6 +12,11 @@ export const createDynamicNavMenuList = (
   isOpen?: boolean[],
   setIsOpen?: SetState<boolean[]>
 ): JSX.Element[] => {
+  const setDropDownState = () => {
+    if (isOpen !== undefined && setIsOpen !== undefined) {
+      return setIsOpen(() => isOpen.fill(false));
+    }
+  };
   return navItems.map((item, index) => {
     switch (item.type) {
       case NavItemType.DROPDOWN:
@@ -23,7 +28,8 @@ export const createDynamicNavMenuList = (
               isOpen,
               setIsOpen,
               index,
-              linkProperties
+              linkProperties,
+              setDropDownState
             }}
           />
         );
@@ -32,10 +38,15 @@ export const createDynamicNavMenuList = (
         return <NavItemInternalLink {...{ item, linkProperties }} />;
 
       case NavItemType.EXTERNAL_LINK:
-        return <NavItemExternalLink item={item} />;
+        return (
+          <NavItemExternalLink
+            item={item}
+            setDropDownState={setDropDownState}
+          />
+        );
 
       case NavItemType.ACTION:
-        return <NavItemCTA item={item} />;
+        return <NavItemCTA item={item} setDropDownState={setDropDownState} />;
 
       default:
         return <></>;

--- a/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
+++ b/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
@@ -12,11 +12,6 @@ export const createDynamicNavMenuList = (
   isOpen?: boolean[],
   setIsOpen?: SetState<boolean[]>
 ): JSX.Element[] => {
-  const setDropDownState = () => {
-    if (isOpen !== undefined && setIsOpen !== undefined) {
-      return setIsOpen(() => isOpen.fill(false));
-    }
-  };
   return navItems.map((item, index) => {
     switch (item.type) {
       case NavItemType.DROPDOWN:
@@ -28,8 +23,7 @@ export const createDynamicNavMenuList = (
               isOpen,
               setIsOpen,
               index,
-              linkProperties,
-              setDropDownState
+              linkProperties
             }}
           />
         );
@@ -38,15 +32,10 @@ export const createDynamicNavMenuList = (
         return <NavItemInternalLink {...{ item, linkProperties }} />;
 
       case NavItemType.EXTERNAL_LINK:
-        return (
-          <NavItemExternalLink
-            item={item}
-            setDropDownState={setDropDownState}
-          />
-        );
+        return <NavItemExternalLink item={item} />;
 
       case NavItemType.ACTION:
-        return <NavItemCTA item={item} setDropDownState={setDropDownState} />;
+        return <NavItemCTA item={item} />;
 
       default:
         return <></>;

--- a/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
+++ b/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
@@ -12,6 +12,7 @@ interface NavDropDownButtonProps {
   setIsOpen: SetState<boolean[]>;
   index: number;
   linkProperties: LinkProperties;
+  setDropDownState: () => void;
 }
 
 export const NavDropDownButton = ({
@@ -19,7 +20,8 @@ export const NavDropDownButton = ({
   isOpen,
   setIsOpen,
   index,
-  linkProperties
+  linkProperties,
+  setDropDownState
 }: NavDropDownButtonProps) => {
   const onToggle = (index: number, setIsOpen: SetState<boolean[]>): void => {
     setIsOpen((prevIsOpen) => {
@@ -47,6 +49,7 @@ export const NavDropDownButton = ({
         items={submenuItems}
         isOpen={isOpen[index]}
         id={`${item.id}-dropdown`}
+        onClick={setDropDownState()}
       />
     </React.Fragment>
   );

--- a/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
+++ b/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { USWDSNavDropDownButton } from '../../uswds/header/nav-drop-down-button';
 import { USWDSMenu } from '../../uswds/header/menu';
 import { DropdownNavLink } from '../types';
 import { createDynamicNavMenuList } from './create-dynamic-nav-menu-list';
 import { SetState } from '$types/aliases';
 import { LinkProperties } from '$types/veda';
+import { useClickOutside } from '$utils/use-click-outside';
 
 interface NavDropDownButtonProps {
   item: DropdownNavLink;
@@ -12,7 +13,6 @@ interface NavDropDownButtonProps {
   setIsOpen: SetState<boolean[]>;
   index: number;
   linkProperties: LinkProperties;
-  setDropDownState: () => void;
 }
 
 export const NavDropDownButton = ({
@@ -20,8 +20,7 @@ export const NavDropDownButton = ({
   isOpen,
   setIsOpen,
   index,
-  linkProperties,
-  setDropDownState
+  linkProperties
 }: NavDropDownButtonProps) => {
   const onToggle = (index: number, setIsOpen: SetState<boolean[]>): void => {
     setIsOpen((prevIsOpen) => {
@@ -34,11 +33,20 @@ export const NavDropDownButton = ({
       return newIsOpen;
     });
   };
-
+  const handleClickOutside = useCallback(() => {
+    if (isOpen[index]) {
+      setIsOpen((prevIsOpen) => {
+        const newIsOpen = [...prevIsOpen];
+        newIsOpen[index] = false;
+        return newIsOpen;
+      });
+    }
+  }, [index, isOpen, setIsOpen]);
+  const dropdownRef = useClickOutside(handleClickOutside);
   const submenuItems = createDynamicNavMenuList(item.children, linkProperties);
 
   return (
-    <React.Fragment key={item.id}>
+    <div key={item.id} ref={dropdownRef}>
       <USWDSNavDropDownButton
         onToggle={() => onToggle(index, setIsOpen)}
         menuId={item.title}
@@ -49,8 +57,7 @@ export const NavDropDownButton = ({
         items={submenuItems}
         isOpen={isOpen[index]}
         id={`${item.id}-dropdown`}
-        onClick={setDropDownState()}
       />
-    </React.Fragment>
+    </div>
   );
 };

--- a/app/scripts/utils/use-click-outside.ts
+++ b/app/scripts/utils/use-click-outside.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react';
+export const useClickOutside = (onClose: () => void) => {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('click', handleClickOutside, true);
+    return () =>
+      document.removeEventListener('click', handleClickOutside, true);
+  }, [onClose]);
+  return ref;
+};


### PR DESCRIPTION
Close the new USWDS page header dropdown when clicking outside of it
[#1296](https://github.com/NASA-IMPACT/veda-ui/issues/1296)

### Validation / Testing
Open one of the two drop down options, click on another link on the page. When the browser navigates to the new page that original dropdown menu should be closed. 
