### PR TITLE
fix: Replace root.render in useThemedControl with React Portal

### DIFF
--- a/app/scripts/components/common/map/controls/aoi/aoi-control.tsx
+++ b/app/scripts/components/common/map/controls/aoi/aoi-control.tsx
@@ -221,12 +221,12 @@ export default function Wrapper({
 }) {
   const { main } = useMaps();
 
-  useThemedControl(
+  const control = useThemedControl(
     () => <AoiControl mapboxMap={main} disableReason={disableReason} />,
     {
       position: 'top-left'
     }
   );
 
-  return null;
+  return control;
 }

--- a/app/scripts/components/common/map/controls/coords.tsx
+++ b/app/scripts/components/common/map/controls/coords.tsx
@@ -56,7 +56,7 @@ export default function MapCoordsControl() {
   const { lng, lat } = position;
   const value = `W ${lng}, N ${lat}`;
 
-  useThemedControl(
+  const control = useThemedControl(
     () => (
       <MapCoordsWrapper>
         <CopyField value={value}>
@@ -77,5 +77,5 @@ export default function MapCoordsControl() {
     { position: 'bottom-left' }
   );
 
-  return null;
+  return control;
 }

--- a/app/scripts/components/common/map/controls/map-options/index.tsx
+++ b/app/scripts/components/common/map/controls/map-options/index.tsx
@@ -254,8 +254,8 @@ function MapOptions(props: MapOptionsProps) {
 }
 
 export default function MapOptionsControl(props: MapOptionsProps) {
-  useThemedControl(() => <MapOptions {...props} />, {
+  const control = useThemedControl(() => <MapOptions {...props} />, {
     position: 'top-right'
   });
-  return null;
+  return control;
 }

--- a/app/scripts/components/exploration/components/map/analysis-message-control.tsx
+++ b/app/scripts/components/exploration/components/map/analysis-message-control.tsx
@@ -186,11 +186,11 @@ export function AnalysisMessage({ mainMap }: { mainMap: MapRef | undefined }) {
 
 export function AnalysisMessageControl() {
   const { main } = useMaps();
-  useThemedControl(() => <AnalysisMessage mainMap={main} />, {
+  const control = useThemedControl(() => <AnalysisMessage mainMap={main} />, {
     position: 'top-left'
   });
 
-  return null;
+  return control;
 }
 
 // / / / / / /      Analysis messages for different states        / / / / / / //

--- a/app/scripts/components/exploration/components/map/tour-control.tsx
+++ b/app/scripts/components/exploration/components/map/tour-control.tsx
@@ -37,11 +37,11 @@ export function ShowTourControl() {
     setIsOpen(true);
   }, [setIsOpen, setCurrentStep, setSteps]);
 
-  useThemedControl(
+  const control = useThemedControl(
     () => <TourButtonComponent onClick={reopenTour} disabled={disabled} />,
     {
       position: 'top-right'
     }
   );
-  return null;
+  return control;
 }


### PR DESCRIPTION
**Related Conversation:** https://github.com/NASA-IMPACT/veda-ui/pull/1395#discussion_r1932291047

### Description of Changes
From the react documentation:
If your app is fully built with React, you shouldn’t need to create any more roots, or to call root.render again.

It is uncommon to call render multiple times. Usually, your components will update state instead.

When you want to render a piece of JSX in a different part of the DOM tree that isn’t a child of your component (for example, a modal or a tooltip), use createPortal instead of createRoot.

How to guide: https://18.react.dev/reference/react-dom/createPortal\#rendering-react-components-into-non-react-dom-nodes


### Notes & Questions About Changes
We had to update all cases where useThemedControl was used to render the returned control.

### Validation / Testing
Ensure all map controls are working as expected and do not re-render infinitely.
