### PR TITLE
fix: run yarnlock to make working dir clean

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8843,7 +8843,7 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0, get-stream@^6.0.1:
+get-stream@^6.0.0:
   version "6.0.1"
   resolved "http://verdaccio.ds.io:4873/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/actions/runs/13116400989/job/36591691753

### Description of Changes
Run yarn.lock to make working directory clean

### Notes
I've seen release fail several times because workign dir is not clean (because yarn.lock is not up to date) - how can we avoid this in the future? 
