### PR TITLE
chore: review commit hooks

### DIFF
--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,0 +1,5 @@
+if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
+  process.exit(0)
+}
+const husky = (await import('husky')).default
+console.log(husky())

--- a/.husky/install.mjs
+++ b/.husky/install.mjs
@@ -1,5 +1,0 @@
-if (process.env.NODE_ENV === 'production' || process.env.CI === 'true') {
-  process.exit(0)
-}
-const husky = (await import('husky')).default
-console.log(husky())

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,2 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 yarn lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 yarn ts-check
 yarn test
 yarn test:e2e

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
 yarn ts-check
 yarn test
-yarn test:e2e

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
-yarn lint-staged
+yarn ts-check
+yarn test
+yarn test:e2e

--- a/package.json
+++ b/package.json
@@ -259,6 +259,5 @@
     "$context": "~/app/scripts/context",
     "$data-layer": "~/app/scripts/data-layer",
     "$test": "~/test"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "yarn lint:scripts && yarn lint:css",
     "lint:scripts": "eslint app/scripts/",
     "lint:css": "stylelint 'app/styles/**/**' 'app/scripts/**/*.(js|ts|tsx|jsx)'",
+    "postinstall": "husky",
     "ts-check": "yarn tsc --noEmit --skipLibCheck",
     "test": "jest",
     "pretest:e2e": "node test/playwright/generateTestData.js",
@@ -78,6 +79,8 @@
     "@types/styled-components": "^5.1.26",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
+    "@uswds/compile": "^1.1.0",
+    "@uswds/uswds": "^3.8.1",
     "babel-jest": "^29.7.0",
     "babel-plugin-styled-components": "^1.13.3",
     "buffer": "^6.0.3",
@@ -100,7 +103,7 @@
     "fs-extra": "^10.0.0",
     "gray-matter": "^4.0.3",
     "gulp": "^4.0.2",
-    "husky": "^8.0.0",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-css-modules-transform": "^4.3.0",
     "jest-environment-jsdom": "^29.7.0",
@@ -123,8 +126,6 @@
     "stylelint": "^16.10.0",
     "stylelint-config-recommended": "^14.0.1",
     "stylelint-config-standard-scss": "^13.1.0",
-    "@uswds/compile": "^1.1.0",
-    "@uswds/uswds": "^3.8.1",
     "ts-jest": "^29.2.5",
     "typescript": "4.8.4"
   },
@@ -161,6 +162,7 @@
     "@tanstack/react-query-devtools": "^4.3.9",
     "@tanstack/react-table": "^8.9.3",
     "@tippyjs/react": "^4.2.6",
+    "@trussworks/react-uswds": "^9.0.0",
     "@turf/area": "^6.5.0",
     "@turf/bbox": "^6.5.0",
     "@turf/bbox-polygon": "^6.5.0",
@@ -243,7 +245,6 @@
     "shpjs": "^4.0.4",
     "styled-components": "^5.3.3",
     "tippy.js": "^6.3.7",
-    "@trussworks/react-uswds": "^9.0.0",
     "use-deep-compare": "^1.1.0",
     "xlsx": "^0.18.5"
   },
@@ -258,5 +259,6 @@
     "$context": "~/app/scripts/context",
     "$data-layer": "~/app/scripts/data-layer",
     "$test": "~/test"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9653,10 +9653,10 @@ humps@^2.0.1:
   resolved "http://verdaccio.ds.io:4873/humps/-/humps-2.0.1.tgz#dd02ea6081bd0568dc5d073184463957ba9ef9aa"
   integrity sha1-3QLqYIG9BWjcXQcxhEY5V7qe+ao=
 
-husky@^8.0.0:
-  version "8.0.3"
-  resolved "http://verdaccio.ds.io:4873/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
-  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+husky@^9.1.7:
+  version "9.1.7"
+  resolved "http://verdaccio.ds.io:4873/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
 iconv-lite@0.6, iconv-lite@0.6.3:
   version "0.6.3"


### PR DESCRIPTION
**Related Ticket:** Close #1329 

### Description of Changes
It seems that there are some changes in both Husky and Yarn in how to make them play nicely together. Husky needs to be run once for each user before the package begins enforcing the git hooks.  When it does that, you should see a new directory `.husky/_`.   For `npm` this is done through a prepare script.  Yarn doesn't support this, so Husky recommends a `postinstall` script. https://typicode.github.io/husky/how-to.html#manual-setup

I've added that script, as well as added a pre-push hook to run the type check and unit tests.  That's easy to remove if contributors prefer pushing separate commits to fix/add tests, though. 

