### PR TITLE
fix: categorical legend

### DIFF
--- a/app/scripts/components/exploration/constants.ts
+++ b/app/scripts/components/exploration/constants.ts
@@ -18,3 +18,5 @@ export const AXIS_BG_COLOR = '#F0F0F0';
 export const HIGHLIGHT_LINE_COLOR = '#CCCCCC';
 export const FADED_TEXT_COLOR = '#83868A';
 export const TEXT_TITLE_BG_COLOR = '#FAFAFA';
+
+export const RENDER_KEY = 'dashboard';

--- a/app/scripts/components/exploration/data-utils-no-faux-module.spec.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.spec.ts
@@ -1,0 +1,79 @@
+import {
+  resolveRenderParams,
+  formatRenderExtensionData
+} from './data-utils-no-faux-module';
+import { RENDER_KEY } from './constants';
+
+const renderExtensionData = {
+  dashboard: {
+    bidx: [1],
+    title: 'VEDA Dashboard Render Parameters',
+    assets: ['cog_default'],
+    resampling: 'bilinear',
+    colormap_name: 'viridis'
+  }
+};
+
+const renderExtensionDataWithAsset = {
+  dashboard: {
+    bidx: [1],
+    title: 'VEDA Dashboard Render Parameters',
+    assets: ['soil_texture_0cm_250m'],
+    nodata: 255,
+    resampling: 'nearest',
+    return_mask: true,
+    colormap_name: 'soil_texture'
+  }
+};
+
+const renderExtensionDataWithColormap = {
+  dashboard: {
+    title: 'VEDA Dashboard Render Parameters',
+    assets: ['cog_default'],
+    rescale: [[0, 0.0001]],
+    colormap: {
+      '0': [22, 158, 242, 255]
+    }
+  }
+};
+
+const userDefinedSourceParameters = {
+  resampling: 'bilinear',
+  bidx: 1,
+  colormap_name: 'viridis',
+  rescale: [0, 0.0001]
+};
+
+const userDefinedSourceParametersWithAsset = {
+  assets: 'soil_texture_5cm_250m',
+  colormap_name: 'soil_texture',
+  nodata: 255
+};
+
+describe('Resolve Render Params', () => {
+  it('give precedence to render parameter data', () => {
+    const sourceParameter = resolveRenderParams(
+      userDefinedSourceParameters,
+      renderExtensionData
+    );
+    expect(sourceParameter).toMatchObject(renderExtensionData[RENDER_KEY]);
+  });
+
+  it('falls back to user defined source parameters when render extension does not have asset namespace', () => {
+    const sourceParameter = resolveRenderParams(
+      userDefinedSourceParametersWithAsset,
+      renderExtensionDataWithAsset
+    );
+    expect(sourceParameter).toMatchObject(userDefinedSourceParametersWithAsset);
+  });
+
+  it('formats render parameter data correctly', () => {
+    const renderData = renderExtensionDataWithColormap['dashboard'];
+    const sourceParameter = formatRenderExtensionData(renderData);
+    expect(sourceParameter).toMatchObject({
+      ...renderData,
+      rescale: renderData.rescale.flat(),
+      colormap: JSON.stringify(renderData.colormap)
+    });
+  });
+});

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -155,8 +155,13 @@ export function resolveLayerTemporalExtent(
   }
 }
 
