### PR TITLE
refactor(card): Remove link props from CardSourcesList

### DIFF
--- a/app/scripts/components/common/card-sources-list.tsx
+++ b/app/scripts/components/common/card-sources-list.tsx
@@ -22,11 +22,12 @@ const SourcesUl = styled.ul`
 
 interface SourcesListProps {
   sources?: TaxonomyItem[];
+  onSourceClick?: (sourceId: string) => void;
   rootPath?: string;
 }
 
 export function CardSourcesList(props: SourcesListProps) {
-  const { sources, rootPath } = props;
+  const { sources, rootPath, onSourceClick } = props;
 
   const { Link } = useVedaUI();
 
@@ -58,6 +59,12 @@ export function CardSourcesList(props: SourcesListProps) {
                   Source: source.id
                 })
               )}`}
+              onClick={(e) => {
+                if (onSourceClick) {
+                  e.preventDefault();
+                  onSourceClick(source.id);
+                }
+              }}
             >
               {source.name}
             </Link>

--- a/app/scripts/components/common/card-sources-list.tsx
+++ b/app/scripts/components/common/card-sources-list.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { listReset } from '@devseed-ui/theme-provider';
 import { useVedaUI } from '$context/veda-ui-provider';
-import { LinkProperties, TaxonomyItem } from '$types/veda';
+import { TaxonomyItem } from '$types/veda';
 
 import { FilterActions } from '$components/common//catalog/utils';
 

--- a/app/scripts/components/common/card-sources.tsx
+++ b/app/scripts/components/common/card-sources.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
 import { listReset } from '@devseed-ui/theme-provider';
+import { useVedaUI } from '$context/veda-ui-provider';
 import { LinkProperties, TaxonomyItem } from '$types/veda';
+
 import { FilterActions } from '$components/common//catalog/utils';
 
 const SourcesUl = styled.ul`
@@ -20,18 +22,18 @@ const SourcesUl = styled.ul`
 
 interface SourcesListProps {
   sources?: TaxonomyItem[];
-  onSourceClick?: (v: string) => void;
   rootPath?: string;
-  linkProperties?: LinkProperties;
 }
 
 export function CardSourcesList(props: SourcesListProps) {
-  const { sources, onSourceClick, linkProperties, rootPath } = props;
-  const { LinkElement, pathAttributeKeyName } = linkProperties as { LinkElement: React.ElementType, pathAttributeKeyName: string };
+  const { sources, rootPath } = props;
+
+  const { Link } = useVedaUI();
+
   if (!sources?.length) return null;
 
   // No link rendering
-  if (!rootPath || !onSourceClick) {
+  if (!rootPath) {
     return (
       <div>
         <span>By</span>{' '}
@@ -50,19 +52,15 @@ export function CardSourcesList(props: SourcesListProps) {
       <SourcesUl>
         {sources.map((source) => (
           <li key={source.id}>
-            <LinkElement
-              {...{[pathAttributeKeyName]:`${rootPath}?${FilterActions.TAXONOMY}=${encodeURIComponent(
+            <Link
+              to={`${rootPath}?${FilterActions.TAXONOMY}=${encodeURIComponent(
                 JSON.stringify({
                   Source: source.id
                 })
-              )}`}}
-              onClick={(e) => {
-                e.preventDefault();
-                onSourceClick(source.id);
-              }}
+              )}`}
             >
               {source.name}
-            </LinkElement>
+            </Link>
           </li>
         ))}
       </SourcesUl>

--- a/app/scripts/components/common/featured-slider-section.tsx
+++ b/app/scripts/components/common/featured-slider-section.tsx
@@ -125,7 +125,6 @@ function FeaturedSliderSection(props: FeaturedSliderSectionProps) {
                             <DatasetClassification dataset={d} />
                           )}
                           <CardSourcesList
-                            linkProperties={linkProperties}
                             sources={getTaxonomy(d, TAXONOMY_SOURCE)?.values}
                           />
                           <VerticalDivider variation='light' />

--- a/app/scripts/components/common/featured-slider-section.tsx
+++ b/app/scripts/components/common/featured-slider-section.tsx
@@ -4,7 +4,7 @@ import { DatasetData, StoryData, datasets, stories, getString } from 'veda';
 import { VerticalDivider } from '@devseed-ui/toolbar';
 import SmartLink from './smart-link';
 import PublishedDate from './pub-date';
-import { CardSourcesList } from './card-sources';
+import { CardSourcesList } from './card-sources-list';
 import { DatasetClassification } from './dataset-classification';
 import { getDescription, getMediaProperty } from './catalog/utils';
 import { Card } from '$components/common/card';

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -33,7 +33,7 @@ import TextHighlight from '$components/common/text-highlight';
 import Pluralize from '$utils/pluralize';
 import { Pill } from '$styles/pill';
 
-import { CardSourcesList } from '$components/common/card-sources';
+import { CardSourcesList } from '$components/common/card-sources-list';
 import {
   getTaxonomy,
   TAXONOMY_SOURCE,

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -148,7 +148,11 @@ export default function HubContent(props: HubContentProps) {
           out of {allStories.length}.
         </span>
         {isFiltering && (
-          <Button {...ButtonLinkProps} size='small' onClick={() => onAction(FilterActions.CLEAR)}>
+          <Button
+            {...ButtonLinkProps}
+            size='small'
+            onClick={() => onAction(FilterActions.CLEAR)}
+          >
             Clear filters <CollecticonXmarkSmall />
           </Button>
         )}
@@ -168,14 +172,6 @@ export default function HubContent(props: HubContentProps) {
                       <CardSourcesList
                         sources={getTaxonomy(d, TAXONOMY_SOURCE)?.values}
                         rootPath={pathname}
-                        linkProperties={linkProperties}
-                        onSourceClick={(id) => {
-                          onAction(FilterActions.TAXONOMY_MULTISELECT, {
-                            key: TAXONOMY_SOURCE,
-                            value: id
-                          });
-                          browseControlsHeaderRef.current?.scrollIntoView();
-                        }}
                       />
                       <VerticalDivider variation='dark' />
 

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -172,6 +172,13 @@ export default function HubContent(props: HubContentProps) {
                       <CardSourcesList
                         sources={getTaxonomy(d, TAXONOMY_SOURCE)?.values}
                         rootPath={pathname}
+                        onSourceClick={(id) => {
+                          onAction(FilterActions.TAXONOMY_MULTISELECT, {
+                            key: TAXONOMY_SOURCE,
+                            value: id
+                          });
+                          browseControlsHeaderRef.current?.scrollIntoView();
+                        }}
                       />
                       <VerticalDivider variation='dark' />
 


### PR DESCRIPTION
**Related Ticket:** contributes to #1344

### Description of Changes

- Removed linkProperties usage on CardSourcesList component
- Renamed component file to `card-sources-list` to reflect component name

### Notes & Questions About Changes

While this remove link properties from the component, it still depends on onClick properties to work. This is because `useFiltersWithQS` is not reacting to querystring changes (at least not in the stories hub), and a trigger event is needed to update the taxonomy filters.

### Validation / Testing

This is ready for review.

Visit http://localhost:9000/stories, click on the 'By Development Seed' Card source link, filters should be updated. 

![taxonomy-change](https://github.com/user-attachments/assets/d04ee23e-fa33-44f4-8ba4-cdec52faf628)




