### PR TITLE
fix: Have LayerInfoModal take in linkProps for pathAttributeName to get working for modern template instance

### DIFF
--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -100,7 +100,7 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
 
   const { parentData } = layerData;
   const path = {
-    [linkProps.pathAttributeKeyName]: dataCatalogPath
+    [linkProps.pathAttributeKeyName]: `${dataCatalogPath}/${parentData.id}`
   };
 
   return (
@@ -144,6 +144,7 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
             size='small'
             inverse={true}
             outline={false}
+            tabIndex='-1'
           >
             Open in Data Catalog
           </USWDSButton>

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -94,11 +94,14 @@ const LayerInfoLinerModal = styled.div`
 export default function LayerInfoModal(props: LayerInfoModalProps) {
   const { revealed, close, layerData } = props;
   const {
-    navigation: { LinkComponent },
+    navigation: { LinkComponent, linkProps },
     routes: { dataCatalogPath }
   } = useVedaUI();
 
   const { parentData } = layerData;
+  const path = {
+    [linkProps.pathAttributeKeyName]: dataCatalogPath
+  };
 
   return (
     <StyledModal
@@ -134,14 +137,13 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
         />
       }
       footerContent={
-        <LinkComponent to={dataCatalogPath}>
+        <LinkComponent {...path}>
           <USWDSButton
             onClick={close}
             type='button'
             size='small'
             inverse={true}
             outline={false}
-            tabindex='-1'
           >
             Open in Data Catalog
           </USWDSButton>


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1282
**Related PR:** https://github.com/developmentseed/next-veda-ui/pull/42

### Description of Changes
Use `linkProps` from VedaUIProvider in LayerInfoModal to get working for modern instances.

### Notes & Questions About Changes
`@teamimpact/veda-ui@5.12.1-1282.0`
`@teamimpact/veda-ui@5.12.1-1282.2`
 was published from these changes. Once this PR is merged, I will unpublish this version and close template PR.

### Validation / Testing
- [ ] Validate the layer-info-modal still works as expected in veda-ui preview
- [ ] Validate the layer-info-modal works in template instance preview https://github.com/developmentseed/next-veda-ui/pull/42
