### PR TITLE
fix: Left Align Banner and Guidance Content

### DIFF
--- a/.env
+++ b/.env
@@ -15,7 +15,7 @@ GOOGLE_FORM = 'https://docs.google.com/forms/d/e/1FAIpQLSfGcd3FDsM3kQIOVKjzdPn4f
 SHOW_CONFIGURABLE_COLOR_MAP = 'TRUE'
 
 # Enables the refactor page header component that uses the USWDS design system
-ENABLE_USWDS_PAGE_HEADER = 'TRUE'
+ENABLE_USWDS_PAGE_HEADER = 'FALSE'
 # Enables the refactor page footer component that uses the USWDS design system
 ENABLE_USWDS_PAGE_FOOTER = 'TRUE'
 # Enables the display of Cookie consent form

--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -4,6 +4,9 @@
   top: 3px;
 }
 
-.veda_one_padding .usa-banner__inner {
-  margin: 0;
+.veda_one_padding {
+  & .usa-banner__inner,
+  & .usa-banner__content {
+    margin: 0;
+  }
 }

--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -1,3 +1,6 @@
 .usa-banner__button:after {
-    top: 3px;
+  top: 3px;
+}
+.usa-banner__inner {
+  justify-content: center;
 }

--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -1,6 +1,9 @@
+@use '$styles/veda-ui-theme-vars.scss' as themeVars;
+
 .usa-banner__button:after {
   top: 3px;
 }
-.usa-banner__inner {
-  justify-content: center;
+
+.veda_one_padding .usa-banner__inner {
+  margin: 0;
 }

--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -4,7 +4,7 @@
   top: 3px;
 }
 
-.veda_one_padding {
+.banner--left-aligned {
   & .usa-banner__inner,
   & .usa-banner__content {
     margin: 0;

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -9,6 +9,7 @@ import {
   USWDSBannerGuidance,
   USWDSMediaBlockBody
 } from '$uswds';
+import { checkEnvFlag } from '$utils/utils';
 
 interface Guidance {
   left?: GuidanceContent;
@@ -100,7 +101,7 @@ export default function Banner({
     ...DEFAULT_GUIDANCE.left,
     ...leftGuidance
   } as GuidanceContent;
-
+  const uswdsHeaderActive = checkEnvFlag(process.env.ENABLE_USWDS_PAGE_HEADER);
   const rightContent = {
     ...DEFAULT_GUIDANCE.right,
     ...rightGuidance
@@ -109,7 +110,7 @@ export default function Banner({
   return (
     <USWDSBanner
       aria-label={ariaLabel ?? DEFAULT_HEADER_TEXT}
-      className={`${className} ${!process.env.ENABLE_USWDS_PAGE_HEADER && 'veda_one_padding'}`}
+      className={`${className} ${!uswdsHeaderActive && 'veda_one_padding'}`}
     >
       <USWDSBannerHeader
         isOpen={isOpen}

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -109,7 +109,7 @@ export default function Banner({
   return (
     <USWDSBanner
       aria-label={ariaLabel ?? DEFAULT_HEADER_TEXT}
-      className={className}
+      className={`${className} ${!process.env.ENABLE_USWDS_PAGE_HEADER && 'veda_one_padding'}`}
     >
       <USWDSBannerHeader
         isOpen={isOpen}

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -92,11 +92,10 @@ export default function Banner({
   leftGuidance,
   rightGuidance,
   className = '',
-  defaultIsOpen = false,
+  defaultIsOpen = true,
   contentId = 'gov-banner-content'
 }: BannerProps) {
   const [isOpen, setIsOpen] = useState(defaultIsOpen);
-
   const leftContent = {
     ...DEFAULT_GUIDANCE.left,
     ...leftGuidance

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -92,7 +92,7 @@ export default function Banner({
   leftGuidance,
   rightGuidance,
   className = '',
-  defaultIsOpen = true,
+  defaultIsOpen = false,
   contentId = 'gov-banner-content'
 }: BannerProps) {
   const [isOpen, setIsOpen] = useState(defaultIsOpen);

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -109,7 +109,7 @@ export default function Banner({
   return (
     <USWDSBanner
       aria-label={ariaLabel ?? DEFAULT_HEADER_TEXT}
-      className={`${className} ${!uswdsHeaderActive && 'veda_one_padding'}`}
+      className={`${className} ${!uswdsHeaderActive && 'banner--left-aligned'}`}
     >
       <USWDSBannerHeader
         isOpen={isOpen}

--- a/mock/veda.config.js
+++ b/mock/veda.config.js
@@ -135,7 +135,7 @@ module.exports = {
     leftGuidance: defaultGuidance.left,
     rightGuidance: defaultGuidance.right,
     className: '',
-    defaultIsOpen: false,
+    defaultIsOpen: true,
     contentId: 'gov-banner-content'
   },
   siteAlert: {

--- a/parcel-resolver-veda/index.js
+++ b/parcel-resolver-veda/index.js
@@ -140,7 +140,7 @@ function getBannerContent(result) {
     leftGuidance: processedLeftGuidance,
     rightGuidance: processedRightGuidance,
     className: '',
-    defaultIsOpen: false,
+    defaultIsOpen: true,
     contentId: 'gov-banner-content'
   });
 }

--- a/parcel-resolver-veda/index.js
+++ b/parcel-resolver-veda/index.js
@@ -118,9 +118,14 @@ function getSiteAlertContent(result) {
 function getBannerContent(result) {
   if (!result.banner) return undefined;
 
-  const { title, leftGuidance, rightGuidance, flagImgSrc, flagImgAlt } =
-    result.banner;
-
+  const {
+    title,
+    leftGuidance,
+    rightGuidance,
+    flagImgSrc,
+    flagImgAlt,
+    defaultIsOpen
+  } = result.banner;
   const processedLeftGuidance = {
     ...leftGuidance,
     text: md.render(leftGuidance.text).replace(/(\r\n|\n|\r)/gm, '')
@@ -140,7 +145,7 @@ function getBannerContent(result) {
     leftGuidance: processedLeftGuidance,
     rightGuidance: processedRightGuidance,
     className: '',
-    defaultIsOpen: true,
+    defaultIsOpen,
     contentId: 'gov-banner-content'
   });
 }


### PR DESCRIPTION

### Description of Changes
Left aligning banner content based on`ENABLE_USWDS_PAGE_HEADER`. If header is set to FALSE the margin-auto css will be removed. 

### Notes & Questions About Changes
Brian and Alex requested that the banner content be left aligned 
![Screenshot 2025-02-21 at 1 09 40 PM](https://github.com/user-attachments/assets/633e95a2-6771-474d-a932-38a94314587a)

https://deploy-preview-165--earth-information-center.netlify.app/

### Validation / Testing
Check netlify preview for left aligned content when .env `ENABLE_USWDS_PAGE_HEADER` is set to FALSE