### PR TITLE
fix: created COOKIE CONSENT FORM feature flag

### DIFF
--- a/.env
+++ b/.env
@@ -18,3 +18,5 @@ SHOW_CONFIGURABLE_COLOR_MAP = 'TRUE'
 ENABLE_USWDS_PAGE_HEADER = 'TRUE'
 # Enables the refactor page footer component that uses the USWDS design system
 ENABLE_USWDS_PAGE_FOOTER = 'TRUE'
+# Enables the display of Cookie consent form
+ENABLE_COOKIE_CONSENT_FORM = 'TRUE'

--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -41,6 +41,7 @@ import { checkEnvFlag } from '$utils/utils';
 const appTitle = process.env.APP_TITLE;
 const appDescription = process.env.APP_DESCRIPTION;
 const isUswdsFooterEnabled = checkEnvFlag(process.env.ENABLE_USWDS_PAGE_FOOTER);
+const isCookieConsentEnabled = checkEnvFlag(process.env.ENABLE_COOKIE_CONSENT_FORM);
 
 export const PAGE_BODY_ID = 'pagebody';
 
@@ -104,7 +105,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}
-        {cookieConsentContent && displayCookieConsentForm && (
+        {isCookieConsentEnabled && displayCookieConsentForm && (
           <CookieConsent
             {...cookieConsentContent}
             setDisplayCookieConsentForm={setDisplayCookieConsentForm}

--- a/mock/veda.config.js
+++ b/mock/veda.config.js
@@ -156,17 +156,17 @@ module.exports = {
     copy: 'We use cookies to enhance your browsing experience and to help us understand how our website is used. These cookies allow us to collect data on site usage and improve our services based on your interactions. To learn more about it, see our [Privacy Policy](https://www.nasa.gov/privacy/#cookies)',
     theme: {
       card: {
-        backgroundColor: '#2276ac',
-        sideBarColor: '#175074',
-        textColor: 'White',
-        linkColor: '#175074'
+        backgroundColor: '#E7F6F8',
+        sideBarColor: '#005EA2',
+        textColor: 'Black',
+        linkColor: '#005EA2'
       },
       acceptButton: {
-        default: { backgroundColor: '#175074', textColor: 'white' },
+        default: { backgroundColor: '#005EA2', textColor: 'white' },
         hover: { backgroundColor: '#2c3e50', textColor: '#white' }
       },
       declineButton: {
-        default: { borderColor: '#175074', textColor: '#175074' },
+        default: { borderColor: '#005EA2', textColor: '#005EA2' },
         hover: { borderColor: '#2c3e50', textColor: '#2c3e50' }
       },
       iconColor: { default: 'White', hover: '#175074' }


### PR DESCRIPTION
**Related Ticket:** _{[link related ticket here](https://github.com/NASA-IMPACT/veda-ui/issues/1416)}_

### Description of Changes
GHG team communicated issues with the cookie consent ENV flag. There is no existing ENV flag, this component was previously designed to leverage the existence of `cookieConsentForm` content as a ternary validation to conditionally show the cookie consent form or not. for future maintenance of this item I have added a cookie consent flag `ENABLE_COOKIE_CONSENT_FORM` to enable the standard functionality. 

### Notes & Questions About Changes
Added `ENABLE_COOKIE_CONSENT_FORM` to the .env .

### Validation / Testing
To test pull down branch and navigation to `.env` file and change `ENABLE_COOKIE_CONSENT_FORM = TRUE` You might also need to delete your local cookies by opening dev tools > application tab > cookies > right click 'clear'. Confirm that the cookie consent form renders on the front-end. 

Go to`.env` file and change `ENABLE_COOKIE_CONSENT_FORM = FALSE` confirm that the cookie consent form does not render on the front-end.