### PR TITLE
feat: Add widget container components for full page and full screen view

### DIFF
--- a/app/scripts/components/common/uswds/icon.tsx
+++ b/app/scripts/components/common/uswds/icon.tsx
@@ -1,0 +1,3 @@
+import { Icon } from '@trussworks/react-uswds';
+
+export const USWDSIcon = Icon;

--- a/app/scripts/components/common/uswds/index.tsx
+++ b/app/scripts/components/common/uswds/index.tsx
@@ -32,6 +32,7 @@ export { USWDSMenu } from './header/menu';
 export { USWDSNavMenuButton } from './header/nav-menu-button';
 export { USWDSNavDropDownButton } from './header/nav-drop-down-button';
 export { USWDSExtendedNav } from './header/extended-nav';
+export { USWDSIcon } from './icon';
 export { USWDSTextInput, USWDSTextInputMask } from './input';
 export { USWDSLink } from './link';
 export { USWDSPagination } from './pagination';

--- a/app/scripts/components/common/widget/fullpage-modal.tsx
+++ b/app/scripts/components/common/widget/fullpage-modal.tsx
@@ -35,25 +35,19 @@ const FullpageModalWidget = ({
   return (
     <>
       {!isFullPage && (
-        <div // widget-container
-          className='width-full height-full border border-base-light radius-md'
-        >
+        <div className='width-full height-full border border-base-light radius-md'>
           <Header
             isExpanded={isFullPage}
             heading={heading}
             handleExpansion={() => setIsFullPage(true)}
           />
-          <div // widget-content
-            className='padding-2'
-          >
-            {children}
-          </div>
+          <div className='padding-2'>{children}</div>
         </div>
       )}
 
       <AnimatePresence>
         {isFullPage && (
-          <motion.div // fullpage-overlay
+          <motion.div
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.9 }}
@@ -65,11 +59,7 @@ const FullpageModalWidget = ({
               heading={heading}
               handleExpansion={() => setIsFullPage(false)}
             />
-            <div // widget-content
-              className='padding-2'
-            >
-              {children}
-            </div>
+            <div className='padding-2'>{children}</div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/scripts/components/common/widget/fullpage-modal.tsx
+++ b/app/scripts/components/common/widget/fullpage-modal.tsx
@@ -1,0 +1,80 @@
+import React, { ReactNode, useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import Header from './header';
+
+interface FullpageModalWidgetProps {
+  heading: string;
+  children: ReactNode;
+}
+
+/**
+ * A React component that toggles the display of modal content between a compact
+ *  widget view and a full-page overlay.
+ *
+ * This component renders a container that initially shows a widget with a
+ * header and content. When the header's expansion handler is activated, the
+ * component transitions to a full-page mode using animated effects provided
+ * by Framer Motion's AnimatePresence and motion.div.
+ *
+ * @param {string} heading - The title text displayed in the header of the
+ * modal.
+ * @param {React.ReactNode} children - The content to be rendered inside the
+ * modal.
+ *
+ * @example
+ * <FullpageModalWidget heading="Modal Title">
+ *   <p>Your content goes here.</p>
+ * </FullpageModalWidget>
+ */
+const FullpageModalWidget = ({
+  heading,
+  children
+}: FullpageModalWidgetProps) => {
+  const [isFullPage, setIsFullPage] = useState(false);
+
+  return (
+    <>
+      {!isFullPage && (
+        <div // widget-container
+          className='width-full height-full border border-base-light radius-md'
+        >
+          <Header
+            isExpanded={isFullPage}
+            heading={heading}
+            handleExpansion={() => setIsFullPage(true)}
+          />
+          <div // widget-content
+            className='padding-2'
+          >
+            {children}
+          </div>
+        </div>
+      )}
+
+      <AnimatePresence>
+        {isFullPage && (
+          <motion.div // fullpage-overlay
+            initial={{ opacity: 0, scale: 0.9 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.9 }}
+            transition={{ duration: 0.3 }}
+            className='position-fixed top-0 left-0 width-full height-full bg-white z-top padding-2 shadow-2'
+          >
+            <Header
+              isExpanded={isFullPage}
+              heading={heading}
+              handleExpansion={() => setIsFullPage(false)}
+            />
+            <div // widget-content
+              className='padding-2'
+            >
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};
+
+export default FullpageModalWidget;

--- a/app/scripts/components/common/widget/fullscreen-api.tsx
+++ b/app/scripts/components/common/widget/fullscreen-api.tsx
@@ -44,7 +44,7 @@ const FullscreenWidget = ({
   };
 
   return (
-    <div // widget-container
+    <div
       ref={widgetRef}
       className='width-full height-full border border-base-light radius-md'
     >
@@ -53,11 +53,7 @@ const FullscreenWidget = ({
         heading={heading}
         handleExpansion={handleFullscreen}
       />
-      <div // widget-content
-        className='padding-2'
-      >
-        {children}
-      </div>
+      <div className='padding-2'>{children}</div>
     </div>
   );
 };

--- a/app/scripts/components/common/widget/fullscreen-api.tsx
+++ b/app/scripts/components/common/widget/fullscreen-api.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode, useRef, useState } from 'react';
+import Header from './header';
+
+/**
+ * Renders a widget component with fullscreen capability.
+ *
+ * This component wraps its children with a container that can be toggled into
+ * fullscreen mode.
+ * The fullscreen state is controlled via the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), and the component
+ * uses a ref to reference its DOM node.
+ *
+ * @param heading - The title to display in the widget's header.
+ * @param children - The content nodes to be rendered inside the widget.
+ *
+ * @example
+ * <FullscreenWidget heading="My Widget">
+ *   <p>This is the widget content.</p>
+ * </FullscreenWidget>
+ */
+const FullscreenWidget = ({
+  heading,
+  children
+}: {
+  heading: string;
+  children: ReactNode;
+}) => {
+  const widgetRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const handleFullscreen = () => {
+    if (widgetRef.current) {
+      if (!document.fullscreenElement) {
+        widgetRef.current
+          .requestFullscreen()
+          .then(() => setIsFullscreen(true))
+          .catch((err) => {
+            // eslint-disable-next-line no-console
+            console.error('Error attempting to enable full-screen mode:', err);
+          });
+      } else if (document.exitFullscreen) {
+        document.exitFullscreen().then(() => setIsFullscreen(false));
+      }
+    }
+  };
+
+  return (
+    <div // widget-container
+      ref={widgetRef}
+      className='width-full height-full border border-base-light radius-md'
+    >
+      <Header
+        isExpanded={isFullscreen}
+        heading={heading}
+        handleExpansion={handleFullscreen}
+      />
+      <div // widget-content
+        className='padding-2'
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default FullscreenWidget;

--- a/app/scripts/components/common/widget/header.tsx
+++ b/app/scripts/components/common/widget/header.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
 import { USWDSIcon, USWDSButton } from '$uswds';
 
 /**
@@ -27,24 +27,39 @@ const Header = ({
   heading: string;
   handleExpansion: () => void;
 }) => {
+  const [showText, setShowText] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const updateButtonVisibility = useCallback(() => {
+    if (containerRef.current) {
+      setShowText(containerRef.current.offsetWidth > 450);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    updateButtonVisibility(); // ensures that the button text visibility is set correctly when the component first renders.
+    window.addEventListener('resize', updateButtonVisibility);
+    return () => window.removeEventListener('resize', updateButtonVisibility);
+  }, [updateButtonVisibility]);
+
   return (
     <div // widget-header
-      className='padding-2 display-flex flex-justify space-between flex-align-center border-bottom border-base-light'
+      ref={containerRef}
+      className='padding-2 display-flex flex-justify space-between flex-align-center'
     >
       {isExpanded ? <h1>{heading}</h1> : <h6>{heading}</h6>}
 
       <USWDSButton // fullscreen-button
         type='button'
         outline={true}
-        className='margin-0'
+        className='margin-0 margin-left-3'
         onClick={handleExpansion}
       >
-        {isExpanded ? (
-          <USWDSIcon.Close size={5} />
-        ) : (
-          <USWDSIcon.ZoomOutMap size={4} />
+        {isExpanded ? <USWDSIcon.Close size={3} /> : <USWDSIcon.ZoomOutMap />}
+
+        {showText && (
+          <span>{isExpanded ? 'Exit fullscreen' : 'Enter fullscreen'}</span>
         )}
-        {isExpanded ? 'Exit fullscreen' : 'Enter fullscreen'}
       </USWDSButton>
     </div>
   );

--- a/app/scripts/components/common/widget/header.tsx
+++ b/app/scripts/components/common/widget/header.tsx
@@ -43,13 +43,13 @@ const Header = ({
   }, [updateButtonVisibility]);
 
   return (
-    <div // widget-header
+    <div
       ref={containerRef}
       className='padding-2 display-flex flex-justify space-between flex-align-center'
     >
       {isExpanded ? <h1>{heading}</h1> : <h6>{heading}</h6>}
 
-      <USWDSButton // fullscreen-button
+      <USWDSButton
         type='button'
         outline={true}
         className='margin-0 margin-left-3'

--- a/app/scripts/components/common/widget/header.tsx
+++ b/app/scripts/components/common/widget/header.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { USWDSIcon, USWDSButton } from '$uswds';
+
+/**
+ * Renders the header for the fullscreen widget.
+ *
+ * This header component displays the widget's title and a button to toggle
+ * between fullscreen and normal modes. When the widget is in fullscreen mode,
+ * the title is displayed as an <h1> element; otherwise, it is displayed as
+ * an <h6>.
+ *
+ * @param {boolean} isExpanded - Indicates whether the widget is currently in
+ * fullscreen or full page mode.
+ * @param {string} heading - The heading text to be displayed in the header.
+ * @param {() => void} handleExpansion - Callback function that toggles the
+ * expanded state.
+ *
+ * @returns {JSX.Element} A JSX element representing the widget header,
+ * including the title and a fullscreen toggle button.
+ */
+const Header = ({
+  isExpanded,
+  heading,
+  handleExpansion
+}: {
+  isExpanded: boolean;
+  heading: string;
+  handleExpansion: () => void;
+}) => {
+  return (
+    <div // widget-header
+      className='padding-2 display-flex flex-justify space-between flex-align-center border-bottom border-base-light'
+    >
+      {isExpanded ? <h1>{heading}</h1> : <h6>{heading}</h6>}
+
+      <USWDSButton // fullscreen-button
+        type='button'
+        outline={true}
+        className='margin-0'
+        onClick={handleExpansion}
+      >
+        {isExpanded ? (
+          <USWDSIcon.Close size={5} />
+        ) : (
+          <USWDSIcon.ZoomOutMap size={4} />
+        )}
+        {isExpanded ? 'Exit fullscreen' : 'Enter fullscreen'}
+      </USWDSButton>
+    </div>
+  );
+};
+
+export default Header;

--- a/app/scripts/components/common/widget/index.ts
+++ b/app/scripts/components/common/widget/index.ts
@@ -1,0 +1,4 @@
+import FullscreenWidget from '$components/common/widget/fullscreen-api';
+import FullpageModalWidget from '$components/common/widget/fullpage-modal';
+
+export { FullscreenWidget, FullpageModalWidget };

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -17,9 +17,12 @@ import SandboxMDXEditor from './legacy/mdx-editor';
 import SandboxTable from './legacy/table';
 import SandboxLayerInfo from './legacy/layer-info';
 import SandboxOverride from './override';
-
 import { USWDSColors } from './colors';
 import Pagination from './pagination';
+import {
+  FullscreenWidget,
+  FullpageModalWidget
+} from '$components/common/widget';
 import { resourceNotFound } from '$components/uhoh';
 import { Card } from '$components/common/card';
 import PageHero from '$components/common/page-hero';
@@ -164,6 +167,66 @@ function Sandbox() {
                       title='USWDS Pagination'
                       to='pagination'
                     />
+                  </Grid>
+
+                  <Grid col={12} className='margin-top-2 margin-bottom-3'>
+                    <h2>Explore widget possibilities</h2>
+                  </Grid>
+                  <Grid col={6} className='margin-bottom-3'>
+                    <FullscreenWidget heading='Fullscreen API'>
+                      <p>
+                        This is using the fullscreen API, displaying the content
+                        in full screen size.
+                      </p>
+                      <img
+                        src='https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXZrcmlkeGVreDFlbGRpNm9leTMxOTh1ZTFocHhtdmxhODZvaWt1biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPnAiaMCws8nOsE/giphy.gif'
+                        width='457'
+                        height='480'
+                      />
+                      <p>
+                        <a href='https://giphy.com/gifs/cat-kitten-computer-3oKIPnAiaMCws8nOsE'>
+                          via GIPHY
+                        </a>
+                      </p>
+                    </FullscreenWidget>
+                  </Grid>
+                  <Grid col={6} className='margin-bottom-3'>
+                    <FullpageModalWidget heading='Fullpage Modal'>
+                      <p>
+                        This is using the a modal approach with a micro
+                        animation. The extend spans the whole page, but does not
+                        cover the browser tools.
+                      </p>
+                      <img
+                        src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXc3azJsZmxoaTE1cXR4dDlvem5taHFlMXJwOWcwZDJrMnoza2YzMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/q5Wtr34IBE1KOYHkyN/giphy.gif'
+                        width='480'
+                        height='360'
+                      />
+                      <p>
+                        <a href='https://giphy.com/gifs/epic-bots-epicbots-q5Wtr34IBE1KOYHkyN'>
+                          via GIPHY
+                        </a>
+                      </p>
+                    </FullpageModalWidget>
+                  </Grid>
+                  <Grid col={6} className='margin-bottom-3'>
+                    <FullpageModalWidget heading='Fullpage Modal 2'>
+                      <p>
+                        This is using the a modal approach with a micro
+                        animation. The extend spans the whole page, but does not
+                        cover the browser tools.
+                      </p>
+                      <img
+                        src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWJqMzdnMTUxZG5mc3R2aWlka3ZtaTZvaXdvZjRkOGx1MjB1NGU2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lzz3B3xLZluuY/giphy.gif'
+                        width='480'
+                        height='350'
+                      />
+                      <p>
+                        <a href='https://giphy.com/gifs/cat-hacker-lzz3B3xLZluuY'>
+                          via GIPHY
+                        </a>
+                      </p>
+                    </FullpageModalWidget>
                   </Grid>
                 </Grid>
               </GridContainer>

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -19,6 +19,9 @@ import SandboxLayerInfo from './legacy/layer-info';
 import SandboxOverride from './override';
 import { USWDSColors } from './colors';
 import Pagination from './pagination';
+import { Figure } from '$components/common/figure';
+import { Caption } from '$components/common/blocks/images';
+import { LazyMap as Map } from '$components/common/blocks/lazy-components';
 import {
   FullscreenWidget,
   FullpageModalWidget
@@ -209,7 +212,7 @@ function Sandbox() {
                       </p>
                     </FullpageModalWidget>
                   </Grid>
-                  <Grid col={8} className='margin-bottom-3'>
+                  <Grid col={4} className='margin-bottom-3'>
                     <FullpageModalWidget heading='Fullpage Modal 2'>
                       <p>
                         This is using the a modal approach with a micro
@@ -226,6 +229,27 @@ function Sandbox() {
                           via GIPHY
                         </a>
                       </p>
+                    </FullpageModalWidget>
+                  </Grid>
+
+                  <Grid col={8} className='margin-bottom-3'>
+                    <FullpageModalWidget heading='Widget with Map'>
+                      <Figure>
+                        <Map
+                          datasetId='no2'
+                          layerId='no2-monthly'
+                          center={[-84.39, 33.75]}
+                          zoom={9.5}
+                          dateTime='2019-06-01'
+                          compareDateTime='2020-06-01'
+                        />
+                        <Caption attrAuthor='NASA' attrUrl='https://nasa.gov/'>
+                          Levels in 10¹⁵ molecules cm⁻². Darker colors indicate
+                          higher nitrogen dioxide (NO₂) levels associated and
+                          more activity. Lighter colors indicate lower levels of
+                          NO₂ and less activity.
+                        </Caption>
+                      </Figure>
                     </FullpageModalWidget>
                   </Grid>
                 </Grid>

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -209,7 +209,7 @@ function Sandbox() {
                       </p>
                     </FullpageModalWidget>
                   </Grid>
-                  <Grid col={6} className='margin-bottom-3'>
+                  <Grid col={8} className='margin-bottom-3'>
                     <FullpageModalWidget heading='Fullpage Modal 2'>
                       <p>
                         This is using the a modal approach with a micro


### PR DESCRIPTION
**Related Ticket:** contribute to #1281 

### Description of Changes
Adding two different components, a fullscreen widget using the [Fullscreen API](https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API), and a full page widget using a model overlay with a micro animation. Both containers consist of a header with the button to toggle, and the content rendering the components children.

To show case the components I add some examples to the sandbox page. 

### Notes & Questions About Changes
I did not yet add the container to our mdx content provider, I will do this in a separate PR to keep to scope small enough to easily review.

### Validation / Testing
- Explore examples on https://deploy-preview-1520--veda-ui.netlify.app/sandbox/
- Open and close full screen or full page mode