### PR TITLE
Fix prop type for Map and Scrollytelling

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -36,7 +36,7 @@ import {
   getDatasetLayers
 } from '$components/exploration/data-utils-no-faux-module';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
-import { ProjectionOptions, VedaDatum, DatasetData } from '$types/veda';
+import { ProjectionOptions, VedaData, DatasetData } from '$types/veda';
 import { EnvConfigContext } from '$context/env-config';
 
 export const mapHeight = '32rem';
@@ -111,7 +111,7 @@ function validateBlockProps(props: MapBlockProps) {
 }
 
 interface MapBlockProps {
-  datasets: VedaDatum<DatasetData>;
+  datasets: VedaData<DatasetData>;
   dateTime?: string;
   compareDateTime?: string;
   center?: [number, number];

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -37,7 +37,7 @@ import {
 import { Layer } from '$components/exploration/components/map/layer';
 import { MapLoading } from '$components/common/loading-skeleton';
 import {
-  type DatasetData as EADatasetData,
+  EADatasetDataLayer,
   DatasetStatus,
   VizDataset,
   VizDatasetSuccess
@@ -161,10 +161,10 @@ function useMapLayersFromChapters(
   const reconciledVizDatasets = uniqueLayerRefs.map(
     ({ datasetId, layerId }) => {
       const layers = datasets[datasetId]?.data.layers;
-
+      // @TECH-DEBT: We are casting which we shouldn't, look into types and clean up because this is masking bad typing issues
       const layer = layers?.find(
         (l) => l.id === layerId
-      ) as EADatasetData | null;
+      ) as EADatasetDataLayer | null;
 
       if (!layer) {
         throw new Error(

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -17,12 +17,8 @@ import { CollecticonCircleXmark } from '@devseed-ui/collecticons';
 
 import { MapRef } from 'react-map-gl';
 import { BlockErrorBoundary } from '..';
-import {
-  ChapterProps,
-  ScrollyChapter,
-  validateChapter
-} from './chapter';
-import { ProjectionOptions, VedaDatum } from '$types/veda';
+import { ChapterProps, ScrollyChapter, validateChapter } from './chapter';
+import { ProjectionOptions, VedaData } from '$types/veda';
 import { projectionDefault } from '$components/common/map/controls/map-options/projections';
 import { userTzDate2utcString, utcString2userTzDate } from '$utils/date';
 import { S_FAILED, S_SUCCEEDED } from '$utils/status';
@@ -41,11 +37,12 @@ import {
 import { Layer } from '$components/exploration/components/map/layer';
 import { MapLoading } from '$components/common/loading-skeleton';
 import {
-  DatasetData,
+  type DatasetData as EADatasetData,
   DatasetStatus,
   VizDataset,
   VizDatasetSuccess
 } from '$components/exploration/types.d.ts';
+import { DatasetData } from '$types/veda';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
 import {
   formatSingleDate,
@@ -135,7 +132,7 @@ function getChapterLayerKey(ch: ScrollyChapter) {
 function useMapLayersFromChapters(
   chList: ScrollyChapter[],
   envApiStacEndpoint: string,
-  datasets: VedaDatum<DatasetData>,
+  datasets: VedaData<DatasetData>
 ): [ResolvedScrollyMapLayer[], string[]] {
   // The layers are unique based on the dataset, layer id and datetime.
   // First we filter out any scrollytelling block that doesn't have layer.
@@ -165,7 +162,9 @@ function useMapLayersFromChapters(
     ({ datasetId, layerId }) => {
       const layers = datasets[datasetId]?.data.layers;
 
-      const layer = layers?.find((l) => l.id === layerId) as DatasetData | null;
+      const layer = layers?.find(
+        (l) => l.id === layerId
+      ) as EADatasetData | null;
 
       if (!layer) {
         throw new Error(
@@ -478,7 +477,7 @@ function Scrollytelling(props) {
 
 Scrollytelling.propTypes = {
   children: T.node,
-  datasets: T.any,
+  datasets: T.any
 };
 
 export function ScrollytellingBlock(props) {

--- a/app/scripts/components/common/map/utils.ts
+++ b/app/scripts/components/common/map/utils.ts
@@ -17,7 +17,7 @@ import { userTzDate2utcString } from '$utils/date';
 import { validateRangeNum } from '$utils/utils';
 import {
   DatasetStatus,
-  DatasetData,
+  EADatasetDataLayer,
   VizDataset
 } from '$components/exploration/types.d.ts';
 import { fixAntimeridian } from '$utils/antimeridian';
@@ -282,7 +282,7 @@ export function getZoomFromBbox(bbox: BBox): number {
   }
 }
 
-export function reconcileVizDataset(dataset: DatasetData): VizDataset {
+export function reconcileVizDataset(dataset: EADatasetDataLayer): VizDataset {
   return {
     status: DatasetStatus.SUCCESS,
     data: dataset,

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -20,6 +20,7 @@ import {
 import { utcString2userTzDate } from '$utils/date';
 import {
   DatasetLayer,
+  VedaData,
   VedaDatum,
   DatasetData,
   DatasetLayerType
@@ -28,27 +29,27 @@ import {
 // @NOTE: All fns from './date-utils` should eventually move here to get rid of their faux modules dependencies
 // `./date-utils` to be deprecated!!
 
-export const getDatasetLayers = (datasets: VedaDatum<DatasetData>) =>
+export const getDatasetLayers = (datasets: VedaData<DatasetData>) =>
   Object.values(datasets).flatMap((dataset: VedaDatum<DatasetData>) => {
-    return dataset!.data.layers.map((l) => ({
+    return dataset.data.layers.map((l) => ({
       ...l,
       parentDataset: {
-        id: dataset!.data.id,
-        name: dataset!.data.name
+        id: dataset.data.id,
+        name: dataset.data.name
       }
     }));
   });
 
-  export const getLayersFromDataset = (datasets: DatasetData[]) =>
-    Object.values(datasets).map((dataset: DatasetData) => {
-      return dataset!.layers.map((l) => ({
-        ...l,
-        parentDataset: {
-          id: dataset!.id,
-          name: dataset!.name
-        }
-      }));
-    });
+export const getLayersFromDataset = (datasets: DatasetData[]) =>
+  Object.values(datasets).map((dataset: DatasetData) => {
+    return dataset.layers.map((l) => ({
+      ...l,
+      parentDataset: {
+        id: dataset.id,
+        name: dataset.name
+      }
+    }));
+  });
 /**
  * Returns an array of metrics based on the given Dataset Layer configuration.
  * If the layer has metrics defined, it returns only the metrics that match the
@@ -66,6 +67,7 @@ function getInitialMetrics(data: DatasetLayer): DataMetric[] {
 
   const foundMetrics = metricsIds
     .map((metric: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return DATA_METRICS.find((m) => m.id === metric)!;
     })
     .filter(Boolean);
@@ -73,7 +75,7 @@ function getInitialMetrics(data: DatasetLayer): DataMetric[] {
   return foundMetrics;
 }
 
-function getInitialColorMap(dataset: DatasetLayer): string|undefined {
+function getInitialColorMap(dataset: DatasetLayer): string | undefined {
   return dataset.sourceParams?.colormap_name;
 }
 

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -90,7 +90,7 @@ export interface EnhancedDatasetLayer extends DatasetLayer {
   parentDataset: ParentDatset;
 }
 
-export interface DatasetData extends EnhancedDatasetLayer {
+export interface EADatasetDataLayer extends EnhancedDatasetLayer {
   isPeriodic: boolean;
   timeDensity: TimeDensity;
   domain: Date[];
@@ -145,7 +145,7 @@ export interface VizDatasetError {
 
 export interface VizDatasetSuccess {
   status: DatasetStatus.SUCCESS;
-  data: DatasetData;
+  data: EADatasetDataLayer;
   error: null;
   settings: DatasetSettings;
   meta?: DatasetMeta;


### PR DESCRIPTION
**Related Ticket:** #1324 

### Description of Changes
While contemplating on what @sandrahoang686  mentioned about the data proptype, I realized that our types are wrong for Map and Scrollytelling (And We have different types, but named same of `DatasetData` which we should address soon.) 

### Notes & Questions About Changes
Map and Scrollytellinglblock seems to expect the same shape of the dataset which is an object (`VedaData<DatasetData>` - am I missing anything?

