### PR TITLE
chore: Set banner defaultIsOpen to false in mock/veda.config.js

### DIFF
--- a/mock/veda.config.js
+++ b/mock/veda.config.js
@@ -172,7 +172,7 @@ module.exports = {
     leftGuidance: defaultGuidance.left,
     rightGuidance: defaultGuidance.right,
     className: '',
-    defaultIsOpen: true,
+    defaultIsOpen: false,
     contentId: 'gov-banner-content'
   },
   siteAlert: {


### PR DESCRIPTION
Just because having it closed by default is more convenient (and I believe the recommended setting? Doesn't explicitly say so in the guidelines, but the examples are all closed https://designsystem.digital.gov/components/banner/).