### PR TITLE
fix: release log generation

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -2,15 +2,7 @@
   "hooks": {
     "after:release": "echo \"VERSION_NUMBER=v${version}\" >> \"$GITHUB_OUTPUT\" "
   },
-  "plugins": {
-    "@release-it/conventional-changelog": {
-      "preset": {
-        "name": "conventionalcommits"
-      }
-    }
-  },
   "git": {
-    "changelog": "git log --pretty=format:\"* %s (%h)\" ${from}...${to}",
     "commitMessage": "chore(release): update to version v${version}",
     "tagName": "v${version}",
     "tagAnnotation": "Release v${version}",
@@ -23,9 +15,30 @@
   "github": {
     "release": true,
     "releaseName": "v${version}",
-    "releaseNotes": null,
     "autoGenerate": false,
     "preRelease": false,
     "draft": false
+  },
+  "plugins": {
+    "@release-it/conventional-changelog": {
+      "infile": "CHANGELOG.md",
+      "preset": {
+        "name": "conventionalcommits",
+        "header": "",
+        "type": [
+          {
+            "type": "feat",
+            "section": "Features"
+          },
+          {
+            "type": "fix",
+            "section": "Bug Fixes"
+          }
+        ],
+        "parserOpts": {
+          "mergePattern": "^(feat|fix|docs|test|ci|refactor|chore|revert)"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
### Description of Changes
Tweak configuration of release-it for better changelog generation

### Notes & Questions About Changes
This config will generate a changelog like this:
<img width="1414" alt="Screenshot 2025-01-21 at 3 41 56 PM" src="https://github.com/user-attachments/assets/01f24c70-efac-4b69-9f6d-c12432f19373" />

We can't really detail the sections per type because of the error that comes from the plugin: https://github.com/release-it/conventional-changelog/issues/110

### Validation / Testing
😌 put trust on me this time (or create a branch off from this one and trigger release action.)
