### PR TITLE
fix: Filter tag name not populated in Dropdown

### DIFF
--- a/app/scripts/components/common/content-taxonomy.tsx
+++ b/app/scripts/components/common/content-taxonomy.tsx
@@ -62,7 +62,7 @@ export function ContentTaxonomy(props: ContentTaxonomyProps) {
                   as={Link}
                   to={`${linkBase}?${
                     FilterActions.TAXONOMY
-                  }=${encodeURIComponent(JSON.stringify({ [name]: [t.id] }))}`}
+                  }=${encodeURIComponent(JSON.stringify({ [name]: t.id }))}`}
                 >
                   {t.name}
                 </Pill>


### PR DESCRIPTION
**Related Ticket:** fix https://github.com/NASA-IMPACT/veda-ui/issues/1482
Alternative to https://github.com/NASA-IMPACT/veda-ui/pull/1483

### Description of Changes
Instead of encoding the id as an array and handling the parsing down the road, we could just use it as string. This way the Dropdown should populate as expected again.

### Notes & Questions About Changes
Was there a specific reason that we added the square brackets? I tried to make sure everything works as described in [this PR](https://github.com/NASA-IMPACT/veda-ui/pull/918) where the change was introduced, but I may lack additional context?


### Validation / Testing
1. Go to this story: https://earth.gov/ghgcenter/stories/modeling-natural-methane-emissions
1. Click on the "Methane" topic
1. See how the stories are filtered by the topic, and the "Filter" button is populated with the topic

Additionally:

- Selecting multiple of the same taxonomy group should execute OR logic
- Selecting across taxonomy groups should execute AND logic
- Tags should persist when page refreshes
- Tags should add/remove correctly when updating filters
- Clicking on the data catalog card and then click on the pills in the info view should take you back to the data catalog filters page with the correct filters checked and you should be able to add/remove filters from there