### PR TITLE
fix: Move UI library seed global style to component level, export veda specific global style to be used with UIlibrary provider

### DIFF
--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -33,6 +33,7 @@ import { usePreviousValue } from '$utils/use-effect-previous';
 
 import { useVedaUI } from '$context/veda-ui-provider';
 import { findParentDatasetFromLayer } from '$utils/data-utils';
+import { globalStyleCSSBlock } from '$styles/theme';
 
 const EXCLUSIVE_SOURCE_WARNING =
   'Can only be analyzed with layers from the same source';
@@ -406,10 +407,7 @@ const Content = styled.div`
   margin-bottom: 8rem;
   position: relative;
   gap: 24px;
-  /* Moving global style of devseed ui library */
-  * {
-    line-height: calc(0.5rem + 1em);
-  }
+  ${globalStyleCSSBlock}
 `;
 
 const Catalog = styled.div`

--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -406,6 +406,10 @@ const Content = styled.div`
   margin-bottom: 8rem;
   position: relative;
   gap: 24px;
+  /* Moving global style of devseed ui library */
+  * {
+    line-height: calc(0.5rem + 1em);
+  }
 `;
 
 const Catalog = styled.div`

--- a/app/scripts/components/common/catalog/catalog-content.tsx
+++ b/app/scripts/components/common/catalog/catalog-content.tsx
@@ -33,7 +33,7 @@ import { usePreviousValue } from '$utils/use-effect-previous';
 
 import { useVedaUI } from '$context/veda-ui-provider';
 import { findParentDatasetFromLayer } from '$utils/data-utils';
-import { globalStyleCSSBlock } from '$styles/theme';
+import { legacyGlobalStyleCSSBlock } from '$styles/legacy-global-styles';
 
 const EXCLUSIVE_SOURCE_WARNING =
   'Can only be analyzed with layers from the same source';
@@ -407,7 +407,9 @@ const Content = styled.div`
   margin-bottom: 8rem;
   position: relative;
   gap: 24px;
-  ${globalStyleCSSBlock}
+  * {
+    ${legacyGlobalStyleCSSBlock}
+  }
 `;
 
 const Catalog = styled.div`

--- a/app/scripts/components/datasets/s-overview/index.tsx
+++ b/app/scripts/components/datasets/s-overview/index.tsx
@@ -12,11 +12,9 @@ import { NotebookConnectButton } from '$components/common/notebook-connect';
 
 import {
   TAXONOMY_GRADE,
-  TAXONOMY_UNCERTAINTY,
+  TAXONOMY_UNCERTAINTY
 } from '$utils/veda-data/taxonomies';
-import {
-  useDataset
-} from '$utils/veda-data';
+import { useDataset } from '$utils/veda-data';
 import { DATASETS_PATH, getDatasetExplorePath } from '$utils/routes';
 import { ContentTaxonomy } from '$components/common/content-taxonomy';
 import { DatasetClassification } from '$components/common/dataset-classification';

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -12,12 +12,14 @@ import { getLayersFromDatasetLayers } from '$utils/data-utils';
 import CatalogContent from '$components/common/catalog/catalog-content-legacy';
 import { useFiltersWithURLAtom } from '$components/common/catalog/controls/hooks/use-filters-with-query';
 import { FilterActions } from '$components/common/catalog/utils';
-
+import { legacyGlobalStyleCSSBlock } from '$styles/legacy-global-styles';
 import { DatasetData, DatasetLayer } from '$types/veda';
 
 const DatasetModal = styled(Modal)`
   z-index: ${themeVal('zIndices.modal')};
