### PR TITLE
fix(feature-slider): prevent openning links after dragging

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -401,7 +401,7 @@ function CardComponent(
     cardType,
     className,
     linkLabel,
-    onCardClickCapture,
+    onClickCapture: onCardClickCapture,
     children: CardContent
   };
 


### PR DESCRIPTION
**Related Ticket:** Fix #1376

### Description of Changes

Fixed the property name passed to `<ElementInteractive/>`.

### Notes & Questions About Changes

We need to migrate `<ElementInteractive/>` to TypeScript. It took me some time to identify the typo since the property isn't referenced in PropTypes or documented in the JSDocs.

### Validation / Testing

1. Visit the data catalog
2. Drag cards from the 'Featured Datasets' section — the navigation does not occur
3. Click on a card — it navigates to the dataset as expected

This is ready for review.