### PR TITLE
refactor: Remove linkProperties from Stories Hub

### DIFF
--- a/app/scripts/components/stories/hub/container.tsx
+++ b/app/scripts/components/stories/hub/container.tsx
@@ -16,8 +16,6 @@ import {
   ContentOverride
 } from '$components/common/page-overrides';
 
-import SmartLink from '$components/common/smart-link';
-
 const allStories = Object.values(stories)
   .map((d) => d!.data)
   .filter((d) => !d.isHidden)
@@ -42,10 +40,6 @@ function StoriesHubContainer() {
         <HubContent
           allStories={allStories}
           onFilterchanges={() => controlVars}
-          linkProperties={{
-            LinkElement: SmartLink,
-            pathAttributeKeyName: 'to'
-          }}
           pathname={STORIES_PATH}
           storiesString={{
             one: getString('stories').one,

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -40,8 +40,9 @@ import {
   TAXONOMY_TOPICS
 } from '$utils/veda-data/taxonomies';
 import { generateTaxonomies } from '$utils/veda-data/taxonomies';
-import { StoryData, LinkProperties } from '$types/veda';
+import { StoryData } from '$types/veda';
 import { UseFiltersWithQueryResult } from '$components/common/catalog/controls/hooks/use-filters-with-query';
+import { useVedaUI } from '$context/veda-ui-provider';
 
 const StoryCount = styled(Subtitle)`
   grid-column: 1 / -1;
@@ -67,40 +68,22 @@ interface StoryDataWithPath extends StoryData {
 }
 interface HubContentProps {
   allStories: StoryDataWithPath[];
-  linkProperties: LinkProperties;
   pathname: string;
   storiesString: { one: string; other: string };
   onFilterchanges: () => UseFiltersWithQueryResult;
 }
 
 export default function HubContent(props: HubContentProps) {
-  const {
-    allStories,
-    linkProperties,
-    pathname,
-    storiesString,
-    onFilterchanges
-  } = props;
+  const { allStories, pathname, storiesString, onFilterchanges } = props;
+
+  const { Link } = useVedaUI();
+
   const browseControlsHeaderRef = useRef<HTMLDivElement>(null);
   const { headerHeight } = useSlidingStickyHeaderProps();
   const { search, taxonomies, onAction } = onFilterchanges();
 
-  const { LinkElement, pathAttributeKeyName } = linkProperties;
   const storyTaxonomies = generateTaxonomies(allStories);
 
-  const ButtonLinkProps = {
-    forwardedAs: LinkElement,
-    [pathAttributeKeyName]: pathname
-  };
-
-  function getPillLinkProps(t) {
-    return {
-      as: LinkElement,
-      [pathAttributeKeyName]: `${pathname}?${
-        FilterActions.TAXONOMY
-      }=${encodeURIComponent(JSON.stringify({ Topics: t.id }))}`
-    };
-  }
   const displayStories = useMemo(
     () =>
       prepareDatasets(allStories, {
@@ -149,7 +132,8 @@ export default function HubContent(props: HubContentProps) {
         </span>
         {isFiltering && (
           <Button
-            {...ButtonLinkProps}
+            forwardedAs={Link}
+            to={pathname}
             size='small'
             onClick={() => onAction(FilterActions.CLEAR)}
           >
@@ -188,10 +172,7 @@ export default function HubContent(props: HubContentProps) {
                     </CardMeta>
                   }
                   linkLabel='View more'
-                  linkProperties={{
-                    ...linkProperties,
-                    linkTo: `${d.asLink?.url ?? d.path}`
-                  }}
+                  to={`${d.asLink?.url ?? d.path}`}
                   title={
                     <TextHighlight value={search} disabled={search.length < 3}>
                       {d.name}
@@ -213,7 +194,12 @@ export default function HubContent(props: HubContentProps) {
                           {topics.map((t) => (
                             <dd key={t.id}>
                               <Pill
-                                {...getPillLinkProps(t)}
+                                as={Link}
+                                to={`${pathname}?${
+                                  FilterActions.TAXONOMY
+                                }=${encodeURIComponent(
+                                  JSON.stringify({ Topics: t.id })
+                                )}`}
                                 onClick={() => {
                                   browseControlsHeaderRef.current?.scrollIntoView();
                                 }}


### PR DESCRIPTION
**Related Ticket:** 

- Contributes to #1344

### Description of Changes

This removes the usage of `linkProperties` approach in favor of UseVedaUI's Link hook. Touched elements are:

- Clear filters button
- Topic pills

### Notes & Questions About Changes

- This is based on the refactor of CardSourcesList in #1401, ideally we should review that first
- There is a bug in the filters behavior, tracked at https://github.com/NASA-IMPACT/veda-ui/issues/1404

### Validation / Testing

This PR does not attempt to fix #1404, so clicking on topic pill links won't apply filters. But they should be valid filter URLs.

To test:

- Visit Stories Hub page
- Right click a topic pill and copy the link
- Paste the link in a new tab, filters are applied correctly
- Click on "Clear filters" button, it should clear the filters

This is ready for a review.