### PR TITLE
chore: Expose Audience and ValueProposition for template instance home

### DIFF
--- a/app/scripts/components/home/value-propostion.tsx
+++ b/app/scripts/components/home/value-propostion.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { getString } from 'veda';
-
 import imgVP01 from '../../../graphics/layout/vp-01-illu.png';
 import imgVP02 from '../../../graphics/layout/vp-02-illu.png';
 import imgVP03 from '../../../graphics/layout/vp-03-illu.png';
@@ -90,8 +88,8 @@ function ValueProposition() {
           <ContentBlockProseAlt>
             <h3>Science communication platform</h3>
             <p>
-              Share your {getString('stories').other.toLocaleLowerCase()} with
-              others through the VEDA Dashboard. Submit a{' '}
+              Share your data stories with others through the VEDA Dashboard.
+              Submit a{' '}
               <a
                 href='#'
                 onClick={(e) => {

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -34,9 +34,11 @@ import {
   datasetLayersAtom,
   externalDatasetsAtom
 } from '$components/exploration/atoms/datasetLayers';
+import Audience from '$components/home/audience';
 
 // Include only the custom stylings for the VEDA components into the library build
 import './styles/veda-components.scss';
+import ValueProposition from '$components/home/value-propostion';
 
 // Adding .last property to array
 /* eslint-disable-next-line fp/no-mutating-methods */
@@ -74,6 +76,8 @@ export {
   StoriesHubContent,
   ExplorationAndAnalysis,
   DatasetSelectorModal,
+  Audience,
+  ValueProposition,
 
   // HOOKS
   useTimelineDatasetAtom,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "lint": "yarn lint:scripts && yarn lint:css",
     "lint:scripts": "eslint app/scripts/",
     "lint:css": "stylelint 'app/styles/**/**' 'app/scripts/**/*.(js|ts|tsx|jsx)'",
-    "postinstall": "husky",
     "ts-check": "yarn tsc --noEmit --skipLibCheck",
     "test": "jest",
     "pretest:e2e": "node test/playwright/generateTestData.js",


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1386
**Related PRs:** https://github.com/developmentseed/next-veda-ui/pull/37

This is just to have template instance match current homepage as it was originally a part of the [Add Content MVP PR](https://github.com/developmentseed/next-veda-ui/pull/22). There will be other iterations as it isn't the final design but this is to have homepage match as much as possible temporily.

**`v5.11.5-1386.1` was built off of this**

### Description of Changes
* Exposes the Audience and ValueProposition components
* Remove husky line based off this [comment](https://github.com/NASA-IMPACT/veda-ui/pull/1345/files#r1917147518). This line makes `yarn install` fail in nextJs build cc @stephenkilbourn 

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
* Make sure homepage renders as supposed to and everything clickable is working as supposed to (Feedback forum and cards)