+// What is a valid source params to make the dataset render as expected?
 const hasValidSourceParams = (params) => {
-  return params && 'colormap_name' in params && 'rescale' in params;
+  return (
+    params &&
+    ('colormap_name' in params || 'colormap' in params) &&
+    'rescale' in params
+  );
 };
 
 /**

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -12,6 +12,7 @@ import {
   TimeDensity,
   TimelineDatasetSuccess
 } from './types.d.ts';
+import { RENDER_KEY } from './constants';
 import {
   DataMetric,
   DATA_METRICS,
@@ -198,12 +199,15 @@ function flattenAndCalculateMinMax(rescale: number[]): [number, number] {
   return [min, max];
 }
 
-function formatRenderExtensionData(renderData): SourceParameters {
+export function formatRenderExtensionData(renderData): SourceParameters {
   return {
     ...renderData,
-    colormap: renderData.colormap && JSON.stringify(renderData.colormap),
-    rescale:
-      renderData.rescale && flattenAndCalculateMinMax([renderData.rescale])
+    ...(renderData.colormap && {
+      colormap: JSON.stringify(renderData.colormap)
+    }),
+    ...(renderData.rescale && {
+      rescale: flattenAndCalculateMinMax([renderData.rescale])
+    })
   };
 }
 
@@ -219,8 +223,6 @@ export function resolveRenderParams(
   datasetSourceParams: Record<string, any> | undefined,
   queryDataRenders: Record<string, any> | undefined
 ): SourceParameters | undefined {
-  const renderKey = 'dashboard';
-
   // @NOTE: Render extension might not have separate namespaces for each asset yet. (2025 Feb)
   // Fallback to manual source parameters when assets are specified
   if (datasetSourceParams?.assets) {
@@ -232,8 +234,8 @@ export function resolveRenderParams(
   }
 
   // return render extension data
-  if (queryDataRenders && queryDataRenders[renderKey]) {
-    const renderParams = queryDataRenders[renderKey];
+  if (queryDataRenders && queryDataRenders[RENDER_KEY]) {
+    const renderParams = queryDataRenders[RENDER_KEY];
     return formatRenderExtensionData(renderParams);
   }
   // return user defined source params (which can be undefined)

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -52,7 +52,7 @@ function reconcileQueryDataWithDataset(
 
       if (isRenderParamsApplicable(base.data.type)) {
         renderParams = resolveRenderParams(
-          base.data.sourceParams,
+          { ...base.data.sourceParams, layerId: base.data.id },
           queryData.data.renders
         );
       }

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -127,7 +127,11 @@ interface LayerLegendUnit {
   label: string;
 }
 // These two values don't match what is returned from stac vs. what dashboard needs
-// ex. colormap value from stac endpoint can be {0: [0,0,0,0]}, while key should be string to for titiler
+// ex. colormap value from stac endpoint is an object {'0': [0,0,0,0]}
+// But this will be translated colorMap[0] = [0,0,0,0] when passed as a query string parameter
+// See how qs (library we are using to format query string) parses object: https://www.npmjs.com/package/qs#parsing-objects
+// rescale value can be [number,number][] while dashboard expects it to be [number, number] for dynamic rescaling
+// So we make sure these two are formatted as we expect for dashboard
 export interface SourceParameters {
   colormap?: string;
   rescale?: [number, number];

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -28,7 +28,7 @@ interface DatasetLayerCommonCompareProps {
 interface DatasetLayerCommonProps extends DatasetLayerCommonCompareProps {
   zoomExtent?: number[];
   bounds?: number[];
-  sourceParams?: Record<string, any>;
+  sourceParams?: SourceParameters;
 }
 
 export type DatasetDatumFn<T> = (bag: DatasetDatumFnResolverBag) => T;
@@ -77,7 +77,7 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   analysis?: {
     metrics: string[];
     exclude: boolean;
-    sourceParams?: Record<string, any>;
+    sourceParams?: SourceParameters;
   };
   assetUrlReplacements?: {
     from: string;

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -126,6 +126,13 @@ export interface DatasetDatumFnResolverBag {
 interface LayerLegendUnit {
   label: string;
 }
+// These two values don't match what is returned from stac vs. what dashboard needs
+// ex. colormap value from stac endpoint can be {0: [0,0,0,0]}, while key should be string to for titiler
+export interface SourceParameters {
+  colormap?: string;
+  rescale?: [number, number];
+  [key: string]: any;
+}
 
 export interface LayerLegendGradient {
   type: 'gradient';


### PR DESCRIPTION
**Related Ticket:** #1456 

### Description of Changes
Categorical legend often doesn't have a colormap name but custom colormap values. This PR makes colormap&&rescale combination valid sourceParam. I think I would still like to run it with back-end team re: what makes sourceParams valid. 

### Notes & Questions About Changes
We need to consolidate where we are subbing colormap and rescale value. The current dataflow seems to be scattered, making it difficult to pin down where the source of the data is. IMO, it should happen while reconciling the render data. 

Also it is interesting... that [GeoGLAM dataset](https://earthdata.nasa.gov/dashboard/exploration?datasets=%5B%7B%22id%22%3A%22geoglam%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2025-01-01T05%3A00%3A00.000Z) has been displayed just fine - which is another categorical dataset with colormap value. It just didn't get caught in any of our error Logic - which probably means that we can do better 😬 

### Validation / Testing
Check campfire nlcd data from the preview of https://github.com/NASA-IMPACT/veda-config/pull/669
direct url: https://deploy-preview-669--visex.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22campfire-nlcd%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2019-01-01T05%3A00%3A00.000Z