### PR TITLE
feat: updates for titiler-cmr layers like HLS

### DIFF
--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -1,10 +1,24 @@
 import React from 'react';
 
+import startOfDay from 'date-fns/startOfDay';
+import endOfDay from 'date-fns/endOfDay';
 import { BaseTimeseriesProps } from '../types';
 import { RasterPaintLayer } from './raster-paint-layer';
+import { userTzDate2utcString } from '$utils/date';
 
 export function CMRTimeseries(props: BaseTimeseriesProps) {
   const { date, sourceParams } = props;
-  const tileParams = { datetime: date, ...sourceParams };
-  return <RasterPaintLayer {...props} tileParams={tileParams} generatorPrefix='cmr-timeseries' />;
+  const start_datetime = userTzDate2utcString(startOfDay(date));
+  const end_datetime = userTzDate2utcString(endOfDay(date));
+  const tileParams = {
+    datetime: `${start_datetime}/${end_datetime}`,
+    ...sourceParams
+  };
+  return (
+    <RasterPaintLayer
+      {...props}
+      tileParams={tileParams}
+      generatorPrefix='cmr-timeseries'
+    />
+  );
 }

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -52,7 +52,24 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
 
   useEffect(
     () => {
-      const tileParamsAsString = qs.stringify(updatedTileParams, {
+      // Create a modified version of the parameters
+      const processedParams = { ...updatedTileParams };
+
+      if (Array.isArray(processedParams.bands)) {
+        // Convert array to string manually using the format you want
+        processedParams.bands = processedParams.bands
+          .map((band) => `bands=${encodeURIComponent(band)}`)
+          .join('&');
+      }
+
+      if (Array.isArray(processedParams.assets)) {
+        processedParams.assets = processedParams.assets
+          .map((asset) => `assets=${encodeURIComponent(asset)}`)
+          .join('&');
+      }
+
+      // Stringify the rest normally
+      const tileParamsAsString = qs.stringify(processedParams, {
         arrayFormat: 'comma'
       });
 

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -56,28 +56,29 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       const processedParams = { ...updatedTileParams } as {
         reScale?: number[];
         colormap_name?: string;
-        bands?: string;
-        assets?: string;
+        bands?: string[];
+        assets?: string[];
         [key: string]: any;
       };
 
-      if (Array.isArray(processedParams.bands)) {
-        // Convert array to string manually using the format you want
-        processedParams.bands = processedParams.bands
-          .map((band) => `bands=${encodeURIComponent(band)}`)
-          .join('&');
-      }
+      // bands and assets need to be sent as repeat query params
+      const { bands, assets, ...regularParams } = processedParams;
 
-      if (Array.isArray(processedParams.assets)) {
-        processedParams.assets = processedParams.assets
-          .map((asset) => `assets=${encodeURIComponent(asset)}`)
-          .join('&');
-      }
+      const repeatParams: Record<string, string[] | undefined> = {};
+      if (Array.isArray(bands)) repeatParams.bands = bands;
+      if (Array.isArray(assets)) repeatParams.assets = assets;
 
-      // Stringify the rest normally
-      const tileParamsAsString = qs.stringify(processedParams, {
+      const regularParamsString = qs.stringify(regularParams, {
         arrayFormat: 'comma'
       });
+
+      const repeatParamsString = qs.stringify(repeatParams, {
+        arrayFormat: 'repeat'
+      });
+
+      const tileParamsAsString = [regularParamsString, repeatParamsString]
+        .filter(Boolean) // Remove empty strings
+        .join('&');
 
       const zarrSource: RasterSourceSpecification = {
         type: 'raster',

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -53,7 +53,13 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
   useEffect(
     () => {
       // Create a modified version of the parameters
-      const processedParams = { ...updatedTileParams };
+      const processedParams = { ...updatedTileParams } as {
+        reScale?: number[];
+        colormap_name?: string;
+        bands?: string;
+        assets?: string;
+        [key: string]: any;
+      };
 
       if (Array.isArray(processedParams.bands)) {
         // Convert array to string manually using the format you want


### PR DESCRIPTION
**Related Ticket:**
resolves #1536
resolves #1537


### Description of Changes
There are two small changes here:
1. Use `arrayFormat = 'repeat'` for `assets` and `bands` parameters to enable passing multiple values to titiler-pgstac or titiler-cmr
2. Provide `datetime` as a range for titiler-cmr tile requests. 
  - This would also be relevant to imagery collections in our own STAC database where `datetime={date}T00:00:00Z` is not guaranteed to intersect with the item datetime.


### Notes & Questions About Changes
- Would it make sense to add a new parameter to the `Layer` props like `datetime_format` so we could control this more explicitly?

### Validation / Testing
Validate that the GPMIMERG dataset still works [link](https://deploy-preview-1534--veda-ui.netlify.app/exploration?search=&datasets=%5B%7B%22id%22%3A%22GPM_3IMERGDF.v07%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22gnbu%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A46%7D%7D%7D%5D&taxonomy=%7B%7D&date=2024-04-27T05%3A00%3A00.000Z)
