### PR TITLE
fix: Topic and Source dropdown in stories tab

### DIFF
--- a/app/scripts/components/common/browse-controls/index.tsx
+++ b/app/scripts/components/common/browse-controls/index.tsx
@@ -132,14 +132,16 @@ export default styled(BrowseControls)`
 interface DropdownOptionsProps {
   size: ButtonProps['size'];
   items: FilterOption[];
-  currentId?: string;
+  currentId?: string | string[];
   onChange: (value: FilterOption['id']) => void;
   prefix: string;
 }
 
 function DropdownOptions(props: DropdownOptionsProps) {
   const { size, items, currentId, onChange, prefix } = props;
-  const currentItem = items.find((d) => d.id === currentId);
+  const currentItem = Array.isArray(currentId)
+  ? items.find(item => item.id === currentId[0])
+  : items.find(item => item.id === currentId);
 
   return (
     <DropdownScrollable


### PR DESCRIPTION
**Related Ticket:** _(https://github.com/NASA-IMPACT/veda-ui/issues/1482)_

### Description of Changes
_Topic and Source field in Stories Tab on the dashboard under Browser do not retain the values selected on single stories_

### Validation / Testing
_Validate topics and source dropdown values after selecting topic/source from singe stories_
