### PR TITLE
fix: Remove the USWDS button from the old page header

### DIFF
--- a/app/scripts/components/common/page-header-legacy/nav-menu-item.tsx
+++ b/app/scripts/components/common/page-header-legacy/nav-menu-item.tsx
@@ -16,7 +16,6 @@ import {
 } from '../page-header/types';
 import { InternalNavLink, ExternalNavLink } from '../types';
 import { useFeedbackModal } from '../layout-root';
-import { USWDSButton } from '$uswds';
 import GlobalMenuLinkCSS from '$styles/menu-link';
 import { useMediaQuery } from '$utils/use-media-query';
 import { LinkProperties } from '$types/veda';
@@ -120,6 +119,32 @@ function LinkDropMenuNavItem({
   }
 }
 
+interface BtnMediaProps {
+  active?: boolean;
+}
+
+// Global menu link style
+const ButtonAsNavLink = styled(Button)`
+  ${media.mediumUp<BtnMediaProps>`
+    background-color: ${themeVal('color.primary-700')};
+    &:hover {
+      background-color: ${themeVal('color.primary-800')};
+    }
+    /* Print & when prop is passed */
+    ${({ active }) => active && '&,'}
+    &:active,
+    &.active {
+      background-color: ${themeVal('color.primary-900')};
+    }
+    &:focus-visible {
+      background-color: ${themeVal('color.primary-200a')};
+    }
+  `}
+  ${media.mediumDown`
+    ${GlobalMenuLinkCSS}
+  `}
+`;
+
 export default function NavMenuItem({
   item,
   alignment,
@@ -164,15 +189,14 @@ export default function NavMenuItem({
   } else if (item.type === NavItemType.ACTION) {
     return (
       <li>
-        <USWDSButton
-          onClick={show}
+        <ButtonAsNavLink
           type='button'
-          size='small'
-          inverse={true}
-          outline={false}
+          size='large'
+          onClick={show}
+          style={{ color: 'white' }}
         >
-          {item.title}
-        </USWDSButton>
+          {title}
+        </ButtonAsNavLink>
         {process.env.GOOGLE_FORM && (
           <GoogleForm
             src={process.env.GOOGLE_FORM}


### PR DESCRIPTION
**Related Ticket:** closes https://github.com/NASA-IMPACT/veda-ui/issues/1388

### Description of Changes

During the recent header redesign, we created a "legacy" version of the old header to keep consistency across existing deployments (like GHG Center) and to ease the development process. However, a USWDS-styled button had accidentally been included in this legacy header and it's causing visual inconsistency with the original GHG Center design. This PR removes the USWDS button from the legacy header and replaces it with the previous styled button (that was removed here https://github.com/NASA-IMPACT/veda-ui/pull/1247/files#diff-3dc664e136e6e14925e5f449b907df7edc49fd1d2744cf0cb1aea27a63646846L51).
 
### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

1. Verify that the new header is shown as usual in the veda UI
1. Verify that the "Contact Us" button is not a USWDS button in the [GHG Center preview deployment](https://github.com/US-GHG-Center/veda-config-ghg/pull/728) and verify that it matches some of the earlier deployments of GHG Center (example of an older deployment: https://deploy-preview-455--ghg-demo.netlify.app/)
