### PR TITLE
refactor(catalog): remove onCardNavigate callback from Catalog

### DIFF
--- a/app/scripts/components/common/catalog/catalog-card.tsx
+++ b/app/scripts/components/common/catalog/catalog-card.tsx
@@ -1,14 +1,22 @@
-import React from "react";
-import styled, { css } from "styled-components";
-import { CollecticonPlus, CollecticonTickSmall, iconDataURI } from "@devseed-ui/collecticons";
-import { glsp, themeVal } from "@devseed-ui/theme-provider";
-import { Card } from "../card";
-import { CardTopicsList } from "../card/styles";
-import TextHighlight from "../text-highlight";
+import React from 'react';
+import styled, { css } from 'styled-components';
+import {
+  CollecticonPlus,
+  CollecticonTickSmall,
+  iconDataURI
+} from '@devseed-ui/collecticons';
+import { glsp, themeVal } from '@devseed-ui/theme-provider';
+import { Card } from '../card';
+import { CardTopicsList } from '../card/styles';
+import TextHighlight from '../text-highlight';
 import { getDatasetDescription, getMediaProperty } from './utils';
-import { DatasetData, DatasetLayer } from "$types/veda";
-import { TAXONOMY_TOPICS, getAllTaxonomyValues, getTaxonomy } from "$utils/veda-data/taxonomies";
-import { Pill } from "$styles/pill";
+import { DatasetData, DatasetLayer } from '$types/veda';
+import {
+  TAXONOMY_TOPICS,
+  getAllTaxonomyValues,
+  getTaxonomy
+} from '$utils/veda-data/taxonomies';
+import { Pill } from '$styles/pill';
 
 interface CatalogCardProps {
   dataset: DatasetData;
@@ -89,14 +97,8 @@ const CardSelectable = styled(Card)<{
 `;
 
 export const CatalogCard = (props: CatalogCardProps) => {
-  const {
-    dataset,
-    layer,
-    searchTerm,
-    selectable,
-    selected,
-    onDatasetClick
-  } = props;
+  const { dataset, layer, searchTerm, selectable, selected, onDatasetClick } =
+    props;
 
   const topics = getTaxonomy(dataset, TAXONOMY_TOPICS)?.values;
   const allTaxonomyValues = getAllTaxonomyValues(dataset).map((v) => v.name);

--- a/app/scripts/components/common/catalog/catalog-card.tsx
+++ b/app/scripts/components/common/catalog/catalog-card.tsx
@@ -17,6 +17,7 @@ import {
   getTaxonomy
 } from '$utils/veda-data/taxonomies';
 import { Pill } from '$styles/pill';
+import { DATASETS_PATH } from '$utils/routes';
 
 interface CatalogCardProps {
   dataset: DatasetData;
@@ -115,6 +116,10 @@ export const CatalogCard = (props: CatalogCardProps) => {
     }
   };
 
+  const interactionProps = selectable
+    ? { onClick: handleClick }
+    : { to: `${DATASETS_PATH}/${dataset.id}` };
+
   return (
     <CardSelectable
       cardType='horizontal-info'
@@ -122,7 +127,7 @@ export const CatalogCard = (props: CatalogCardProps) => {
       selectable={selectable}
       tagLabels={allTaxonomyValues}
       linkLabel='View dataset'
-      onClick={handleClick}
+      {...interactionProps}
       title={
         <TextHighlight value={searchTerm} disabled={searchTerm.length < 3}>
           {title}

--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -35,7 +35,6 @@ export interface CatalogContentProps {
   search: string;
   taxonomies: Record<string, string[]>;
   onAction: (action: FilterActions, value?: any) => void;
-  onCardNavigate?: (path: string) => void;
 }
 
 const DEFAULT_SORT_OPTION = 'asc';
@@ -72,7 +71,6 @@ function CatalogContent({
   search,
   taxonomies,
   onAction,
-  onCardNavigate
 }: CatalogContentProps) {
   const [exclusiveSourceSelected, setExclusiveSourceSelected] = useState<string | null>(null);
   const isSelectable = selectedIds !== undefined;
@@ -278,7 +276,6 @@ function CatalogContent({
                   <CatalogCard
                     dataset={d}
                     searchTerm={search}
-                    {...(onCardNavigate && {onDatasetClick: () => onCardNavigate(getDatasetPath(d, pathname))})}
                   />
                 </li>
               ))}

--- a/app/scripts/components/common/catalog/index.tsx
+++ b/app/scripts/components/common/catalog/index.tsx
@@ -41,13 +41,11 @@ export interface CatalogViewProps {
     taxonomies: Record<string, string[]> | Record<string, never>,
     onAction: () => void,
   } | any;
-  onCardNavigate?: (path: string) => void;
 }
 
 function CatalogView({
   datasets,
   onFilterChanges,
-  onCardNavigate
 }: CatalogViewProps) {
 
   const { headerHeight } = useSlidingStickyHeaderProps();
@@ -70,7 +68,6 @@ function CatalogView({
         search={search}
         taxonomies={taxonomies}
         onAction={onAction}
-        onCardNavigate={onCardNavigate}
       />
     </CatalogWrapper>
   );

--- a/app/scripts/components/data-catalog/container.tsx
+++ b/app/scripts/components/data-catalog/container.tsx
@@ -20,11 +20,6 @@ import { useFiltersWithQS } from '$components/common/catalog/controls/hooks/use-
 export default function DataCatalogContainer() {
   const allDatasets = getAllDatasetsProps(veda_faux_module_datasets);
   const controlVars = useFiltersWithQS();
-  const navigate = useNavigate();
-
-  const handleCardNavigation = (path: string) => {
-    navigate(path);
-  };
 
   return (
     <PageMainContent>
@@ -40,7 +35,6 @@ export default function DataCatalogContainer() {
       <CatalogView
         datasets={allDatasets}
         onFilterChanges={() => controlVars}
-        onCardNavigate={handleCardNavigation}
       />
     </PageMainContent>
   );


### PR DESCRIPTION
**Related Tickets:** (contributes to) #1344 

### Description of Changes

- Format `catalog-card` file
- Remove `onCardNavigate` callback
- Pass `onClick` and `to` acording to new type definitions

### Notes & Questions About Changes

This is based on the refactored Card component in #1365, which introduces a `to` property to render the card as a link.

### Validation / Testing

Behaviour of DatasetSelectorModal in E&A should remaing unaffected, Catalog view cards are rendered as links.

This is ready for review.