### PR TITLE
chore: Remove linkProperties from PageFooter & consolidate creating nav menu item logic

### DIFF
--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -36,12 +36,18 @@ import {
   mainNavItems,
   subNavItems
 } from '$components/common/page-header/default-config';
+import {
+  footerNavItems,
+  footerSubNavItems
+} from '$components/common/page-footer/default-config';
 import { checkEnvFlag } from '$utils/utils';
 
 const appTitle = process.env.APP_TITLE;
 const appDescription = process.env.APP_DESCRIPTION;
 const isUswdsFooterEnabled = checkEnvFlag(process.env.ENABLE_USWDS_PAGE_FOOTER);
-const isCookieConsentEnabled = checkEnvFlag(process.env.ENABLE_COOKIE_CONSENT_FORM);
+const isCookieConsentEnabled = checkEnvFlag(
+  process.env.ENABLE_COOKIE_CONSENT_FORM
+);
 
 export const PAGE_BODY_ID = 'pagebody';
 
@@ -116,10 +122,9 @@ function LayoutRoot(props: { children?: ReactNode }) {
       </PageBody>
       {isUswdsFooterEnabled ? (
         <PageFooter
-          mainNavItems={mainNavItems}
-          subNavItems={subNavItems}
+          mainNavItems={footerNavItems}
+          subNavItems={footerSubNavItems}
           hideFooter={hideFooter}
-          linkProperties={{ LinkElement: NavLink, pathAttributeKeyName: 'to' }}
           logoSvg={<NasaLogoColor />}
           footerSettings={footerSettings}
         />

--- a/app/scripts/components/common/page-footer/default-config.ts
+++ b/app/scripts/components/common/page-footer/default-config.ts
@@ -1,4 +1,20 @@
-import { getFooterSettingsFromVedaConfig } from 'veda';
+import {
+  getNavItemsFromVedaConfig,
+  getFooterSettingsFromVedaConfig
+} from 'veda';
+import { InternalNavLink, ExternalNavLink } from '../types';
+import {
+  aboutNavItem,
+  contactUsNavItem,
+  dataCatalogNavItem,
+  explorationNavItem,
+  storiesNavItem
+} from '../page-header/default-config';
+import {
+  ActionNavItem,
+  DropdownNavLink
+} from '$components/common/page-header/types';
+
 const defaultFooterSettings = {
   secondarySection: {
     division: 'NASA EarthData 2024',
@@ -10,7 +26,54 @@ const defaultFooterSettings = {
   },
   returnToTop: true
 };
+
+export const defaultMainNavItems: (
+  | ExternalNavLink
+  | InternalNavLink
+  | DropdownNavLink
+  | ActionNavItem
+)[] = [
+  {
+    ...dataCatalogNavItem,
+    customClassNames: 'usa-footer__primary-link'
+  },
+  {
+    ...explorationNavItem,
+    customClassNames: 'usa-footer__primary-link'
+  },
+  {
+    ...storiesNavItem,
+    customClassNames: 'usa-footer__primary-link'
+  }
+];
+
+export let defaultSubNavItems: (
+  | ExternalNavLink
+  | InternalNavLink
+  | DropdownNavLink
+  | ActionNavItem
+)[] = [
+  {
+    ...aboutNavItem,
+    customClassNames: 'usa-link text-base-dark text-underline'
+  }
+];
+
+if (process.env.GOOGLE_FORM !== undefined) {
+  defaultSubNavItems = [
+    ...defaultSubNavItems,
+    {
+      ...contactUsNavItem,
+      customClassNames: 'usa-link text-base-dark text-underline'
+    }
+  ];
+}
+
 const footerSettings =
   getFooterSettingsFromVedaConfig() ?? defaultFooterSettings;
+const footerNavItems =
+  getNavItemsFromVedaConfig()?.footerNavItems ?? defaultMainNavItems;
+const footerSubNavItems =
+  getNavItemsFromVedaConfig()?.footerSubNavItems ?? defaultSubNavItems;
 
-export { footerSettings };
+export { footerSettings, footerNavItems, footerSubNavItems };

--- a/app/scripts/components/common/page-footer/footer.test.tsx
+++ b/app/scripts/components/common/page-footer/footer.test.tsx
@@ -1,6 +1,8 @@
-import React, { ComponentType } from 'react';
+import React from 'react';
+import { BrowserRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { navItems } from '../../../../../mock/veda.config.js';
+import { VedaUIConfigProvider } from '../../../../../test/utils.js';
 import NasaLogoColor from '../nasa-logo-color';
 import { NavItem } from '../page-header/types.js';
 
@@ -18,13 +20,10 @@ const defaultFooterSetting = {
   returnToTop: true
 };
 
-const mockMainNavItems: NavItem[] = navItems.mainNavItems;
-const mockSubNavItems: NavItem[] = navItems.subNavItems;
+const mockMainNavItems: NavItem[] = navItems.footerNavItems;
+const mockSubNavItems: NavItem[] = navItems.footerSubNavItems;
 const hideFooter = false;
-const mockLinkProperties = {
-  pathAttributeKeyName: 'to',
-  LinkElement: 'a' as unknown as ComponentType
-};
+
 jest.mock('./default-config', () => ({
   footerSettings: {
     secondarySection: {
@@ -45,13 +44,17 @@ describe('PageFooter', () => {
   });
   test('renders the PageFooter', () => {
     render(
-      <PageFooter
-        mainNavItems={mockMainNavItems}
-        subNavItems={mockSubNavItems}
-        hideFooter={hideFooter}
-        logoSvg={<NasaLogoColor />}
-        footerSettings={defaultFooterSetting}
-      />
+      <BrowserRouter basename=''>
+        <VedaUIConfigProvider>
+          <PageFooter
+            mainNavItems={mockMainNavItems}
+            subNavItems={mockSubNavItems}
+            hideFooter={hideFooter}
+            logoSvg={<NasaLogoColor />}
+            footerSettings={defaultFooterSetting}
+          />
+        </VedaUIConfigProvider>
+      </BrowserRouter>
     );
     const footerElement = document.querySelector('footer');
 
@@ -61,13 +64,17 @@ describe('PageFooter', () => {
 
   test('renders correct buttons and links', () => {
     render(
-      <PageFooter
-        mainNavItems={mockMainNavItems}
-        subNavItems={mockSubNavItems}
-        hideFooter={hideFooter}
-        logoSvg={<NasaLogoColor />}
-        footerSettings={defaultFooterSetting}
-      />
+      <BrowserRouter basename=''>
+        <VedaUIConfigProvider>
+          <PageFooter
+            mainNavItems={mockMainNavItems}
+            subNavItems={mockSubNavItems}
+            hideFooter={hideFooter}
+            logoSvg={<NasaLogoColor />}
+            footerSettings={defaultFooterSetting}
+          />
+        </VedaUIConfigProvider>
+      </BrowserRouter>
     );
     expect(screen.getByText('Data Catalog')).toBeInTheDocument();
     expect(screen.getByText('Exploration')).toBeInTheDocument();
@@ -94,13 +101,17 @@ describe('PageFooter dynamic settings', () => {
       }
     }));
     render(
-      <PageFooter
-        mainNavItems={mockMainNavItems}
-        subNavItems={mockSubNavItems}
-        hideFooter={true}
-        logoSvg={<NasaLogoColor />}
-        footerSettings={defaultFooterSetting}
-      />
+      <BrowserRouter basename=''>
+        <VedaUIConfigProvider>
+          <PageFooter
+            mainNavItems={mockMainNavItems}
+            subNavItems={mockSubNavItems}
+            hideFooter={true}
+            logoSvg={<NasaLogoColor />}
+            footerSettings={defaultFooterSetting}
+          />
+        </VedaUIConfigProvider>
+      </BrowserRouter>
     );
     const footerElement = document.querySelector('footer');
     expect(footerElement).toHaveClass('display-none');

--- a/app/scripts/components/common/page-footer/footer.test.tsx
+++ b/app/scripts/components/common/page-footer/footer.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { navItems } from '../../../../../mock/veda.config.js';
 import { VedaUIConfigProvider } from '../../../../../test/utils.js';
@@ -44,7 +44,7 @@ describe('PageFooter', () => {
   });
   test('renders the PageFooter', () => {
     render(
-      <BrowserRouter basename=''>
+      <MemoryRouter basename=''>
         <VedaUIConfigProvider>
           <PageFooter
             mainNavItems={mockMainNavItems}
@@ -54,7 +54,7 @@ describe('PageFooter', () => {
             footerSettings={defaultFooterSetting}
           />
         </VedaUIConfigProvider>
-      </BrowserRouter>
+      </MemoryRouter>
     );
     const footerElement = document.querySelector('footer');
 
@@ -64,7 +64,7 @@ describe('PageFooter', () => {
 
   test('renders correct buttons and links', () => {
     render(
-      <BrowserRouter basename=''>
+      <MemoryRouter basename=''>
         <VedaUIConfigProvider>
           <PageFooter
             mainNavItems={mockMainNavItems}
@@ -74,7 +74,7 @@ describe('PageFooter', () => {
             footerSettings={defaultFooterSetting}
           />
         </VedaUIConfigProvider>
-      </BrowserRouter>
+      </MemoryRouter>
     );
     expect(screen.getByText('Data Catalog')).toBeInTheDocument();
     expect(screen.getByText('Exploration')).toBeInTheDocument();
@@ -101,7 +101,7 @@ describe('PageFooter dynamic settings', () => {
       }
     }));
     render(
-      <BrowserRouter basename=''>
+      <MemoryRouter basename=''>
         <VedaUIConfigProvider>
           <PageFooter
             mainNavItems={mockMainNavItems}
@@ -111,7 +111,7 @@ describe('PageFooter dynamic settings', () => {
             footerSettings={defaultFooterSetting}
           />
         </VedaUIConfigProvider>
-      </BrowserRouter>
+      </MemoryRouter>
     );
     const footerElement = document.querySelector('footer');
     expect(footerElement).toHaveClass('display-none');

--- a/app/scripts/components/common/page-footer/footer.test.tsx
+++ b/app/scripts/components/common/page-footer/footer.test.tsx
@@ -20,7 +20,6 @@ const defaultFooterSetting = {
 
 const mockMainNavItems: NavItem[] = navItems.mainNavItems;
 const mockSubNavItems: NavItem[] = navItems.subNavItems;
-// const mockFooterSettings = footerSettings;
 const hideFooter = false;
 const mockLinkProperties = {
   pathAttributeKeyName: 'to',
@@ -51,7 +50,6 @@ describe('PageFooter', () => {
         subNavItems={mockSubNavItems}
         hideFooter={hideFooter}
         logoSvg={<NasaLogoColor />}
-        linkProperties={mockLinkProperties}
         footerSettings={defaultFooterSetting}
       />
     );
@@ -68,7 +66,6 @@ describe('PageFooter', () => {
         subNavItems={mockSubNavItems}
         hideFooter={hideFooter}
         logoSvg={<NasaLogoColor />}
-        linkProperties={mockLinkProperties}
         footerSettings={defaultFooterSetting}
       />
     );
@@ -98,7 +95,6 @@ describe('PageFooter dynamic settings', () => {
     }));
     render(
       <PageFooter
-        linkProperties={mockLinkProperties}
         mainNavItems={mockMainNavItems}
         subNavItems={mockSubNavItems}
         hideFooter={true}

--- a/app/scripts/components/common/page-footer/index.tsx
+++ b/app/scripts/components/common/page-footer/index.tsx
@@ -1,11 +1,8 @@
 import React, { useMemo } from 'react';
 import { Icon } from '@trussworks/react-uswds';
-import { DropdownNavLink, NavLinkItem } from '../types';
-import { ActionNavItem, NavItemType } from '../page-header/types';
-import { NavItemCTA } from '../page-header/nav/nav-item-cta';
+import { NavItem } from '../page-header/types';
+import { createDynamicNavMenuList } from '../page-header/nav/create-dynamic-nav-menu-list';
 import ReturnToTopButton from './return-to-top-button';
-
-import { LinkProperties } from '$types/veda';
 import {
   USWDSFooter,
   USWDSFooterNav,
@@ -13,11 +10,10 @@ import {
 } from '$components/common/uswds';
 
 interface PageFooterProps {
-  mainNavItems: (NavLinkItem | DropdownNavLink | ActionNavItem)[];
-  subNavItems: (NavLinkItem | DropdownNavLink | ActionNavItem)[];
+  mainNavItems: NavItem[];
+  subNavItems: NavItem[];
   hideFooter?: boolean;
   logoSvg?: SVGElement | JSX.Element;
-  linkProperties: LinkProperties;
   footerSettings: {
     secondarySection: {
       division: string;
@@ -36,74 +32,17 @@ export default function PageFooter({
   subNavItems,
   hideFooter,
   logoSvg,
-  linkProperties,
   footerSettings
 }: PageFooterProps) {
   const { returnToTop, secondarySection } = footerSettings;
-  const FooterNavItemInternalLink = (item) => {
-    const { item: linkContents, linkClasses, linkProperties } = item;
-    if (linkProperties.LinkElement) {
-      const path = {
-        [linkProperties.pathAttributeKeyName]: linkContents.to
-      };
-      const LinkElement = linkProperties.LinkElement;
-      return (
-        <LinkElement
-          key={linkContents.id}
-          {...path}
-          className={linkClasses}
-          id={linkContents.id}
-        >
-          <span>{linkContents.title}</span>
-        </LinkElement>
-      );
-    }
-    // If the link provided is invalid, do not render the element
-    return null;
-  };
-
-  const createNavElement = (navItems, linkClasses) => {
-    //removing 'dropdown' items from array
-    const cleanedNavItems = navItems.filter((a) => {
-      if (a.type !== 'dropdown') {
-        return a;
-      }
-    });
-
-    return cleanedNavItems.map((item) => {
-      switch (item.type) {
-        case NavItemType.ACTION:
-          return <NavItemCTA item={item} customClasses={linkClasses} />;
-
-        case NavItemType.EXTERNAL_LINK:
-          return (
-            <a className={linkClasses} href={item.to} key={item.id}>
-              {item.title}
-            </a>
-          );
-        case NavItemType.INTERNAL_LINK:
-          return (
-            <FooterNavItemInternalLink
-              item={item}
-              linkClasses={linkClasses}
-              linkProperties={linkProperties}
-            />
-          );
-
-        default:
-          return <></>;
-      }
-    });
-  };
 
   const primaryItems = useMemo(
-    () => createNavElement(mainNavItems, 'usa-footer__primary-link'),
+    () => createDynamicNavMenuList({ navItems: mainNavItems }),
     [mainNavItems]
   );
   const secondaryItems = useMemo(
-    () =>
-      createNavElement(subNavItems, 'usa-link text-base-dark text-underline'),
-    [mainNavItems]
+    () => createDynamicNavMenuList({ navItems: subNavItems }),
+    [subNavItems]
   );
 
   return (

--- a/app/scripts/components/common/page-header/default-config.ts
+++ b/app/scripts/components/common/page-header/default-config.ts
@@ -13,32 +13,47 @@ import {
   ABOUT_PATH
 } from '$utils/routes';
 
-let defaultMainNavItems: (
+export const dataCatalogNavItem: InternalNavLink = {
+  id: 'data-catalog',
+  title: 'Data Catalog',
+  to: DATASETS_PATH,
+  type: NavItemType.INTERNAL_LINK
+};
+
+export const explorationNavItem: InternalNavLink = {
+  id: 'exploration',
+  title: 'Exploration',
+  to: EXPLORATION_PATH,
+  type: NavItemType.INTERNAL_LINK
+};
+
+export const storiesNavItem: InternalNavLink = {
+  id: 'stories',
+  title: getString('stories').other,
+  to: STORIES_PATH,
+  type: NavItemType.INTERNAL_LINK
+};
+
+export const aboutNavItem: InternalNavLink = {
+  id: 'about',
+  title: 'About',
+  to: ABOUT_PATH,
+  type: NavItemType.INTERNAL_LINK
+};
+
+export const contactUsNavItem: ActionNavItem = {
+  id: 'contact-us',
+  title: 'Contact us',
+  actionId: 'open-google-form',
+  type: NavItemType.ACTION
+};
+
+export let defaultMainNavItems: (
   | ExternalNavLink
   | InternalNavLink
   | DropdownNavLink
   | ActionNavItem
-)[] = [
-  {
-    id: 'data-catalog',
-
-    title: 'Data Catalog',
-    to: DATASETS_PATH,
-    type: NavItemType.INTERNAL_LINK
-  },
-  {
-    id: 'exploration',
-    title: 'Exploration',
-    to: EXPLORATION_PATH,
-    type: NavItemType.INTERNAL_LINK
-  },
-  {
-    id: 'stories',
-    title: getString('stories').other,
-    to: STORIES_PATH,
-    type: NavItemType.INTERNAL_LINK
-  }
-];
+)[] = [dataCatalogNavItem, explorationNavItem, storiesNavItem];
 
 if (!!process.env.HUB_URL && !!process.env.HUB_NAME)
   defaultMainNavItems = [
@@ -50,34 +65,20 @@ if (!!process.env.HUB_URL && !!process.env.HUB_NAME)
     } as ExternalNavLink
   ];
 
-let defaultSubNavItems: (
+export let defaultSubNavItems: (
   | ExternalNavLink
   | InternalNavLink
   | DropdownNavLink
   | ActionNavItem
-)[] = [
-  {
-    id: 'about',
-    title: 'About',
-    to: ABOUT_PATH,
-    type: NavItemType.INTERNAL_LINK
-  }
-];
+)[] = [aboutNavItem];
 
 if (process.env.GOOGLE_FORM !== undefined) {
-  defaultSubNavItems = [
-    ...defaultSubNavItems,
-    {
-      id: 'contact-us',
-      title: 'Contact us',
-      actionId: 'open-google-form',
-      type: NavItemType.ACTION
-    }
-  ];
+  defaultSubNavItems = [...defaultSubNavItems, contactUsNavItem];
 }
 
 const mainNavItems =
-  getNavItemsFromVedaConfig()?.mainNavItems ?? defaultMainNavItems;
+  getNavItemsFromVedaConfig()?.headerNavItems ?? defaultMainNavItems;
 const subNavItems =
   getNavItemsFromVedaConfig()?.subNavItems ?? defaultSubNavItems;
+
 export { mainNavItems, subNavItems };

--- a/app/scripts/components/common/page-header/index.tsx
+++ b/app/scripts/components/common/page-header/index.tsx
@@ -43,12 +43,17 @@ export default function PageHeader({
   }, []);
 
   const primaryItems = useMemo(
-    () => createDynamicNavMenuList(mainNavItems, isOpen, setIsOpen),
+    () =>
+      createDynamicNavMenuList({
+        navItems: mainNavItems,
+        dropdownIsOpen: isOpen,
+        dropdownSetIsOpen: setIsOpen
+      }),
     [mainNavItems, isOpen]
   );
 
   const secondaryItems = useMemo(
-    () => createDynamicNavMenuList(subNavItems),
+    () => createDynamicNavMenuList({ navItems: subNavItems }),
     [subNavItems]
   );
 

--- a/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
+++ b/app/scripts/components/common/page-header/nav/create-dynamic-nav-menu-list.tsx
@@ -5,22 +5,27 @@ import { NavItemExternalLink, NavItemInternalLink } from './nav-item-links';
 import { NavItemCTA } from './nav-item-cta';
 import { SetState } from '$types/aliases';
 
-export const createDynamicNavMenuList = (
-  navItems: NavItem[],
-  isOpen?: boolean[],
-  setIsOpen?: SetState<boolean[]>
-): JSX.Element[] => {
+export const createDynamicNavMenuList = ({
+  navItems,
+  dropdownIsOpen,
+  dropdownSetIsOpen
+}: {
+  navItems: NavItem[];
+  dropdownIsOpen?: boolean[];
+  dropdownSetIsOpen?: SetState<boolean[]>;
+}): JSX.Element[] => {
   // @TODO:Need to elevate this functionality to outside of the header. Allow this function to take classname as an argument so we can dynamcally create different types of links across multiple compoenents and apply various visual styling.
   return navItems.map((item, index) => {
     switch (item.type) {
       case NavItemType.DROPDOWN:
-        if (isOpen === undefined || setIsOpen === undefined) return <></>;
+        if (dropdownIsOpen === undefined || dropdownSetIsOpen === undefined)
+          return <></>;
         return (
           <NavDropDownButton
             {...{
               item,
-              isOpen,
-              setIsOpen,
+              isOpen: dropdownIsOpen,
+              setIsOpen: dropdownSetIsOpen,
               index
             }}
           />

--- a/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
+++ b/app/scripts/components/common/page-header/nav/nav-dropdown-button.tsx
@@ -39,7 +39,7 @@ export const NavDropDownButton = ({
     }
   }, [index, isOpen, setIsOpen]);
   const dropdownRef = useClickOutside(handleClickOutside);
-  const submenuItems = createDynamicNavMenuList(item.children);
+  const submenuItems = createDynamicNavMenuList({ navItems: item.children });
 
   return (
     <div key={item.id} ref={dropdownRef}>

--- a/app/scripts/components/common/page-header/nav/nav-item-cta.tsx
+++ b/app/scripts/components/common/page-header/nav/nav-item-cta.tsx
@@ -5,22 +5,18 @@ import { useDisplay } from '$utils/use-display';
 
 interface NavItemCTAProps {
   item: ActionNavItem;
-  customClasses?: string;
 }
 
-export const NavItemCTA = ({ item, customClasses }: NavItemCTAProps) => {
+export const NavItemCTA = ({ item }: NavItemCTAProps) => {
   const { isRevealed, show, hide } = useDisplay();
+  const defaultClassName = 'usa-nav__link';
 
   return (
     <React.Fragment key={item.id}>
       {item.actionId === 'open-google-form' && (
         <>
           <button
-            className={
-              customClasses && customClasses != ''
-                ? customClasses
-                : 'usa-nav__link'
-            }
+            className={item.customClassNames || defaultClassName}
             type='button'
             tabIndex={0}
             id={item.id}

--- a/app/scripts/components/common/page-header/nav/nav-item-links.tsx
+++ b/app/scripts/components/common/page-header/nav/nav-item-links.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ExternalNavLink, InternalNavLink } from '../../types';
 import { useVedaUI } from '$context/veda-ui-provider';
 
-
 interface NavItemExternalLinkProps {
   item: ExternalNavLink;
 }
@@ -12,13 +11,14 @@ interface NavItemInternalLinkProps {
 }
 
 export const NavItemExternalLink = ({ item }: NavItemExternalLinkProps) => {
+  const defaultClassName = 'usa-nav__link';
   return (
     <a
       key={item.id}
       target='_blank'
       rel='noopener noreferrer'
       href={item.href}
-      className='usa-nav__link'
+      className={item.customClassNames || defaultClassName}
       id={item.id}
     >
       <span>{item.title}</span>
@@ -34,11 +34,12 @@ export const NavItemInternalLink = ({ item }: NavItemInternalLinkProps) => {
   const path = {
     [linkProps.pathAttributeKeyName]: (item as InternalNavLink).to
   };
+  const defaultClassName = 'usa-nav__link';
   return (
     <LinkComponent
       key={item.id}
       {...path}
-      className='usa-nav__link'
+      className={item.customClassNames || defaultClassName}
       id={item.id}
     >
       <span>{item.title}</span>

--- a/app/scripts/components/common/page-header/page-header.test.tsx
+++ b/app/scripts/components/common/page-header/page-header.test.tsx
@@ -12,7 +12,7 @@ import PageHeader from './index';
 // @NOTE: Possible Test cases
 // config & create dynamic nav menu list fn - different scenerios, happy vs unhappy path
 
-const mockMainNavItems: NavItem[] = navItems.mainNavItems;
+const mockMainNavItems: NavItem[] = navItems.headerNavItems;
 const mockSubNavItems: NavItem[] = navItems.subNavItems;
 
 const testTitle = 'Test Title';

--- a/app/scripts/components/common/page-header/types.ts
+++ b/app/scripts/components/common/page-header/types.ts
@@ -21,6 +21,7 @@ export interface ActionNavItem extends BaseNavItems {
   actionId: ActionId;
   src?: string;
   type: NavItemType.ACTION;
+  customClassNames?: string;
 }
 
 export interface DropdownNavLink extends BaseNavItems {

--- a/app/scripts/components/common/types.ts
+++ b/app/scripts/components/common/types.ts
@@ -17,12 +17,14 @@ export interface InternalNavLink {
   id: string;
   title: string;
   to: string;
+  customClassNames?: string;
   type: 'internalLink';
 }
 export interface ExternalNavLink {
   id: string;
   title: string;
   href: string;
+  customClassNames?: string;
   type: 'externalLink';
 }
 export type NavLinkItem = ExternalNavLink | InternalNavLink;

--- a/mock/veda.config.js
+++ b/mock/veda.config.js
@@ -1,7 +1,42 @@
 const dotEnvConfig = require('dotenv').config();
 const { parsed: config } = dotEnvConfig;
 
-let mainNavItems = [
+const dataCatalogNavItem = {
+  id: 'data-catalog',
+  title: 'Data Catalog',
+  to: '/data-catalog',
+  type: 'internalLink'
+};
+
+const explorationNavItem = {
+  id: 'exploration',
+  title: 'Exploration',
+  to: '/exploration',
+  type: 'internalLink'
+};
+
+const storiesNavItem = {
+  id: 'stories',
+  title: 'Stories',
+  to: '/stories',
+  type: 'internalLink'
+};
+
+const aboutNavItem = {
+  id: 'about',
+  title: 'About',
+  to: '/about',
+  type: 'internalLink'
+};
+
+const contactUsNavItem = {
+  id: 'contact-us',
+  title: 'Contact us',
+  actionId: 'open-google-form',
+  type: 'action'
+};
+
+let headerNavItems = [
   {
     id: 'test',
     title: 'TestDropdown1',
@@ -28,23 +63,23 @@ let mainNavItems = [
       }
     ]
   },
+  dataCatalogNavItem,
+  explorationNavItem,
+  storiesNavItem
+];
+
+let footerNavItems = [
   {
-    id: 'data-catalog',
-    title: 'Data Catalog',
-    to: '/data-catalog',
-    type: 'internalLink'
+    ...dataCatalogNavItem,
+    customClassNames: 'usa-footer__primary-link'
   },
   {
-    id: 'exploration',
-    title: 'Exploration',
-    to: '/exploration',
-    type: 'internalLink'
+    ...explorationNavItem,
+    customClassNames: 'usa-footer__primary-link'
   },
   {
-    id: 'stories',
-    title: 'Stories',
-    to: '/stories',
-    type: 'internalLink'
+    ...storiesNavItem,
+    customClassNames: 'usa-footer__primary-link'
   }
 ];
 
@@ -61,8 +96,8 @@ let footerSettings = {
 };
 
 if (!!config.HUB_URL && !!config.HUB_NAME)
-  mainNavItems = [
-    ...mainNavItems,
+  headerNavItems = [
+    ...headerNavItems,
     {
       id: 'hub',
       title: process.env.HUB_NAME,
@@ -71,12 +106,12 @@ if (!!config.HUB_URL && !!config.HUB_NAME)
     }
   ];
 
-let subNavItems = [
+let subNavItems = [aboutNavItem];
+
+let footerSubNavItems = [
   {
-    id: 'about',
-    title: 'About',
-    to: '/about',
-    type: 'internalLink'
+    ...aboutNavItem,
+    customClassNames: 'usa-link text-base-dark text-underline'
   }
 ];
 
@@ -96,15 +131,14 @@ const defaultGuidance = {
 };
 
 if (config.GOOGLE_FORM) {
-  subNavItems = [
-    ...subNavItems,
+  footerSubNavItems = [
+    ...footerSubNavItems,
     {
-      id: 'contact-us',
-      title: 'Contact us',
-      actionId: 'open-google-form',
-      type: 'action'
+      ...contactUsNavItem,
+      customClassNames: 'usa-link text-base-dark text-underline'
     }
   ];
+  subNavItems = [...subNavItems, contactUsNavItem];
 }
 
 module.exports = {
@@ -146,8 +180,10 @@ module.exports = {
     showIcon: true
   },
   navItems: {
-    mainNavItems,
-    subNavItems
+    headerNavItems,
+    footerNavItems,
+    subNavItems,
+    footerSubNavItems
   },
 
   footerSettings,

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -383,8 +383,10 @@ declare module 'veda' {
 
   export const getNavItemsFromVedaConfig: () =>
     | {
-        mainNavItems: (NavLinkItem | DropdownNavLink)[] | undefined;
+        headerNavItems: (NavLinkItem | DropdownNavLink)[] | undefined;
+        footerNavItems: NavLinkItem[] | undefined;
         subNavItems: (NavLinkItem | DropdownNavLink)[] | undefined;
+        footerSubNavItems: NavLinkItem[] | undefined;
       }
     | undefined;
 


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1381, https://github.com/NASA-IMPACT/veda-ui/issues/1323
### Description of Changes
* Removed LinkProperties from PageFooter
* Consolidated creating the nav menu item logic - both header and footer now use `createDynamicNavMenuList` instead of redundant duplicate logic that was created just for the footer
* added `customClassNames` attribute to InternalLinkNavItem, ExternalLinkNavItem, ActionNavItem so we can control what classes each item has now
* created default-config file for footer to be definitive 

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
- [ ] Make sure Header and Footer linking logic works as expected
