### PR TITLE
chore: Add tests for the widget components

### DIFF
--- a/app/scripts/components/common/widget/__snapshots__/widget.test.tsx.snap
+++ b/app/scripts/components/common/widget/__snapshots__/widget.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FullscreenWidget matches snapshot 1`] = `
+<div
+  class="width-full height-full border border-base-light radius-md"
+  data-testid="widget-container"
+>
+  <div
+    class="padding-2 display-flex flex-justify space-between flex-align-center"
+    data-testid="widget-header"
+  >
+    <h6>
+      Test Fullscreen Widget
+    </h6>
+    <button
+      class="usa-button usa-button--outline margin-0 margin-left-3"
+      data-testid="widget-toggle"
+      type="button"
+    >
+      <svg
+        aria-label="Enter fullscreen"
+        class="usa-icon"
+        focusable="false"
+        height="1em"
+        role="img"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m15 3 2.3 2.3-2.89 2.87 1.42 1.42L18.7 6.7 21 9V3h-6zM3 9l2.3-2.3 2.87 2.89 1.42-1.42L6.7 5.3 9 3H3v6zm6 12-2.3-2.3 2.89-2.87-1.42-1.42L5.3 17.3 3 15v6h6zm12-6-2.3 2.3-2.87-2.89-1.42 1.42 2.89 2.87L15 21h6v-6z"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    class="padding-2"
+    data-testid="widget-content"
+  >
+    <div>
+      Widget Content
+    </div>
+  </div>
+</div>
+`;

--- a/app/scripts/components/common/widget/fullpage-modal.tsx
+++ b/app/scripts/components/common/widget/fullpage-modal.tsx
@@ -35,13 +35,18 @@ const FullpageModalWidget = ({
   return (
     <>
       {!isFullPage && (
-        <div className='width-full height-full border border-base-light radius-md'>
+        <div
+          className='width-full height-full border border-base-light radius-md'
+          data-testid='widget-container'
+        >
           <Header
             isExpanded={isFullPage}
             heading={heading}
             handleExpansion={() => setIsFullPage(true)}
           />
-          <div className='padding-2'>{children}</div>
+          <div className='padding-2' data-testid='widget-content'>
+            {children}
+          </div>
         </div>
       )}
 
@@ -53,13 +58,16 @@ const FullpageModalWidget = ({
             exit={{ opacity: 0, scale: 0.9 }}
             transition={{ duration: 0.3 }}
             className='position-fixed top-0 left-0 width-full height-full bg-white z-top padding-2 shadow-2'
+            data-testid='widget-container'
           >
             <Header
               isExpanded={isFullPage}
               heading={heading}
               handleExpansion={() => setIsFullPage(false)}
             />
-            <div className='padding-2'>{children}</div>
+            <div className='padding-2' data-testid='full-content'>
+              {children}
+            </div>
           </motion.div>
         )}
       </AnimatePresence>

--- a/app/scripts/components/common/widget/fullscreen-api.tsx
+++ b/app/scripts/components/common/widget/fullscreen-api.tsx
@@ -47,13 +47,19 @@ const FullscreenWidget = ({
     <div
       ref={widgetRef}
       className='width-full height-full border border-base-light radius-md'
+      data-testid='widget-container'
     >
       <Header
         isExpanded={isFullscreen}
         heading={heading}
         handleExpansion={handleFullscreen}
       />
-      <div className='padding-2'>{children}</div>
+      <div
+        className='padding-2'
+        data-testid={isFullscreen ? 'full-content' : 'widget-content'}
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/app/scripts/components/common/widget/header.tsx
+++ b/app/scripts/components/common/widget/header.tsx
@@ -46,6 +46,7 @@ const Header = ({
     <div
       ref={containerRef}
       className='padding-2 display-flex flex-justify space-between flex-align-center'
+      data-testid='widget-header'
     >
       {isExpanded ? <h1>{heading}</h1> : <h6>{heading}</h6>}
 
@@ -54,8 +55,13 @@ const Header = ({
         outline={true}
         className='margin-0 margin-left-3'
         onClick={handleExpansion}
+        data-testid='widget-toggle'
       >
-        {isExpanded ? <USWDSIcon.Close size={3} /> : <USWDSIcon.ZoomOutMap />}
+        {isExpanded ? (
+          <USWDSIcon.Close size={3} role='img' aria-label='Exit fullscreen' />
+        ) : (
+          <USWDSIcon.ZoomOutMap role='img' aria-label='Enter fullscreen' />
+        )}
 
         {showText && (
           <span>{isExpanded ? 'Exit fullscreen' : 'Enter fullscreen'}</span>

--- a/app/scripts/components/common/widget/widget.test.tsx
+++ b/app/scripts/components/common/widget/widget.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  act
+} from '@testing-library/react';
+import FullpageModal from './fullpage-modal';
+import FullscreenWidget from './fullscreen-api';
+
+const setContainerWidth = (width: number) => {
+  // eslint-disable-next-line fp/no-mutating-methods
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    value: width
+  });
+};
+
+describe('FullpageModal', () => {
+  const defaultProps = {
+    heading: 'Test Modal Widget',
+    children: <div>Modal Content</div>
+  };
+
+  afterEach(cleanup);
+
+  it('renders whith heading', () => {
+    render(<FullpageModal {...defaultProps} />);
+    expect(screen.getByText('Test Modal Widget')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Enter fullscreen/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('widget-content')).toBeInTheDocument();
+  });
+
+  it('expands when fullscreen button is clicked', () => {
+    render(<FullpageModal {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Enter fullscreen/i });
+
+    fireEvent.click(button);
+
+    expect(screen.queryByTestId('widget-content')).not.toBeInTheDocument();
+    expect(screen.getByTestId('full-content')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Exit fullscreen/i })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the button with text on wide widgets', () => {
+    setContainerWidth(500);
+
+    render(<FullpageModal {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Enter fullscreen/i });
+
+    expect(button).toHaveTextContent('Enter fullscreen');
+  });
+
+  it('renders the button without text on small widgets', () => {
+    setContainerWidth(200);
+
+    render(<FullpageModal {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Enter fullscreen/i });
+    expect(button).not.toHaveTextContent('Enter fullscreen');
+  });
+
+  it('updates button text visibility when window resizes', () => {
+    setContainerWidth(500);
+    render(<FullpageModal {...defaultProps} />);
+
+    expect(screen.getByText('Enter fullscreen')).toBeInTheDocument();
+
+    setContainerWidth(200);
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(screen.queryByText('Enter fullscreen')).not.toBeInTheDocument();
+  });
+});
+
+describe('FullscreenWidget', () => {
+  const defaultProps = {
+    heading: 'Test Fullscreen Widget',
+    children: <div>Widget Content</div>
+  };
+
+  it('renders with heading', () => {
+    render(<FullscreenWidget {...defaultProps} />);
+    expect(screen.getByText('Test Fullscreen Widget')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Enter fullscreen/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('widget-content')).toBeInTheDocument();
+  });
+
+  it('expands when fullscreen button is clicked', async () => {
+    render(<FullscreenWidget {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /Enter fullscreen/i });
+
+    Element.prototype.requestFullscreen = jest
+      .fn()
+      .mockResolvedValue(Promise.resolve());
+
+    Document.prototype.exitFullscreen = jest
+      .fn()
+      .mockResolvedValue(Promise.resolve());
+
+    await act(async () => {
+      fireEvent.click(button);
+      document.dispatchEvent(new Event('fullscreenchange'));
+    });
+
+    expect(Element.prototype.requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId('full-content')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Exit fullscreen/i })
+    ).toBeInTheDocument();
+  });
+
+  it('matches snapshot', () => {
+    const { container } = render(<FullscreenWidget {...defaultProps} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -19,13 +19,7 @@ import SandboxLayerInfo from './legacy/layer-info';
 import SandboxOverride from './override';
 import { USWDSColors } from './colors';
 import Pagination from './pagination';
-import { Figure } from '$components/common/figure';
-import { Caption } from '$components/common/blocks/images';
-import { LazyMap as Map } from '$components/common/blocks/lazy-components';
-import {
-  FullscreenWidget,
-  FullpageModalWidget
-} from '$components/common/widget';
+import Widgets from './widgets';
 import { resourceNotFound } from '$components/uhoh';
 import { Card } from '$components/common/card';
 import PageHero from '$components/common/page-hero';
@@ -112,6 +106,11 @@ const pages = [
     id: 'pagination',
     name: 'USWDS Pagination',
     component: Pagination
+  },
+  {
+    id: 'widgets',
+    name: 'USWDS Widgets',
+    component: Widgets
   }
 ];
 
@@ -171,86 +170,12 @@ function Sandbox() {
                       to='pagination'
                     />
                   </Grid>
-
-                  <Grid col={12} className='margin-top-2 margin-bottom-3'>
-                    <h2>Explore widget possibilities</h2>
-                  </Grid>
-                  <Grid col={6} className='margin-bottom-3'>
-                    <FullscreenWidget heading='Fullscreen API'>
-                      <p>
-                        This is using the fullscreen API, displaying the content
-                        in full screen size.
-                      </p>
-                      <img
-                        src='https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXZrcmlkeGVreDFlbGRpNm9leTMxOTh1ZTFocHhtdmxhODZvaWt1biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPnAiaMCws8nOsE/giphy.gif'
-                        width='457'
-                        height='480'
-                      />
-                      <p>
-                        <a href='https://giphy.com/gifs/cat-kitten-computer-3oKIPnAiaMCws8nOsE'>
-                          via GIPHY
-                        </a>
-                      </p>
-                    </FullscreenWidget>
-                  </Grid>
-                  <Grid col={6} className='margin-bottom-3'>
-                    <FullpageModalWidget heading='Fullpage Modal'>
-                      <p>
-                        This is using the a modal approach with a micro
-                        animation. The extend spans the whole page, but does not
-                        cover the browser tools.
-                      </p>
-                      <img
-                        src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXc3azJsZmxoaTE1cXR4dDlvem5taHFlMXJwOWcwZDJrMnoza2YzMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/q5Wtr34IBE1KOYHkyN/giphy.gif'
-                        width='480'
-                        height='360'
-                      />
-                      <p>
-                        <a href='https://giphy.com/gifs/epic-bots-epicbots-q5Wtr34IBE1KOYHkyN'>
-                          via GIPHY
-                        </a>
-                      </p>
-                    </FullpageModalWidget>
-                  </Grid>
                   <Grid col={4} className='margin-bottom-3'>
-                    <FullpageModalWidget heading='Fullpage Modal 2'>
-                      <p>
-                        This is using the a modal approach with a micro
-                        animation. The extend spans the whole page, but does not
-                        cover the browser tools.
-                      </p>
-                      <img
-                        src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWJqMzdnMTUxZG5mc3R2aWlka3ZtaTZvaXdvZjRkOGx1MjB1NGU2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lzz3B3xLZluuY/giphy.gif'
-                        width='480'
-                        height='350'
-                      />
-                      <p>
-                        <a href='https://giphy.com/gifs/cat-hacker-lzz3B3xLZluuY'>
-                          via GIPHY
-                        </a>
-                      </p>
-                    </FullpageModalWidget>
-                  </Grid>
-
-                  <Grid col={8} className='margin-bottom-3'>
-                    <FullpageModalWidget heading='Widget with Map'>
-                      <Figure>
-                        <Map
-                          datasetId='no2'
-                          layerId='no2-monthly'
-                          center={[-84.39, 33.75]}
-                          zoom={9.5}
-                          dateTime='2019-06-01'
-                          compareDateTime='2020-06-01'
-                        />
-                        <Caption attrAuthor='NASA' attrUrl='https://nasa.gov/'>
-                          Levels in 10¹⁵ molecules cm⁻². Darker colors indicate
-                          higher nitrogen dioxide (NO₂) levels associated and
-                          more activity. Lighter colors indicate lower levels of
-                          NO₂ and less activity.
-                        </Caption>
-                      </Figure>
-                    </FullpageModalWidget>
+                    <Card
+                      linkLabel='View more'
+                      title='USWDS Widgets'
+                      to='widgets'
+                    />
                   </Grid>
                 </Grid>
               </GridContainer>

--- a/app/scripts/components/sandbox/widgets/index.tsx
+++ b/app/scripts/components/sandbox/widgets/index.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { GridContainer, Grid } from '@trussworks/react-uswds';
+
+import { Figure } from '$components/common/figure';
+import { Caption } from '$components/common/blocks/images';
+import { LazyMap as Map } from '$components/common/blocks/lazy-components';
+import {
+  FullscreenWidget,
+  FullpageModalWidget
+} from '$components/common/widget';
+
+export default function WidgetSandbox() {
+  return (
+    <GridContainer>
+      <Grid row gap={3}>
+        <Grid col={12} className='margin-top-2 margin-bottom-3'>
+          <h2>Explore widget possibilities</h2>
+        </Grid>
+        <Grid col={6} className='margin-bottom-3'>
+          <FullscreenWidget heading='Fullscreen API'>
+            <p>
+              This is using the fullscreen API, displaying the content in full
+              screen size.
+            </p>
+            <img
+              src='https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbXZrcmlkeGVreDFlbGRpNm9leTMxOTh1ZTFocHhtdmxhODZvaWt1biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3oKIPnAiaMCws8nOsE/giphy.gif'
+              width='457'
+              height='480'
+            />
+            <p>
+              <a href='https://giphy.com/gifs/cat-kitten-computer-3oKIPnAiaMCws8nOsE'>
+                via GIPHY
+              </a>
+            </p>
+          </FullscreenWidget>
+        </Grid>
+        <Grid col={6} className='margin-bottom-3'>
+          <FullpageModalWidget heading='Fullpage Modal'>
+            <p>
+              This is using the a modal approach with a micro animation. The
+              extend spans the whole page, but does not cover the browser tools.
+            </p>
+            <img
+              src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExaXc3azJsZmxoaTE1cXR4dDlvem5taHFlMXJwOWcwZDJrMnoza2YzMCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/q5Wtr34IBE1KOYHkyN/giphy.gif'
+              width='480'
+              height='360'
+            />
+            <p>
+              <a href='https://giphy.com/gifs/epic-bots-epicbots-q5Wtr34IBE1KOYHkyN'>
+                via GIPHY
+              </a>
+            </p>
+          </FullpageModalWidget>
+        </Grid>
+        <Grid col={4} className='margin-bottom-3'>
+          <FullpageModalWidget heading='Small Widget'>
+            <p>
+              This is using the a modal approach with a micro animation. The
+              extend spans the whole page, but does not cover the browser tools.
+            </p>
+            <img
+              src='https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExZWJqMzdnMTUxZG5mc3R2aWlka3ZtaTZvaXdvZjRkOGx1MjB1NGU2bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/lzz3B3xLZluuY/giphy.gif'
+              width='480'
+              height='350'
+            />
+            <p>
+              <a href='https://giphy.com/gifs/cat-hacker-lzz3B3xLZluuY'>
+                via GIPHY
+              </a>
+            </p>
+          </FullpageModalWidget>
+        </Grid>
+
+        <Grid col={8} className='margin-bottom-3'>
+          <FullpageModalWidget heading='Widget with Map'>
+            <Figure>
+              <Map
+                datasetId='no2'
+                layerId='no2-monthly'
+                center={[-84.39, 33.75]}
+                zoom={9.5}
+                dateTime='2019-06-01'
+                compareDateTime='2020-06-01'
+              />
+              <Caption attrAuthor='NASA' attrUrl='https://nasa.gov/'>
+                Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher
+                nitrogen dioxide (NO₂) levels associated and more activity.
+                Lighter colors indicate lower levels of NO₂ and less activity.
+              </Caption>
+            </Figure>
+          </FullpageModalWidget>
+        </Grid>
+      </Grid>
+    </GridContainer>
+  );
+}

--- a/test/playwright/tests/widget.spec.ts
+++ b/test/playwright/tests/widget.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from '../pages/basePage';
+
+test.describe('Widgets', () => {
+  let pageErrorCalled = false;
+
+  test.beforeEach(async ({ page, consentBanner }) => {
+    // Log all uncaught errors to the terminal
+    page.on('pageerror', (exception) => {
+      // eslint-disable-next-line no-console
+      console.warn(`Uncaught exception: "${exception}"`);
+      pageErrorCalled = true;
+    });
+
+    // Navigate to the test page rendering the widget component
+    await page.goto('/sandbox/widgets');
+    await consentBanner.acceptButton.click();
+  });
+
+  test('should open and close the Fullpage Modal widget', async ({ page }) => {
+    const widgetContainer = page
+      .locator('[data-testid="widget-container"]')
+      .filter({ hasText: 'Fullpage Modal' });
+
+    await expect(widgetContainer).toBeVisible();
+
+    const widgetHeader = widgetContainer.locator(
+      '[data-testid="widget-header"]'
+    );
+    await expect(widgetHeader).toBeVisible();
+
+    const toggleButton = widgetContainer.locator(
+      '[data-testid="widget-toggle"]'
+    );
+    await expect(toggleButton).toBeVisible();
+    const widgetContent = widgetContainer.locator(
+      '[data-testid="widget-content"]'
+    );
+
+    const fullContent = page.locator('[data-testid="full-content"]');
+
+    await expect(widgetContent).toBeVisible();
+    await expect(fullContent).toBeHidden();
+
+    await toggleButton.click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500); // Wait for animation to complete
+
+    await expect(widgetContent).toBeHidden();
+    await expect(fullContent).toBeVisible();
+
+    await widgetContainer.locator('[data-testid="widget-toggle"]').click();
+    // eslint-disable-next-line playwright/no-wait-for-timeout
+    await page.waitForTimeout(500); // Wait for animation to complete
+
+    await expect(widgetContent).toBeVisible();
+    await expect(fullContent).toBeHidden();
+
+    // scroll page to bottom
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    expect(pageErrorCalled, 'no javascript exceptions thrown on page').toBe(
+      false
+    );
+  });
+
+  test('should render the button with or without text, depending on widget width', async ({
+    page
+  }) => {
+    const bigContainer = page
+      .locator('[data-testid="widget-container"]')
+      .filter({ hasText: 'Widget with Map' });
+    const buttonWithText = bigContainer.locator(
+      '[data-testid="widget-toggle"]'
+    );
+    await expect(buttonWithText).toBeVisible();
+    await expect(buttonWithText).toHaveText('Enter fullscreen');
+
+    const smallContainer = page
+      .locator('[data-testid="widget-container"]')
+      .filter({ hasText: 'Small Widget' });
+    const buttonWithIconOnly = smallContainer.locator(
+      '[data-testid="widget-toggle"]'
+    );
+    await expect(buttonWithIconOnly).toBeVisible();
+    await expect(buttonWithIconOnly).not.toHaveText('Enter fullscreen');
+  });
+});


### PR DESCRIPTION
**Related Ticket:** close [#1522](https://github.com/NASA-IMPACT/veda-ui/issues/1522)

### Description of Changes
Adding tests for both the widgets on the sandbox page (with playwright) and testing the actual rendering with jest/testing-library.
Also added a few data-testid attributes to make it easier to select elements in tests, which works for both playwright and jest

### Notes & Questions About Changes
There's now a snapshot test for the widget. If any changes accidentally affect this component, the test will catch it. Developers will need to review the changes and update the snapshot if they're intentional.

### Validation / Testing
You can run the tests by using `yarn test` for unit tests and `yarn test:e2e` for end-to-end tests.