### PR TITLE
fix: Make banner flag path and alt text configurable

### DIFF
--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -27,6 +27,7 @@ interface BannerProps {
   headerActionText?: string;
   ariaLabel?: string;
   flagImgAlt?: string;
+  flagImgSrc?: string;
   leftGuidance?: GuidanceContent;
   rightGuidance?: GuidanceContent;
   className?: string;
@@ -38,6 +39,10 @@ const DEFAULT_HEADER_TEXT =
   'An official website of the United States government';
 
 const DEFAULT_HEADER_ACTION_TEXT = "Here's how you know";
+
+const DEFAULT_FLAG_SRC = '/img/us_flag_small.png';
+
+const DEFAULT_FLAG_ALT = 'U.S. flag';
 
 const DEFAULT_GUIDANCE: Guidance = {
   left: {
@@ -82,6 +87,7 @@ export default function Banner({
   headerActionText,
   ariaLabel,
   flagImgAlt = '',
+  flagImgSrc,
   leftGuidance,
   rightGuidance,
   className = '',
@@ -108,7 +114,10 @@ export default function Banner({
       <USWDSBannerHeader
         isOpen={isOpen}
         flagImg={
-          <USWDSBannerFlag src='/img/us_flag_small.png' alt={flagImgAlt} />
+          <USWDSBannerFlag
+            src={flagImgSrc ?? DEFAULT_FLAG_SRC}
+            alt={flagImgAlt ?? DEFAULT_FLAG_ALT}
+          />
         }
         headerText={headerText ?? DEFAULT_HEADER_TEXT}
         headerActionText={headerActionText ?? DEFAULT_HEADER_ACTION_TEXT}

--- a/parcel-resolver-veda/index.js
+++ b/parcel-resolver-veda/index.js
@@ -118,7 +118,8 @@ function getSiteAlertContent(result) {
 function getBannerContent(result) {
   if (!result.banner) return undefined;
 
-  const { title, leftGuidance, rightGuidance } = result.banner;
+  const { title, leftGuidance, rightGuidance, flagImgSrc, flagImgAlt } =
+    result.banner;
 
   const processedLeftGuidance = {
     ...leftGuidance,
@@ -134,8 +135,8 @@ function getBannerContent(result) {
     headerText: title,
     headerActionText: "Here's how you know",
     ariaLabel: title,
-    flagImgSrc: '/img/us_flag_small.png',
-    flagImgAlt: '',
+    flagImgSrc: flagImgSrc,
+    flagImgAlt: flagImgAlt,
     leftGuidance: processedLeftGuidance,
     rightGuidance: processedRightGuidance,
     className: '',


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1415

### Description of Changes

Make the USWDS banner flag path and alt texts configurable. The USWDS assets are currently resolved incorrectly because they're using absolute paths (starting with '/') which are being resolved relative to earth.gov instead of earth.gov/ghgcenter. As an immediate fix, this PR makes the flag path configurable so we can adjust it based on the deployment context. 

### Notes & Questions About Changes
- Path resolution could potentially affect other USWDS assets beyond the flag and in other components. We'll be tackling this via #1429 (subpath route handling) and #1389

### Validation / Testing
- Start veda-ui locally
- Change the `flagImgSrc` path in veda-config.js to `/img/icon-https.svg`
- Restart your server
- Verify that the flag img in the banner shows the new icon
- Change it back the original flag path
- Verify that the flag icon is shown 