### PR TITLE
[Do not merge this yet] Hide toolbar when an AOI is created

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/aoi-control.tsx
@@ -120,14 +120,18 @@ function AoiControl({
 
   return (
     <>
-      <Tip disabled={!disableReason} content={disableReason} placement='bottom'>
-        <div>
+      {!aoi && ( // only show the toolbar when there is no AOI
+        <Tip
+          disabled={!disableReason}
+          content={disableReason}
+          placement='bottom'
+        >
           <AnalysisToolbar
             visuallyDisabled={!!disableReason}
             size='small'
             data-tour='analysis-tour'
           >
-            {isDrawing ? (
+            {isDrawing ? ( // toolbar for drawing mode
               <USWDSButtonGroup className='margin-neg-05 margin-right-0'>
                 <USWDSButton
                   onClick={drawingActions.confirm}
@@ -177,10 +181,11 @@ function AoiControl({
               </>
             )}
           </AnalysisToolbar>
-        </div>
-      </Tip>
+        </Tip>
+      )}
 
       {!isDrawing && !!aoi && (
+        // a way to delete the AOI
         <FloatingBar container={mapboxMap.getContainer()}>
           <USWDSButton
             onClick={onTrashClick}


### PR DESCRIPTION
Based on our discussions around improving the user experience when creating a new AOI after a shape has already been drawn, this PR introduces an alternative user flow:
- Users can only create a new AOI (via selection, drawing, or uploading) after deleting the existing one.
- While an AOI is present, the toolbar for creating new AOIs will be hidden, reducing the risk of unintentional overwrites and clarifying the workflow.

This proposal is a variation (Version B ☺️) of the current approach in #1395 (Version A). It emphasizes deliberate action on the part of the user, ensuring that any new AOI creation starts from a clean slate.

Feedback on whether this alternative flow better aligns with user needs would be greatly appreciated! We could even run some A/B testing with both of the deploy preview links!