### PR TITLE
fix: Scrollytelling layout in Next instance

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -359,7 +359,7 @@ function Scrollytelling(props) {
 
   return (
     <>
-      <ScrollyMapContainer topOffset={topOffset}>
+      <ScrollyMapContainer topOffset={topOffset || 0}>
         {areLayersLoading && <MapLoading />}
 
         {/*


### PR DESCRIPTION
**Related Ticket:** #1402 

### Description of Changes
Provide a fallback value for top offset of ScrollyMapContainer: When `topOffset` is undefined it causes the css `top` property to be faulty, which makes the `position: sticky` not working.

### Notes & Questions About Changes
Do we still need the whole `useSlidingStickyHeaderProps` logic with the USWDS header?

### Validation / Testing
You will to validate in the next-veda instance, making sure the map stays sticky on the top when scrolling down. 
Related PR on next-veda-ui: https://github.com/developmentseed/next-veda-ui/pull/41
