### PR TITLE
fix: Change filter action type in Stories Hub, add missing action

### DIFF
--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -159,7 +159,7 @@ export default function HubContent(props: HubContentProps) {
                         sources={getTaxonomy(d, TAXONOMY_SOURCE)?.values}
                         rootPath={storiesCatalogPath}
                         onSourceClick={(id) => {
-                          onAction(FilterActions.TAXONOMY_MULTISELECT, {
+                          onAction(FilterActions.TAXONOMY, {
                             key: TAXONOMY_SOURCE,
                             value: id
                           });
@@ -203,6 +203,10 @@ export default function HubContent(props: HubContentProps) {
                                   JSON.stringify({ Topics: t.id })
                                 )}`}
                                 onClick={() => {
+                                  onAction(FilterActions.TAXONOMY, {
+                                    key: TAXONOMY_TOPICS,
+                                    value: t.id
+                                  });
                                   browseControlsHeaderRef.current?.scrollIntoView();
                                 }}
                               >


### PR DESCRIPTION
**Related Ticket:** closes https://github.com/NASA-IMPACT/veda-ui/issues/1404

### Description of Changes

The changes here apply to the Stories Hub

1. Changed the filter action when filtering by `Source` from `TAXONOMY_MULTISELECT` to `TAXONOMY`
2. Added an `onAction` handler when clicking on the topic `Pills` inside of the Cards

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
1. Visit the [Stories Hub](https://deploy-preview-1425--veda-ui.netlify.app/stories)
2. In the card list, click the "By Development Seed" source link on the second card
- The URL is updated to: https://deploy-preview-1425--veda-ui.netlify.app/stories?taxonomy=%7B%22Source%22%3A%22development-seed%22%7D
- The cards are filtered correctly
- The source filter dropdown is updated

3. Clear the filters. In the card list, click on the "Agriculture" topic pill
- The URL is updated to: https://deploy-preview-1425--veda-ui.netlify.app/stories?taxonomy=%7B%22Topics%22%3A%22agriculture%22%7D
- The cards are filtered

4. Reload the page with the agriculture topic filter
- The URL remains the same
- The cards are filtered

5. Visit the page with the source set directly: https://deploy-preview-1425--veda-ui.netlify.app/stories?taxonomy=%7B%22Source%22%3A%22development-seed%22%7D
- The source is selected properly in the dropdown
- The cards are filtered

