### PR TITLE
chore: Remove PageMainContent from exported components

### DIFF
--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -13,7 +13,6 @@ import ReactQueryProvider from './context/react-query';
 import Embed from './components/common/blocks/embed';
 import DevseedUiThemeProvider from './theme-provider';
 import CatalogView from './components/common/catalog';
-import { PageMainContent } from '$styles/page';
 import PageHero from '$components/common/page-hero';
 import StoriesHubContent from '$components/stories/hub/hub-content';
 import { useFiltersWithQS } from '$components/common/catalog/controls/hooks/use-filters-with-query';
@@ -68,7 +67,6 @@ export {
   Image,
   CatalogView,
   DevseedUiThemeProvider,
-  PageMainContent,
   PageHero,
   PageHeader,
   PageFooter,


### PR DESCRIPTION
**Related PR:** https://github.com/NASA-IMPACT/next-veda-ui/pull/55

### Description of Changes
Since `<PageMainContent />` just a styled component with 3 lines of css, we don't really need to expose it. It is already removed from next-veda-ui, see [linked PR](https://github.com/NASA-IMPACT/next-veda-ui/pull/55).


### Notes & Questions About Changes
I assume no other instance has been using it so far.

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
