### PR TITLE
chore(release): cut minor version manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@developmentseed/veda-ui",
   "description": "Dashboard",
-  "version": "5.11.8",
+  "version": "5.12.0",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
**Related Ticket:** I am sorry, I messed up the versioning on the main branch/tag/release (it is v5.12.8 now without matching tags/release)  while trying to fix automatic versioning of the package. This is a manual attempt to fix the version number. 