### PR TITLE
fix: display infoDescription for layer modal

### DIFF
--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -21,6 +21,7 @@ import {
 import { OptionItem } from '$components/common/form/checkable-filter';
 import { Pill } from '$styles/pill';
 import { usePreviousValue } from '$utils/use-effect-previous';
+import { getParentDataset } from '$components/exploration/data-utils-no-faux-module';
 
 const EXCLUSIVE_SOURCE_WARNING =
   'Can only be analyzed with layers from the same source';
@@ -51,10 +52,7 @@ function enhanceDatasetLayers(dataset) {
     ...dataset,
     layers: dataset.layers.map((layer) => ({
       ...layer,
-      parentDataset: {
-        id: dataset.id,
-        name: dataset.name
-      }
+      parentDataset: getParentDataset(dataset)
     }))
   };
 }

--- a/app/scripts/components/exploration/atoms/datasetLayers.ts
+++ b/app/scripts/components/exploration/atoms/datasetLayers.ts
@@ -1,4 +1,5 @@
 import { atom } from 'jotai';
+import { getParentDataset } from '../data-utils-no-faux-module';
 import { DatasetLayer } from '$types/veda';
 
 /**
@@ -18,11 +19,7 @@ export const datasetLayersAtom = atom<DatasetLayer[]>((get) => {
   return datasets.flatMap((dataset) => {
     return (dataset.layers || []).map((l: any) => ({
       ...l,
-      parentDataset: {
-        id: dataset.id,
-        name: dataset.name,
-        infoDescription: dataset.infoDescription
-      }
+      parentDataset: getParentDataset(dataset)
     }));
   });
 });

--- a/app/scripts/components/exploration/atoms/datasetLayers.ts
+++ b/app/scripts/components/exploration/atoms/datasetLayers.ts
@@ -20,7 +20,8 @@ export const datasetLayersAtom = atom<DatasetLayer[]>((get) => {
       ...l,
       parentDataset: {
         id: dataset.id,
-        name: dataset.name
+        name: dataset.name,
+        infoDescription: dataset.infoDescription
       }
     }));
   });

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -127,17 +127,12 @@ export function DatasetListItem(props: DatasetListItemProps) {
   }, [queryClient, datasetId]);
 
   const onClickLayerInfo = useCallback(() => {
-    const parentInfoDesc = findDatasetAttribute(datasets, {
-      datasetId: dataset.data.parentDataset.id,
-      attr: 'infoDescription'
-    });
     const data: LayerInfoModalData = {
       name: dataset.data.name,
       description: dataset.data.description,
       info: dataset.data.info,
       parentData: {
-        ...dataset.data.parentDataset,
-        infoDescription: parentInfoDesc
+        ...dataset.data.parentDataset
       }
     };
     setModalLayerInfo(data);

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -89,7 +89,6 @@ const DatasetData = styled.div`
 `;
 
 interface DatasetListItemProps {
-  datasets: TimelineDataset[];
   datasetId: string;
   width: number;
   xScaled?: ScaleTime<number, number>;

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -21,7 +21,6 @@ import {
 import { DatasetChart } from './dataset-chart';
 import { getBlockBoundaries, lumpBlocks } from './block-utils';
 import DataLayerCard from './data-layer-card';
-import { findDatasetAttribute } from '$components/exploration/data-utils-no-faux-module';
 import {
   DatasetStatus,
   TimelineDataset,
@@ -99,7 +98,7 @@ interface DatasetListItemProps {
 }
 
 export function DatasetListItem(props: DatasetListItemProps) {
-  const { datasets, datasetId, width, xScaled, onDragStart, onDragEnd } = props;
+  const { datasetId, width, xScaled, onDragStart, onDragEnd } = props;
 
   const datasetAtom = useTimelineDatasetAtom(datasetId);
   const dataset = useAtomValue(datasetAtom);
@@ -131,9 +130,7 @@ export function DatasetListItem(props: DatasetListItemProps) {
       name: dataset.data.name,
       description: dataset.data.description,
       info: dataset.data.info,
-      parentData: {
-        ...dataset.data.parentDataset
-      }
+      parentData: dataset.data.parentDataset
     };
     setModalLayerInfo(data);
   }, [dataset]);

--- a/app/scripts/components/exploration/components/datasets/dataset-list.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list.tsx
@@ -34,7 +34,6 @@ export function DatasetList(props: DatasetListProps) {
     >
       {datasets.map((dataset) => (
         <DatasetListItem
-          datasets={datasets}
           key={dataset.data.id}
           datasetId={dataset.data.id}
           width={width}

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -9,7 +9,7 @@ import {
   ModalHeadline
 } from '@devseed-ui/modal';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
-import { LayerInfo } from '$types/veda';
+import { LayerInfo, ParentDatset } from '$types/veda';
 import { CollecticonDatasetLayers } from '$components/common/icons/dataset-layers';
 import { ParentDatasetTitle } from '$components/common/catalog/catalog-content';
 import { useVedaUI } from '$context/veda-ui-provider';
@@ -56,11 +56,7 @@ export interface LayerInfoModalData {
   name: string;
   info?: LayerInfo;
   description: string;
-  parentData: {
-    id: string;
-    name: string;
-    infoDescription: string | undefined;
-  };
+  parentData: ParentDatset;
 }
 
 interface LayerInfoModalProps {

--- a/app/scripts/components/exploration/components/layer-info-modal.tsx
+++ b/app/scripts/components/exploration/components/layer-info-modal.tsx
@@ -59,7 +59,7 @@ export interface LayerInfoModalData {
   parentData: {
     id: string;
     name: string;
-    infoDescription?: string;
+    infoDescription: string | undefined;
   };
 }
 
@@ -102,7 +102,6 @@ export default function LayerInfoModal(props: LayerInfoModalProps) {
   const path = {
     [linkProps.pathAttributeKeyName]: `${dataCatalogPath}/${parentData.id}`
   };
-
   return (
     <StyledModal
       id='modal'

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -23,8 +23,17 @@ import {
   VedaData,
   VedaDatum,
   DatasetData,
-  DatasetLayerType
+  DatasetLayerType,
+  ParentDatset
 } from '$types/veda';
+
+export function getParentDataset(data: DatasetData): ParentDatset {
+  return {
+    id: data.id,
+    name: data.name,
+    infoDescription: data.infoDescription
+  };
+}
 
 // @NOTE: All fns from './date-utils` should eventually move here to get rid of their faux modules dependencies
 // `./date-utils` to be deprecated!!
@@ -33,11 +42,7 @@ export const getDatasetLayers = (datasets: VedaData<DatasetData>) =>
   Object.values(datasets).flatMap((dataset: VedaDatum<DatasetData>) => {
     return dataset.data.layers.map((l) => ({
       ...l,
-      parentDataset: {
-        id: dataset.data.id,
-        name: dataset.data.name,
-        infoDescription: dataset.data.infoDescription
-      }
+      parentDataset: getParentDataset(dataset.data)
     }));
   });
 
@@ -45,11 +50,7 @@ export const getLayersFromDataset = (datasets: DatasetData[]) =>
   Object.values(datasets).map((dataset: DatasetData) => {
     return dataset.layers.map((l) => ({
       ...l,
-      parentDataset: {
-        id: dataset.id,
-        name: dataset.name,
-        infoDescription: dataset.infoDescription
-      }
+      parentDataset: getParentDataset(dataset)
     }));
   });
 

--- a/app/scripts/components/exploration/data-utils-no-faux-module.ts
+++ b/app/scripts/components/exploration/data-utils-no-faux-module.ts
@@ -35,7 +35,8 @@ export const getDatasetLayers = (datasets: VedaData<DatasetData>) =>
       ...l,
       parentDataset: {
         id: dataset.data.id,
-        name: dataset.data.name
+        name: dataset.data.name,
+        infoDescription: dataset.data.infoDescription
       }
     }));
   });
@@ -46,7 +47,8 @@ export const getLayersFromDataset = (datasets: DatasetData[]) =>
       ...l,
       parentDataset: {
         id: dataset.id,
-        name: dataset.name
+        name: dataset.name,
+        infoDescription: dataset.infoDescription
       }
     }));
   });

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -1,5 +1,5 @@
 import { DataMetric } from './components/datasets/analysis-metrics';
-import { DatasetLayer } from '$types/veda';
+import { DatasetLayer, ParentDatset } from '$types/veda';
 
 export enum TimeDensity {
   YEAR = 'year',
@@ -81,10 +81,6 @@ export type TimelineDatasetAnalysis =
   | TimelineDatasetAnalysisSuccess;
 
 // END TimelineDatasetAnalysis type discriminants
-export interface ParentDatset {
-  id: string;
-  name: string;
-}
 export interface EnhancedDatasetLayer extends DatasetLayer {
   id: string;
   parentDataset: ParentDatset;

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -273,6 +273,7 @@ export type PageOverrides =
 export interface ParentDatset {
   id: string;
   name: string;
+  infoDescription: string | undefined;
 }
 export interface EnhancedDatasetLayer extends DatasetLayer {
   id: string;


### PR DESCRIPTION
**Related Ticket:** Reported by GHG team that the dashboard is unable to load any kind of info description of the layer

![image (1)](https://github.com/user-attachments/assets/d7dd5e01-3310-4ef7-a2e0-5f95e4fd2624)

### Description of Changes

I think `infoDescription` was somehow missed from one of the changes. I did not trace down the changesets, but my guess is that the data catalog only needs the id and name of the parent dataset, while e&a needs infoDescription, and we somehow ended up with a way of getting the parent dataset for data catalog.  I consolidated them to be one type (which means that data catalog parent dataset will have an unnecessary attribute - which I think is better than diverging `ParentDataset` type throughout the app.)  This PR picks it up again