### PR TITLE
fix: fix automatic release name

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -22,7 +22,7 @@
   },
   "github": {
     "release": true,
-    "releaseName": "V${version}",
+    "releaseName": "v${version}",
     "releaseNotes": null,
     "autoGenerate": true,
     "preRelease": false,


### PR DESCRIPTION
**Related Ticket:** #1347 

### Description of Changes
I don't think this is the reason why the release versioning was wrong, but it is a fix that needs to go in anyway. (All other places use small `v` for release)