-
+  * {
+    ${legacyGlobalStyleCSSBlock}
+  }
   /* Override ModalContents */
   > div {
     display: flex;

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -18,6 +18,10 @@ const Container = styled.div`
   flex-grow: 1;
   height: 100%;
 
+  /* Moving global style of devseed ui library */
+  * {
+    line-height: calc(0.5rem + 1em);
+  }
   .panel-wrapper {
     flex-grow: 1;
   }

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -10,6 +10,7 @@ import { useAnalysisController } from './hooks/use-analysis-data-request';
 import { TimelineDataset } from './types.d.ts';
 import { selectedCompareDateAtom, selectedDateAtom } from './atoms/dates';
 import { CLEAR_LOCATION, urlAtom } from '$utils/params-location-atom/url';
+import { globalStyleCSSBlock } from '$styles/theme';
 
 // @TODO: "height: 100%" Added for exploration container to show correctly in NextJs instance but investigate why this is needed and possibly work to remove
 const Container = styled.div`
@@ -18,10 +19,8 @@ const Container = styled.div`
   flex-grow: 1;
   height: 100%;
 
-  /* Moving global style of devseed ui library */
-  * {
-    line-height: calc(0.5rem + 1em);
-  }
+  ${globalStyleCSSBlock}
+
   .panel-wrapper {
     flex-grow: 1;
   }

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -10,7 +10,7 @@ import { useAnalysisController } from './hooks/use-analysis-data-request';
 import { TimelineDataset } from './types.d.ts';
 import { selectedCompareDateAtom, selectedDateAtom } from './atoms/dates';
 import { CLEAR_LOCATION, urlAtom } from '$utils/params-location-atom/url';
-import { globalStyleCSSBlock } from '$styles/theme';
+import { legacyGlobalStyleCSSBlock } from '$styles/legacy-global-styles';
 
 // @TODO: "height: 100%" Added for exploration container to show correctly in NextJs instance but investigate why this is needed and possibly work to remove
 const Container = styled.div`
@@ -18,8 +18,9 @@ const Container = styled.div`
   flex-flow: column;
   flex-grow: 1;
   height: 100%;
-
-  ${globalStyleCSSBlock}
+  * {
+    ${legacyGlobalStyleCSSBlock}
+  }
 
   .panel-wrapper {
     flex-grow: 1;

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -18,9 +18,6 @@ const Container = styled.div`
   flex-flow: column;
   flex-grow: 1;
   height: 100%;
-  * {
-    ${legacyGlobalStyleCSSBlock}
-  }
 
   .panel-wrapper {
     flex-grow: 1;
@@ -31,7 +28,9 @@ const Container = styled.div`
     flex-direction: column;
     position: relative;
   }
-
+  * {
+    ${legacyGlobalStyleCSSBlock}
+  }
   .panel-timeline {
     box-shadow: 0 -1px 0 0 ${themeVal('color.base-100')};
   }

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -61,6 +61,10 @@ const BrowseFoldHeader = styled(FoldHeader)`
 
 const FoldWithTopMargin = styled(Fold)`
   margin-top: ${glsp()};
+  /* Moving global style of devseed ui library */
+  * {
+    line-height: calc(0.5rem + 1em);
+  }
 `;
 
 interface StoryDataWithPath extends StoryData {

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -43,6 +43,7 @@ import { generateTaxonomies } from '$utils/veda-data/taxonomies';
 import { StoryData } from '$types/veda';
 import { UseFiltersWithQueryResult } from '$components/common/catalog/controls/hooks/use-filters-with-query';
 import { useVedaUI } from '$context/veda-ui-provider';
+import { globalStyleCSSBlock } from '$styles/theme';
 
 const StoryCount = styled(Subtitle)`
   grid-column: 1 / -1;
@@ -61,10 +62,7 @@ const BrowseFoldHeader = styled(FoldHeader)`
 
 const FoldWithTopMargin = styled(Fold)`
   margin-top: ${glsp()};
-  /* Moving global style of devseed ui library */
-  * {
-    line-height: calc(0.5rem + 1em);
-  }
+  ${globalStyleCSSBlock}
 `;
 
 interface StoryDataWithPath extends StoryData {

--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -43,7 +43,7 @@ import { generateTaxonomies } from '$utils/veda-data/taxonomies';
 import { StoryData } from '$types/veda';
 import { UseFiltersWithQueryResult } from '$components/common/catalog/controls/hooks/use-filters-with-query';
 import { useVedaUI } from '$context/veda-ui-provider';
-import { globalStyleCSSBlock } from '$styles/theme';
+import { legacyGlobalStyleCSSBlock } from '$styles/legacy-global-styles';
 
 const StoryCount = styled(Subtitle)`
   grid-column: 1 / -1;
@@ -62,7 +62,9 @@ const BrowseFoldHeader = styled(FoldHeader)`
 
 const FoldWithTopMargin = styled(Fold)`
   margin-top: ${glsp()};
-  ${globalStyleCSSBlock}
+  * {
+    ${legacyGlobalStyleCSSBlock}
+  }
 `;
 
 interface StoryDataWithPath extends StoryData {

--- a/app/scripts/index.ts
+++ b/app/scripts/index.ts
@@ -35,6 +35,8 @@ import {
   externalDatasetsAtom
 } from '$components/exploration/atoms/datasetLayers';
 
+import { GlobalStyles as LegacyGlobalStyles } from '$styles/legacy-global-styles';
+
 // Include only the custom stylings for the VEDA components into the library build
 import './styles/veda-components.scss';
 import CatalogContent from '$components/common/catalog/catalog-content';
@@ -97,5 +99,8 @@ export {
   // STATE
   timelineDatasetsAtom,
   externalDatasetsAtom,
-  datasetLayersAtom
+  datasetLayersAtom,
+
+  // STYLE
+  LegacyGlobalStyles
 };

--- a/app/scripts/main.tsx
+++ b/app/scripts/main.tsx
@@ -22,7 +22,8 @@ import { userPages } from 'veda';
 import DevseedUiThemeProvider from './theme-provider';
 
 import { discoveryRoutes } from './redirects';
-import theme, { GlobalStyles } from '$styles/theme';
+import theme from '$styles/theme';
+import { GlobalStyles } from '$styles/legacy-global-styles';
 import { getAppURL } from '$utils/history';
 import LayoutRoot from '$components/common/layout-root';
 import { LayoutRootContextProvider } from '$components/common/layout-root/context';

--- a/app/scripts/styles/legacy-global-styles.js
+++ b/app/scripts/styles/legacy-global-styles.js
@@ -1,8 +1,56 @@
-import { css } from 'styled-components';
-import { themeVal } from '@devseed-ui/theme-provider';
+import { css, createGlobalStyle } from 'styled-components';
+import { themeVal, media } from '@devseed-ui/theme-provider';
+import { reactTippyStyles } from '$components/common/tip';
+/**
+ * Print values for all variables across media queries.
+ */
+export const GlobalStyles = createGlobalStyle`
+  /* stylelint-disable-next-line selector-type-no-unknown */
+  ${reactTippyStyles()}
+
+  .tether-element.tether-element {
+    z-index: ${themeVal('zIndices.dropdown')};
+  }
+
+  :root {
+    --base-space-multiplier: ${themeVal('layout.glspMultiplier.xsmall')};
+    --base-font-family: ${themeVal('type.base.family')};
+    --veda-color-primary: ${themeVal('color.primary')};
+    --veda-color-secondary: ${themeVal('color.secondary')};
+    --veda-color-link: ${themeVal('color.link')};
+    --veda-color-base: ${themeVal('color.base')};
+  }
+
+  ${media.smallUp`
+    :root {
+      --base-text-increment: ${themeVal('type.base.sizeIncrement.small')};
+      --base-space-multiplier: ${themeVal('layout.glspMultiplier.small')};
+    }
+  `}
+
+  ${media.mediumUp`
+    :root {
+      --base-text-increment: ${themeVal('type.base.sizeIncrement.medium')};
+      --base-space-multiplier: ${themeVal('layout.glspMultiplier.medium')};
+    }
+  `}
+
+  ${media.largeUp`
+    :root {
+      --base-text-increment: ${themeVal('type.base.sizeIncrement.large')};
+      --base-space-multiplier: ${themeVal('layout.glspMultiplier.large')};
+    }
+  `}
+
+  ${media.xlargeUp`
+    :root {
+      --base-text-increment: ${themeVal('type.base.sizeIncrement.xlarge')};
+      --base-space-multiplier: ${themeVal('layout.glspMultiplier.xlarge')};
+    }
+  `}
+`;
 
 export const legacyGlobalStyleCSSBlock = css`
-  font-size: 16px;
   font-family: ${themeVal('type.base.family')};
   line-height: calc(0.5rem + 1em);
 `;

--- a/app/scripts/styles/legacy-global-styles.js
+++ b/app/scripts/styles/legacy-global-styles.js
@@ -1,0 +1,8 @@
+import { css } from 'styled-components';
+import { themeVal } from '@devseed-ui/theme-provider';
+
+export const legacyGlobalStyleCSSBlock = css`
+  font-size: 16px;
+  font-family: ${themeVal('type.base.family')};
+  line-height: calc(0.5rem + 1em);
+`;

--- a/app/scripts/styles/page.js
+++ b/app/scripts/styles/page.js
@@ -5,15 +5,13 @@ import { media } from '@devseed-ui/theme-provider';
 
 import { VarHeading, VarLead } from './variable-components';
 import { variableBaseType, variableGlsp } from './variable-utils';
+import { globalStyleCSSBlock } from '$styles/theme';
 
 export const PageMainContent = styled.main`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  /* Moving global style of devseed ui library */
-  * {
-    line-height: calc(0.5rem + 1em);
-  }
+  ${globalStyleCSSBlock};
 `;
 
 export const PageMainTitle = styled(VarHeading).attrs((props) => ({

--- a/app/scripts/styles/page.js
+++ b/app/scripts/styles/page.js
@@ -10,6 +10,10 @@ export const PageMainContent = styled.main`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+  /* Moving global style of devseed ui library */
+  * {
+    line-height: calc(0.5rem + 1em);
+  }
 `;
 
 export const PageMainTitle = styled(VarHeading).attrs((props) => ({

--- a/app/scripts/styles/page.js
+++ b/app/scripts/styles/page.js
@@ -5,13 +5,15 @@ import { media } from '@devseed-ui/theme-provider';
 
 import { VarHeading, VarLead } from './variable-components';
 import { variableBaseType, variableGlsp } from './variable-utils';
-import { globalStyleCSSBlock } from '$styles/theme';
+import { legacyGlobalStyleCSSBlock } from '$styles/legacy-global-styles';
 
 export const PageMainContent = styled.main`
   flex-grow: 1;
   display: flex;
   flex-direction: column;
-  ${globalStyleCSSBlock};
+  * {
+    ${legacyGlobalStyleCSSBlock};
+  }
 `;
 
 export const PageMainTitle = styled(VarHeading).attrs((props) => ({

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -1,4 +1,4 @@
-import { css, createGlobalStyle } from 'styled-components';
+import { createGlobalStyle } from 'styled-components';
 import { createUITheme, media, themeVal } from '@devseed-ui/theme-provider';
 import { defaultsDeep } from 'lodash';
 import { theme } from 'veda';
@@ -59,11 +59,6 @@ export const VEDA_OVERRIDE_THEME = {
     }
   }
 };
-
-export const globalStyleCSSBlock = css`
-  font-size: 16px;
-  line-height: calc(0.5rem + 1em);
-`;
 
 export default function themeOverrides() {
   if (theme) {

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -1,9 +1,6 @@
-import { createGlobalStyle } from 'styled-components';
-import { createUITheme, media, themeVal } from '@devseed-ui/theme-provider';
+import { createUITheme } from '@devseed-ui/theme-provider';
 import { defaultsDeep } from 'lodash';
 import { theme } from 'veda';
-
-import { reactTippyStyles } from '$components/common/tip';
 
 export const VEDA_OVERRIDE_THEME = {
   zIndices: {
@@ -67,52 +64,3 @@ export default function themeOverrides() {
     return createUITheme(VEDA_OVERRIDE_THEME);
   }
 }
-
-/**
- * Print values for all variables across media queries.
- */
-export const GlobalStyles = createGlobalStyle`
-  /* stylelint-disable-next-line selector-type-no-unknown */
-  ${reactTippyStyles()}
-
-  .tether-element.tether-element {
-    z-index: ${themeVal('zIndices.dropdown')};
-  }
-
-  :root {
-    --base-space-multiplier: ${themeVal('layout.glspMultiplier.xsmall')};
-    --base-font-family: ${themeVal('type.base.family')};
-    --veda-color-primary: ${themeVal('color.primary')};
-    --veda-color-secondary: ${themeVal('color.secondary')};
-    --veda-color-link: ${themeVal('color.link')};
-    --veda-color-base: ${themeVal('color.base')};
-  }
-
-  ${media.smallUp`
-    :root {
-      --base-text-increment: ${themeVal('type.base.sizeIncrement.small')};
-      --base-space-multiplier: ${themeVal('layout.glspMultiplier.small')};
-    }
-  `}
-
-  ${media.mediumUp`
-    :root {
-      --base-text-increment: ${themeVal('type.base.sizeIncrement.medium')};
-      --base-space-multiplier: ${themeVal('layout.glspMultiplier.medium')};
-    }
-  `}
-
-  ${media.largeUp`
-    :root {
-      --base-text-increment: ${themeVal('type.base.sizeIncrement.large')};
-      --base-space-multiplier: ${themeVal('layout.glspMultiplier.large')};
-    }
-  `}
-
-  ${media.xlargeUp`
-    :root {
-      --base-text-increment: ${themeVal('type.base.sizeIncrement.xlarge')};
-      --base-space-multiplier: ${themeVal('layout.glspMultiplier.xlarge')};
-    }
-  `}
-`;

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -1,4 +1,4 @@
-import { createGlobalStyle } from 'styled-components';
+import { css, createGlobalStyle } from 'styled-components';
 import { createUITheme, media, themeVal } from '@devseed-ui/theme-provider';
 import { defaultsDeep } from 'lodash';
 import { theme } from 'veda';
@@ -59,6 +59,11 @@ export const VEDA_OVERRIDE_THEME = {
     }
   }
 };
+
+export const globalStyleCSSBlock = css`
+  font-size: 16px;
+  line-height: calc(0.5rem + 1em);
+`;
 
 export default function themeOverrides() {
   if (theme) {

--- a/app/scripts/styles/theme.ts
+++ b/app/scripts/styles/theme.ts
@@ -34,6 +34,7 @@ export const VEDA_OVERRIDE_THEME = {
       family: '"Public Sans",sans-serif',
       leadSize: '1.25rem',
       extrabold: '800',
+      line: 'inherit',
       // Increments to the type.base.size for each media breakpoint.
       sizeIncrement: {
         small: '0rem',


### PR DESCRIPTION
**Related Ticket:** #1503 

### Description of Changes
Nav height (specifically, the bottom row) varies depending on which page a user is on in Next instance: https://veda-ui-next-test.netlify.app/exploration?datasets=%5B%5D&taxonomy=%7B%7D (Navigate to any other page than homepage, the bottom row becomes taller.) 
This is because devseed ui library injects the default global line height: https://github.com/developmentseed/ui-library-seed/blob/96807c534c46521ce781717aa09d20ae1134e99b/packages/theme-provider/src/theme.js#L59  - and the homepage does not use ui library theme - therefore it has a different global style value. In this pr, I am passing the global line-height value as inherent and moving the global line height value to the top level of each component. 

### Notes & Questions About Changes

I am exporting GlobalStyle, and using it for the pages that use devseed ui library components (https://github.com/NASA-IMPACT/next-veda-ui/pull/56) - most of the globalstyle is just css variables that ui seed library needs, which I think should have no conflict with uswds. 


### Validation / Testing
There are two things to validate.
- The components don't look different inside of VEDA UI instance. 
- USWDS Header doesn't change heights in Next instance. 
- But this change will decrease the height of USWDS nav bottom row - Tagging @faustoperez to check