### PR TITLE
Fix mailto link

### DIFF
--- a/app/scripts/components/common/smart-link.tsx
+++ b/app/scripts/components/common/smart-link.tsx
@@ -33,10 +33,9 @@ interface CustomLinkProps {
  */
 export function CustomLink(props: CustomLinkProps) {
   const { href, ...rest } = props;
-  const isExternalLink = /^https?:\/\//.test(href);
-  const isMailtoLink = /^mailto?:/.test(href);
+  const isExternalLink = /^(https?:\/\/|mailto:)/i.test(href);
   const linkProps = getLinkProps(href);
-  return (isExternalLink || isMailtoLink) ? (
+  return (isExternalLink) ? (
     // @ts-expect-error linkProps returned from getLinkProps are not being recognized suddenly
     <a {...linkProps} {...rest} />
   ) : (

--- a/app/scripts/components/common/smart-link.tsx
+++ b/app/scripts/components/common/smart-link.tsx
@@ -34,8 +34,9 @@ interface CustomLinkProps {
 export function CustomLink(props: CustomLinkProps) {
   const { href, ...rest } = props;
   const isExternalLink = /^https?:\/\//.test(href);
+  const isMailtoLink = /^mailto?:/.test(href);
   const linkProps = getLinkProps(href);
-  return isExternalLink ? (
+  return (isExternalLink || isMailtoLink) ? (
     // @ts-expect-error linkProps returned from getLinkProps are not being recognized suddenly
     <a {...linkProps} {...rest} />
   ) : (

--- a/app/scripts/utils/url.ts
+++ b/app/scripts/utils/url.ts
@@ -13,7 +13,8 @@ export const getLinkProps = (
 ) => {
   // Open the link in a new tab when link is external
   const isExternalLink = /^https?:\/\//.test(linkTo);
-  return isExternalLink
+  const isMailtoLink = /^mailto?:/.test(linkTo);
+  return (isExternalLink || isMailtoLink)
     ? {
         href: linkTo,
         to: linkTo,

--- a/app/scripts/utils/url.ts
+++ b/app/scripts/utils/url.ts
@@ -12,9 +12,9 @@ export const getLinkProps = (
   >
 ) => {
   // Open the link in a new tab when link is external
-  const isExternalLink = /^https?:\/\//.test(linkTo);
-  const isMailtoLink = /^mailto?:/.test(linkTo);
-  return (isExternalLink || isMailtoLink)
+  const isExternalLink = /^(https?:\/\/|mailto:)/i.test(linkTo);
+
+  return (isExternalLink)
     ? {
         href: linkTo,
         to: linkTo,


### PR DESCRIPTION
**Related Ticket:** [_{GHGC #643 }_](https://github.com/US-GHG-Center/veda-config-ghg/issues/643)

### Description of Changes
_{Add mailto regex check in addition to external link check.}_

### Notes & Questions About Changes
_{Instead of creating a different regex check for the mailto link, its added to the same regex that was previously available.}_

### Validation / Testing
_{If an email is used in mdx, it can be clicked to open the email client directly."}_
