### PR TITLE
fix: AttrAuthor and Url Causing Image Size to Change #1478

### DIFF
--- a/app/scripts/components/common/figure.js
+++ b/app/scripts/components/common/figure.js
@@ -12,6 +12,7 @@ export const Figure = styled.figure`
   position: relative;
   display: inline-block;
   vertical-align: top;
+  width: 100%;
 
   > a {
     display: block;


### PR DESCRIPTION
**Related Ticket:** fix #1478 

### Description of Changes
Added a style attribute to set the width of images to Figure element. This way, the image size is displayed as expected.

### Notes & Questions About Changes
Were there any other stories where we had this image size issue?

### Validation / Testing
1. Go to the story: https://www.earthdata.nasa.gov/dashboard/stories/blizzards
2. Keep on scrolling, and you would see the image size in the block is consistent and does not scale to a smaller size as it did while adding AttrAuthor and Url.
