### PR TITLE
fix: Add wrapping div for scrollytelling map and chapters

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -358,7 +358,7 @@ function Scrollytelling(props) {
     activeChapterLayerData ?? {};
 
   return (
-    <>
+    <div>
       <ScrollyMapContainer topOffset={topOffset || 0}>
         {areLayersLoading && <MapLoading />}
 
@@ -470,7 +470,7 @@ function Scrollytelling(props) {
         </Map>
       </ScrollyMapContainer>
       <TheChapters>{children}</TheChapters>
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
**Related Ticket:** Fix #1418

### Description of Changes
Since the legacy instance was using a lazyload-wrapper this wasn't necessary, but for instances not using this approach, the additional wrapping div is actually required to build the layout as intended. It doesn't hurt the legacy either.


### Validation / Testing
Go to a story, make sure you can scroll down all the way to see text content below the scrollymap, as well as map comparison blocks.