### PR TITLE
chore: Include only lib folder when publishing, Add Dataset and Story data type to export

### DIFF
--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -22,6 +22,7 @@ import type {
   InternalNavLink,
   NavItemType
 } from '$components/common/page-header/types';
+import type { DatasetData, StoryData } from '$types/veda';
 
 import ExplorationAndAnalysis from '$components/exploration';
 import useTimelineDatasetAtom from '$components/exploration/hooks/use-timeline-dataset-atom';
@@ -80,6 +81,8 @@ export {
   NavItem,
   NavItemType,
   InternalNavLink,
+  DatasetData,
+  StoryData,
 
   // STATE
   timelineDatasetsAtom,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "module": "lib/module.js",
   "types": "lib/index.d.ts",
   "browserslist": "> 0.5%, last 2 versions, not dead",
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "serve": "NODE_ENV=development gulp serve",
     "build": "NODE_ENV=production gulp",


### PR DESCRIPTION
We are publishing everything in the folder which should not be necessary. Explicitly scope the folder to publish (`files` in `package.json`)

Also add more types to export (Dataset, Story) 
