### PR TITLE
chore: Update the gulp task for copying USWDS assets

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -72,8 +72,15 @@ function copyNetlifyCMS() {
   return gulp.src('admin/**/*').pipe(gulp.dest('dist/admin'));
 }
 
+// Copy the USWDS image assets from node_modules to the dist directory.
+// This ensures all USWDS images are available for the instances during deployment.
 function copyUswdsImages() {
-  return uswds.copyImages();
+  return gulp
+    .src([
+      path.join(__dirname, 'node_modules/@uswds/uswds/dist/img/**/*'),
+      'node_modules/@uswds/uswds/dist/img/**/*'
+    ])
+    .pipe(gulp.dest('dist/img'));
 }
 
 // Task that uses Parcel to build the library version of the VEDA UI.


### PR DESCRIPTION
**Related Ticket:** closes https://github.com/NASA-IMPACT/veda-ui/issues/1373

### Description of Changes
The gulp task for copying the USWDS assets during deployment was not copying the assets at all. I've updated the task by replacing the generic `uswds.copyImages()` function with an explicit gulp task

### Notes & Questions About Changes
- The change follows the same pattern as other copy tasks in our gulpfile
- No other configuration changes are needed as the task is already used into the existing build process

### Validation / Testing
- In the deploy preview for veda-ui and veda-config-ghg (PR with deployment: https://github.com/US-GHG-Center/veda-config-ghg/pull/698), verify that USWDS icons appear correctly in the `SiteAlert` or `Banner` components
- Check if the icons appear when running the veda-ui locally
