### PR TITLE
chore: Add USWDS Card Accessibility States

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -204,7 +204,6 @@ export default function CardComponent(
       data.footerContent
     ) {
       baseProps['uswds'] = true;
-      baseProps['to'] = to;
       baseProps['children'] = (
         <FlagCard
           imgSrc={data.imgSrc}
@@ -225,7 +224,7 @@ export default function CardComponent(
   // Link variant
   if (to) {
     if (baseProps['uswds']) {
-      return <LinkWrapper to={to}>{baseProps['children']}</LinkWrapper>;
+      return <CardLinkWrapper to={to}>{baseProps['children']}</CardLinkWrapper>;
     }
     return (
       <ElementInteractive
@@ -285,7 +284,13 @@ export function ExternalLinkFlag() {
   );
 }
 
-function LinkWrapper({ children, to }: { children: JSX.Element; to: string }) {
+function CardLinkWrapper({
+  children,
+  to
+}: {
+  children: JSX.Element;
+  to: string;
+}) {
   const { Link } = useVedaUI();
   return (
     <Link

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -202,6 +202,8 @@ export default function CardComponent(
       data.description &&
       data.footerContent
     ) {
+      baseProps['uswds'] = true;
+      baseProps['to'] = to;
       baseProps['children'] = (
         <FlagCard
           imgSrc={data.imgSrc}
@@ -212,7 +214,6 @@ export default function CardComponent(
           cardLabel='data_collection'
         />
       );
-      baseProps['style'] = { width: '100%' };
     }
 
     return baseProps;
@@ -222,6 +223,9 @@ export default function CardComponent(
 
   // Link variant
   if (to) {
+    if (baseProps['uswds']) {
+      return <LinkWrapper to={to}>{baseProps['children']}</LinkWrapper>;
+    }
     return (
       <ElementInteractive
         {...baseProps}
@@ -277,5 +281,17 @@ export function ExternalLinkFlag() {
       <FlagText>External Link</FlagText>
       <CollecticonExpandTopRight size='small' meaningful={false} />
     </ExternalLinkMark>
+  );
+}
+
+function LinkWrapper({ children, to }: { children: any; to: string }) {
+  const { Link } = useVedaUI();
+  return (
+    <Link
+      to={to}
+      style={{ width: '100%', margin: 0, padding: 0, overflow: 'hidden' }}
+    >
+      {children}
+    </Link>
   );
 }

--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -18,6 +18,7 @@ import * as utils from '$utils/utils';
 import { ElementInteractive } from '$components/common/element-interactive';
 import { useVedaUI } from '$context/veda-ui-provider';
 import { variableGlsp } from '$styles/variable-utils';
+import './styles.scss';
 
 /**
  * @NOTE: This component is the controller where a cardType can be passed in.
@@ -284,12 +285,19 @@ export function ExternalLinkFlag() {
   );
 }
 
-function LinkWrapper({ children, to }: { children: any; to: string }) {
+function LinkWrapper({ children, to }: { children: JSX.Element; to: string }) {
   const { Link } = useVedaUI();
   return (
     <Link
+      className='card-a11y-states'
       to={to}
-      style={{ width: '100%', margin: 0, padding: 0, overflow: 'hidden' }}
+      style={{
+        width: '100%',
+        margin: 0,
+        padding: 0,
+        overflow: 'hidden',
+        borderRadius: '0.5rem'
+      }}
     >
       {children}
     </Link>

--- a/app/scripts/components/common/card/styles.scss
+++ b/app/scripts/components/common/card/styles.scss
@@ -1,0 +1,7 @@
+@use '$styles/veda-ui-theme-vars.scss' as themeVars;
+
+.card-a11y-states {
+  &:hover {
+    box-shadow: 2px 4px 4px themeVars.$veda-uswds-color-base-lighter;
+  }
+}

--- a/app/scripts/components/common/card/styles.scss
+++ b/app/scripts/components/common/card/styles.scss
@@ -4,4 +4,9 @@
   &:hover {
     box-shadow: 2px 4px 4px themeVars.$veda-uswds-color-base-lighter;
   }
+
+  &:focus {
+    outline: 4px solid themeVars.$veda-uswds-link-focus-color;
+    outline-offset: 4px;
+  }
 }

--- a/app/scripts/components/common/card/styles.scss
+++ b/app/scripts/components/common/card/styles.scss
@@ -1,12 +1,22 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
+@use 'uswds-core/src/styles/mixins/utilities' as mixins;
 
 .card-a11y-states {
+  text-decoration: none;
   &:hover {
-    box-shadow: 2px 4px 4px themeVars.$veda-uswds-color-base-lighter;
+    @include mixins.u-shadow(2);
+
+    .usa-card__heading {
+      text-decoration: underline;
+    }
   }
 
   &:focus {
     outline: 4px solid themeVars.$veda-uswds-link-focus-color;
     outline-offset: 4px;
+
+    .usa-card__heading {
+      text-decoration: underline;
+    }
   }
 }

--- a/app/scripts/components/common/card/uswds-cards/styles.scss
+++ b/app/scripts/components/common/card/uswds-cards/styles.scss
@@ -1,7 +1,11 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
 
 .usa-card {
-  margin-bottom: 0;
+  margin: 0 !important;
+}
+
+.usa-card__container {
+  margin: 0;
 }
 
 .card-header {

--- a/app/scripts/styles/_uswds-theme.scss
+++ b/app/scripts/styles/_uswds-theme.scss
@@ -19,5 +19,6 @@
   $theme-font-type-serif: 'public-sans',
   $theme-font-type-sans: 'public-sans',
   $theme-color-base-darkest: 'gray-cool-80',
-  $theme-color-base-ink: 'gray-cool-90'
+  $theme-color-base-ink: 'gray-cool-90',
+  $theme-color-primary-vivid: 'blue-40v'
 );

--- a/app/scripts/styles/_veda-ui-theme-vars.scss
+++ b/app/scripts/styles/_veda-ui-theme-vars.scss
@@ -52,7 +52,7 @@ $veda-uswds-spacing-tablet: spacing.units('tablet');
 
 $veda-uswds-spacing-mobile-lg: spacing.units('mobile-lg');
 
-//PADDING
+// PADDING
 $veda-uswds-padding-1: spacing.units(1);
 $veda-uswds-padding-2: spacing.units(2);
 $veda-uswds-padding-3: spacing.units(3);

--- a/app/scripts/styles/_veda-ui-theme-vars.scss
+++ b/app/scripts/styles/_veda-ui-theme-vars.scss
@@ -31,6 +31,7 @@ $veda-uswds-color-primary-light: utils.color('blue-30');
 $veda-uswds-color-primary-lightest: utils.color('blue-5');
 $veda-uswds-color-secondary: utils.color('red-50');
 $veda-uswds-color-base-dark: utils.color('gray-cool-60');
+$veda-uswds-color-base-lighter: utils.color('gray-cool-10');
 $veda-uswds-color-base-darkest: utils.color('gray-cool-80');
 $veda-uswds-color-gray-cool: utils.color('gray-cool-50');
 // re-mapped, theme-token 'base-darkest' originally mapped to 'gray-90'

--- a/app/scripts/styles/_veda-ui-theme-vars.scss
+++ b/app/scripts/styles/_veda-ui-theme-vars.scss
@@ -41,6 +41,7 @@ $veda-uswds-color-base-white: utils.color('white');
 $veda-uswds-color-base-ink: utils.color(
   'gray-cool-90'
 ); // re-mapped, theme-token 'ink' originally mapped to 'gray-90'
+$veda-uswds-link-focus-color: utils.color('blue-40v');
 
 // SPACING
 $veda-uswds-spacing-5: spacing.units(0.5);


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1501

### Description of Changes
This PR adds the card accessibility states to uswds cards (Hover & Focus) BUT just at the card wrapper level and not directly around each specific expose-able card. When specific cards are directly imported and used, the instance should be able to control accessibility states.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
