### PR TITLE
fix: Empty story  description close #1424

### DIFF
--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -24,15 +24,12 @@ export function prepareDatasets(
   options: FilterOptionsType
 ): StoryData[];
 export function prepareDatasets(
-  data: DatasetData[] | StoryData[],
+  data: (DatasetData | StoryData)[],
   options: FilterOptionsType
 ) {
   const { sortField, sortDir, search, taxonomies, filterLayers } = options;
-  let filtered = [...data];
+  let filtered = data.filter((d) => !d.isHidden);
 
-  filtered = filtered.filter((d) => !d.isHidden);
-
-  // Does the free text search appear in specific fields?
   if (search && search.length >= 3) {
     const searchLower = search.toLowerCase();
     // Function to check if searchLower is included in any of the string fields

--- a/app/scripts/components/common/catalog/prepare-datasets.ts
+++ b/app/scripts/components/common/catalog/prepare-datasets.ts
@@ -50,13 +50,15 @@ export function prepareDatasets(
       // Pre-calculate lowercased versions to use in comparisons
       const idLower = d.id.toLowerCase();
       const nameLower = d.name.toLowerCase();
-      const descriptionLower = d.description.toLowerCase();
+      const descriptionLower = d.description?.toLowerCase();
+      const cardDescriptionLower = d.cardDescription?.toLowerCase();
       const topicsTaxonomy = d.taxonomy.find((t) => t.name === TAXONOMY_TOPICS);
       // Check if any of the conditions for including the item are met
       return (
         idLower.includes(searchLower) ||
         nameLower.includes(searchLower) ||
-        descriptionLower.includes(searchLower) ||
+        descriptionLower?.includes(searchLower) ||
+        cardDescriptionLower?.includes(searchLower) ||
         (isDatasetData(d) && d.layers.some(layerMatchesSearch)) ||
         topicsTaxonomy?.values.some((t) => includesSearchLower(t.name))
       );

--- a/app/scripts/components/common/catalog/utils.ts
+++ b/app/scripts/components/common/catalog/utils.ts
@@ -88,7 +88,7 @@ type DataObject = DatasetData | DatasetLayer | StoryData | FormatBlock;
  * @returns The appropriate description string
  */
 export const getDescription = (data: DataObject): string => {
-  return data.cardDescription ?? data.description;
+  return data.cardDescription ?? data.description ?? '';
 };
 
 /**

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -170,25 +170,32 @@ export interface DatasetUsage {
   label: string;
   title: string;
 }
+
 /**
- * Data structure for the Datasets frontmatter.
+ * Data structure shared between DatasetData and StoryData
  */
-export interface DatasetData {
+export interface ContentDataBase {
   featured?: boolean;
-  sourceExclusive?: string;
   id: string;
   name: string;
-  infoDescription?: string;
   taxonomy: Taxonomy[];
   description: string;
   cardDescription?: string;
-  usage?: DatasetUsage[];
   media?: Media;
   cardMedia?: Media;
-  layers: DatasetLayer[];
   related?: RelatedContentData[];
-  disableExplore?: boolean;
   isHidden?: boolean;
+}
+
+/**
+ * Data structure unique to the Datasets frontmatter.
+ */
+export interface DatasetData extends ContentDataBase {
+  sourceExclusive?: string;
+  infoDescription?: string;
+  usage?: DatasetUsage[];
+  layers: DatasetLayer[];
+  disableExplore?: boolean;
 }
 
 // ///////////////////////////////////////////////////////////////////////////
@@ -196,24 +203,17 @@ export interface DatasetData {
 // ///////////////////////////////////////////////////////////////////////////
 
 /**
- * Data structure for the Stories frontmatter.
+ * Data structure unique to the Stories frontmatter.
  */
-export interface StoryData {
+export interface StoryData extends ContentDataBase {
   featured?: boolean;
   id: string;
   name: string;
-  description: string;
-  cardDescription?: string;
   pubDate: string;
   path?: string;
-  media?: Media;
-  cardMedia?: Media;
-  taxonomy: Taxonomy[];
-  related?: RelatedContentData[];
   asLink?: LinkContentData;
   hideExternalLinkBadge?: boolean;
   isLinkExternal?: boolean;
-  isHidden?: boolean;
 }
 
 // ///////////////////////////////////////////////////////////////////////////

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -179,7 +179,7 @@ export interface ContentDataBase {
   id: string;
   name: string;
   taxonomy: Taxonomy[];
-  description: string;
+
   cardDescription?: string;
   media?: Media;
   cardMedia?: Media;
@@ -195,6 +195,7 @@ export interface DatasetData extends ContentDataBase {
   infoDescription?: string;
   usage?: DatasetUsage[];
   layers: DatasetLayer[];
+  description: string;
   disableExplore?: boolean;
 }
 
@@ -213,6 +214,7 @@ export interface StoryData extends ContentDataBase {
   path?: string;
   asLink?: LinkContentData;
   hideExternalLinkBadge?: boolean;
+  description?: string; // Description is optional for StoryData
   isLinkExternal?: boolean;
 }
 

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -3,7 +3,7 @@ id: no2
 name: 'Nitrogen Dioxide'
 featured: true
 sourceExclusive: Mock
-description: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
+cardDescription: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
 usage:
   - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
     label: Static notebook

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -3,7 +3,7 @@ id: no2
 name: 'Nitrogen Dioxide'
 featured: true
 sourceExclusive: Mock
-cardDescription: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
+description: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
 usage:
   - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
     label: Static notebook

--- a/mock/stories/life-of-water.stories.mdx
+++ b/mock/stories/life-of-water.stories.mdx
@@ -2,7 +2,7 @@
 featured: true
 id: 'life-of-water'
 name: This is the life of water
-description: 'Sed sed lectus vitae odio vestibulum mattis. Integer iaculis nisl lectus, vel aliquet nulla imperdiet in.'
+cardDescription: 'Sed sed lectus vitae odio vestibulum mattis. Integer iaculis nisl lectus, vel aliquet nulla imperdiet in.'
 media:
   src: ::file ./img-placeholder-6.jpg
   alt: Generic placeholder by Unsplash


### PR DESCRIPTION
**Related Ticket:** #1424 

### Description of Changes
Handle the case when description is empty
Add card description to search criteria
Separate out shared data structure between StoryData and Datasetdata

### Notes & Questions About Changes

It might not be very intuitive that DatasetData requires description while StoryData doesn't. but it takes a bigger scope of change if we want to make description optional for DatasetData. (And we might not want it? See the problem of empty description in this comment: https://github.com/NASA-IMPACT/veda-ui/issues/1424#issuecomment-2634734891) 


### Validation / Testing
I removed `description` from life of water story for testing: https://deploy-preview-1438--veda-ui.netlify.app/stories?search=null