### PR TITLE
fix: Legend populated after enountering a datset without it

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -406,7 +406,7 @@ function Scrollytelling(props) {
         <SwitchTransition>
           <CSSTransition
             key={name}
-            timeout={!activeChapterLayer ? 1 : undefined}
+            timeout={1}
             addEndListener={(node, done) => {
               if (!activeChapterLayer) return;
               node?.addEventListener('transitionend', done, false);

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -406,7 +406,7 @@ function Scrollytelling(props) {
         <SwitchTransition>
           <CSSTransition
             key={name}
-            timeout={1}
+            timeout={!activeChapterLayer ? 1 : undefined}
             addEndListener={(node, done) => {
               if (!activeChapterLayer) return;
               node?.addEventListener('transitionend', done, false);

--- a/app/scripts/components/common/map/layer-legend.tsx
+++ b/app/scripts/components/common/map/layer-legend.tsx
@@ -24,7 +24,7 @@ import {
   WidgetItemHeadline,
   WidgetItemHGroup
 } from '$styles/panel';
-import { LayerLegendCategorical, LayerLegendGradient } from '$types/veda';
+import { LayerLegendCategorical, LayerLegendGradient, LayerLegendText} from '$types/veda';
 import { divergingColorMaps, sequentialColorMaps, restColorMaps } from '$components/exploration/components/datasets/colorMaps';
 import { DEFAULT_COLORMAP } from '$components/exploration/components/datasets/colormap-options';
 
@@ -210,7 +210,7 @@ const LegendBody = styled(WidgetItemBodyInner)`
 `;
 
 export function LayerLegend(
-  props: LayerLegendCommonProps & (LayerLegendGradient | LayerLegendCategorical)
+  props: LayerLegendCommonProps & (LayerLegendGradient | LayerLegendCategorical | LayerLegendText)
 ) {
   const { id, type, title, description } = props;
 

--- a/app/scripts/components/common/notebook-connect.tsx
+++ b/app/scripts/components/common/notebook-connect.tsx
@@ -9,8 +9,9 @@ import {
   CollecticonDownload2
 } from '@devseed-ui/collecticons';
 import { Modal } from '@devseed-ui/modal';
-import { DatasetData, datasets } from 'veda';
+import { datasets } from 'veda';
 
+import { DatasetData } from '$types/veda';
 import { HintedError } from '$utils/hinted-error';
 import { variableGlsp } from '$styles/variable-utils';
 
@@ -134,7 +135,11 @@ export function NotebookConnectModal(props: {
           <DatasetUsages>
             {datasetUsagesWithIcon.map((datasetUsage) => (
               <li key={datasetUsage.url}>
-                <DatasetUsageLink href={datasetUsage.url} target='_blank' rel='noopener'>
+                <DatasetUsageLink
+                  href={datasetUsage.url}
+                  target='_blank'
+                  rel='noopener'
+                >
                   {IconByType[datasetUsage.type]}
                   <DatasetUsageLabel>
                     <h4>{datasetUsage.title}</h4>
@@ -240,7 +245,7 @@ function NotebookConnectCalloutSelf(props: NotebookConnectCalloutProps) {
       <NotebookConnectButton
         // compact={false}
         variation='base-outline'
-        dataset={dataset.data}
+        dataset={dataset.data as DatasetData}
       />
     </div>
   );

--- a/app/scripts/components/common/notebook-connect.tsx
+++ b/app/scripts/components/common/notebook-connect.tsx
@@ -10,7 +10,6 @@ import {
 } from '@devseed-ui/collecticons';
 import { Modal } from '@devseed-ui/modal';
 import { datasets } from 'veda';
-
 import { DatasetData } from '$types/veda';
 import { HintedError } from '$utils/hinted-error';
 import { variableGlsp } from '$styles/variable-utils';

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -14,7 +14,7 @@ import Tippy from '@tippyjs/react';
 import { LayerInfoLiner } from '../layer-info-modal';
 import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
-import { LayerLegendCategorical, LayerLegendGradient } from '$types/veda';
+import { LayerLegendCategorical, LayerLegendGradient, LayerLegendText } from '$types/veda';
 import { TipButton } from '$components/common/tip-button';
 import {
   LayerCategoricalGraphic,
@@ -42,7 +42,7 @@ interface CardProps {
   colorMapScale: colorMapScale | undefined;
   setColorMapScale: (colorMapScale: colorMapScale) => void;
   onClickLayerInfo: () => void;
-  datasetLegend: LayerLegendCategorical | LayerLegendGradient | undefined;
+  datasetLegend: LayerLegendCategorical | LayerLegendGradient | LayerLegendText | undefined;
 }
 
 const Header = styled.header`

--- a/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
@@ -114,7 +114,7 @@ export function DatasetChart(props: DatasetChartProps) {
         </g>
         <g transform={`translate(0, ${CHART_MARGIN})`}>
           <AxisGrid
-            yLabel={dataset.data.legend?.unit?.label}
+            yLabel={dataset.data.legend?.type !== 'text' ? dataset.data.legend?.unit?.label : undefined}
             y={y}
             width={width}
             height={height}

--- a/app/scripts/types/veda.ts
+++ b/app/scripts/types/veda.ts
@@ -40,7 +40,7 @@ export interface DatasetLayerCompareSTAC extends DatasetLayerCommonProps {
   type: DatasetLayerType;
   name: string;
   description: string;
-  legend?: LayerLegendCategorical | LayerLegendGradient;
+  legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
 }
 
 export interface DatasetLayerCompareInternal extends DatasetLayerCommonProps {
@@ -74,7 +74,7 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   basemapId?: 'dark' | 'light' | 'satellite' | 'topo';
   type: DatasetLayerType;
   compare: DatasetLayerCompareSTAC | DatasetLayerCompareInternal | null;
-  legend?: LayerLegendCategorical | LayerLegendGradient;
+  legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
   analysis?: {
     metrics: string[];
     exclude: boolean;
@@ -105,7 +105,7 @@ export interface DatasetLayerCompareNormalized extends DatasetLayerCommonProps {
   time_density?: 'day' | 'month' | 'year';
   stacCol: string;
   type: DatasetLayerType;
-  legend?: LayerLegendCategorical | LayerLegendGradient;
+  legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
 }
 
 // export type DatasetLayerCompareNormalized = DatasetLayerCompareNoLegend | DatasetLayerCompareWLegend
@@ -157,6 +157,10 @@ export interface LayerLegendCategorical {
   type: 'categorical';
   unit?: LayerLegendUnit;
   stops: CategoricalStop[];
+}
+
+export interface LayerLegendText {
+  type: 'text';
 }
 
 /**

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -89,7 +89,7 @@ layers:
     legend:
       unit: 
         label: Molecules cm3
-      type: gradient
+      type: text
       min: "Less"
       max: "More"
       stops:

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -1,3 +1,5 @@
+// import { LayerLegendText } from '$types/veda';
+
 declare module 'veda' {
   import * as dateFns from 'date-fns';
   import { MDXModule } from 'mdx/types';
@@ -72,7 +74,7 @@ declare module 'veda' {
     basemapId?: 'dark' | 'light' | 'satellite' | 'topo';
     type: DatasetLayerType;
     compare: DatasetLayerCompareSTAC | DatasetLayerCompareInternal | null;
-    legend?: LayerLegendCategorical | LayerLegendGradient;
+    legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
     analysis?: {
       metrics: string[];
       exclude: boolean;

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -1,5 +1,3 @@
-// import { LayerLegendText } from '$types/veda';
-
 declare module 'veda' {
   import * as dateFns from 'date-fns';
   import { MDXModule } from 'mdx/types';

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -42,7 +42,7 @@ declare module 'veda' {
     type: DatasetLayerType;
     name: string;
     description: string;
-    legend?: LayerLegendCategorical | LayerLegendGradient;
+    legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
   }
 
   export interface DatasetLayerCompareInternal extends DatasetLayerCommonProps {
@@ -106,7 +106,7 @@ declare module 'veda' {
     time_density?: 'day' | 'month' | 'year';
     stacCol: string;
     type: DatasetLayerType;
-    legend?: LayerLegendCategorical | LayerLegendGradient;
+    legend?: LayerLegendCategorical | LayerLegendGradient | LayerLegendText;
   }
 
   // export type DatasetLayerCompareNormalized = DatasetLayerCompareNoLegend | DatasetLayerCompareWLegend
@@ -146,6 +146,10 @@ declare module 'veda' {
     type: 'categorical';
     unit?: LayerLegendUnit;
     stops: CategoricalStop[];
+  }
+
+  export interface LayerLegendText {
+    type: 'text';
   }
 
   /**


### PR DESCRIPTION
**Related Ticket:** #1484 

### Description of Changes
The current .mdx file contains a temporary fix where the legend properties are set to a transparent color to avoid issues with scrollytelling. We will update this to set legends that do not need a color swatch (e.g., categorical or graphical types) to type: text and remove unnecessary properties like stops, color, and label.

#### Before (Temporary Fix):
```
legend:
  type: categorical
  stops:
    - color: "rgba(0, 0, 0, 0)"  # using transparent for now to fix the issues with scrollytelling
      label: "Imagery"
```
#### After (Updated Configuration):
```
legend:
  type: text
```
### Notes & Questions About Changes
Would it be better if we could just remove the swatch and keep the legend title instead of removing the legend all together. This would help users who are accessing the story to know what imagery they are look at on the map. Removing the legends entirely could create a sense of unknowingness with what is shown on the map. (implemented in this pull request)

### Validation / Testing
1. In the .mdx file 
- Find the legend configuration for any layers that were previously set as type: categorical or type: graphical.
- Update type to text for legends that do not require a color swatch.
- Remove unnecessary properties like stops, color, and label.
3. Go to https://www.earthdata.nasa.gov/dashboard/stories/blizzards or https://www.earthdata.nasa.gov/dashboard/stories/2024-tornadoes
4. Go to Scrollytelling section, and notice that the legends are populated even after we scroll through block that does not have a legend. 

> [!NOTE]  
> The use case for this legend type is for satellite imagery, where we'd still want the information of what is being shown, but don't need to show colors