### PR TITLE
fix(release): release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,21 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      VERSION_NUMBER: ${{ steps.git-release.outputs.VERSION_NUMBER }}
     steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            veda-ui
+            veda-config
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
       - name: git config
         run: |
           git config user.name "${GITHUB_ACTOR}"
@@ -36,24 +45,10 @@ jobs:
         run: yarn release  --ci --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  preview-build:
-    runs-on: ubuntu-latest
-    needs: "release"
-    steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PEM }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            veda-ui
-            veda-config
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{steps.generate-token.outputs.token}}
           repository: nasa-impact/veda-config
           event-type: update-version
-          client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": "${{ needs.release.outputs.VERSION_NUMBER || inputs.VERSION_NUMBER }}"}'
+          client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": "${{ steps.git-release.outputs.VERSION_NUMBER || inputs.VERSION_NUMBER }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ on:
 permissions:
   contents: write
 
+# This action requires a GitHub app with content write access installed 
+# to bypass the main branch  protection rule and dispatch the event to a different repo
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We need to check out the repo with github key so it can bypass the branch protection rule. I gave up separating jobs and just merged both of them into one this PR - so both jobs can have access to app token.
