### PR TITLE
feat: Support custom time interval

### DIFF
--- a/app/scripts/components/exploration/data-utils.spec.ts
+++ b/app/scripts/components/exploration/data-utils.spec.ts
@@ -344,49 +344,49 @@ describe('generateDates', () => {
 });
 
 describe('getBiggestDurationDesignator', () => {
-  test('returns Y for year-based duration', () => {
+  it('returns Y for year-based duration', () => {
     expect(getBiggestDurationDesignator('P1Y')).toBe('Y');
   });
 
-  test('returns M for month-based duration', () => {
+  it('returns M for month-based duration', () => {
     expect(getBiggestDurationDesignator('P2M')).toBe('M');
   });
 
-  test('returns W for week-based duration', () => {
+  it('returns W for week-based duration', () => {
     expect(getBiggestDurationDesignator('P3W')).toBe('W');
   });
 
-  test('returns D for day-based duration', () => {
+  it('returns D for day-based duration', () => {
     expect(getBiggestDurationDesignator('P10D')).toBe('D');
   });
 
-  test('returns TH for hour-based duration with T', () => {
+  it('returns TH for hour-based duration with T', () => {
     expect(getBiggestDurationDesignator('PT5H')).toBe('TH');
   });
 
-  test('returns TM for minute-based duration with T', () => {
+  it('returns TM for minute-based duration with T', () => {
     expect(getBiggestDurationDesignator('PT30M')).toBe('TM');
   });
 
-  test('returns TS for second-based duration with T', () => {
+  it('returns TS for second-based duration with T', () => {
     expect(getBiggestDurationDesignator('PT45S')).toBe('TS');
   });
 
-  test('returns Y from mixed duration', () => {
+  it('returns Y from mixed duration', () => {
     expect(getBiggestDurationDesignator('P1Y2M10DT5H30M')).toBe('Y');
   });
 
-  test('returns TH from time-only duration', () => {
+  it('returns TH from time-only duration', () => {
     expect(getBiggestDurationDesignator('PT5H30M')).toBe('TH');
   });
 
-  test('throws error on invalid input (no P)', () => {
+  it('throws error on invalid input (no P)', () => {
     expect(() => getBiggestDurationDesignator('T5H')).toThrow(
       'Invalid ISO duration'
     );
   });
 
-  test('throws error if no valid designators found', () => {
+  it('throws error if no valid designators found', () => {
     expect(() => getBiggestDurationDesignator('P')).toThrow(
       'No valid designators found'
     );
@@ -394,27 +394,27 @@ describe('getBiggestDurationDesignator', () => {
 });
 
 describe('getTimeDensityFromInterval', () => {
-  test('returns YEAR for "P1Y"', () => {
+  it('returns YEAR for "P1Y"', () => {
     expect(getTimeDensityFromInterval('P1Y')).toBe(TimeDensity.YEAR);
   });
 
-  test('returns MONTH for "P1M"', () => {
+  it('returns MONTH for "P1M"', () => {
     expect(getTimeDensityFromInterval('P1M')).toBe(TimeDensity.MONTH);
   });
 
-  test('returns DAY for "P1W"', () => {
+  it('returns DAY for "P1W"', () => {
     expect(getTimeDensityFromInterval('P1W')).toBe(TimeDensity.DAY);
   });
 
-  test('returns DAY for "PT5H30M"', () => {
+  it('returns DAY when the biggest interval is smaller than a day ("PT5H30M")', () => {
     expect(getTimeDensityFromInterval('PT5H30M')).toBe(TimeDensity.DAY);
   });
 
-  test('returns DAY for null interval', () => {
+  it('returns DAY for null interval', () => {
     expect(getTimeDensityFromInterval(null)).toBe(TimeDensity.DAY);
   });
 
-  test('returns correct density from mixed duration', () => {
+  it('returns correct density from mixed duration', () => {
     expect(getTimeDensityFromInterval('P1Y2M10DT5H')).toBe(TimeDensity.YEAR);
     expect(getTimeDensityFromInterval('P2M10DT5H')).toBe(TimeDensity.MONTH);
     expect(getTimeDensityFromInterval('P10DT5H')).toBe(TimeDensity.DAY);

--- a/app/scripts/components/exploration/data-utils.spec.ts
+++ b/app/scripts/components/exploration/data-utils.spec.ts
@@ -1,9 +1,13 @@
 import {
-  resolveRenderParams,
+  getTimeDensityFromInterval,
+  getBiggestDurationDesignator,
   formatRenderExtensionData,
+  generateDates,
+  resolveRenderParams,
   SourceParametersWithLayerId
 } from './data-utils';
 import { RENDER_KEY } from '$components/exploration/constants';
+import { TimeDensity } from '$components/exploration/types.d.ts';
 
 const LAYER_KEY = 'layer-1';
 const renderExtensionData = {
@@ -93,5 +97,326 @@ describe('Resolve Render Params', () => {
       rescale: renderData.rescale.flat(),
       colormap: JSON.stringify(renderData.colormap)
     });
+  });
+});
+
+describe('generateDates', () => {
+  it('should generate daily dates correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-01-05');
+    const interval = 'P1D'; // 1 day interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-01-02'));
+    expect(result[2]).toEqual(new Date('2023-01-03'));
+    expect(result[3]).toEqual(new Date('2023-01-04'));
+    expect(result[4]).toEqual(new Date('2023-01-05'));
+  });
+
+  it('should generate weekly dates correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-02-01');
+    const interval = 'P1W'; // 1 week interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-01-08'));
+    expect(result[2]).toEqual(new Date('2023-01-15'));
+    expect(result[3]).toEqual(new Date('2023-01-22'));
+    expect(result[4]).toEqual(new Date('2023-01-29'));
+  });
+
+  it('should generate monthly dates correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-06-01');
+    const interval = 'P1M'; // 1 month interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(6);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-02-01'));
+    expect(result[2]).toEqual(new Date('2023-03-01'));
+    expect(result[3]).toEqual(new Date('2023-04-01'));
+    expect(result[4]).toEqual(new Date('2023-05-01'));
+    expect(result[5]).toEqual(new Date('2023-06-01'));
+  });
+
+  it('should generate yearly dates correctly', () => {
+    const start = new Date('2020-01-01');
+    const end = new Date('2025-01-01');
+    const interval = 'P1Y'; // 1 year interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(6);
+    expect(result[0]).toEqual(new Date('2020-01-01'));
+    expect(result[1]).toEqual(new Date('2021-01-01'));
+    expect(result[2]).toEqual(new Date('2022-01-01'));
+    expect(result[3]).toEqual(new Date('2023-01-01'));
+    expect(result[4]).toEqual(new Date('2024-01-01'));
+    expect(result[5]).toEqual(new Date('2025-01-01'));
+  });
+
+  it('should handle hourly intervals correctly', () => {
+    const start = new Date('2023-01-01T12:00:00');
+    const end = new Date('2023-01-01T16:00:00');
+    const interval = 'PT1H'; // 1 hour interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0]).toEqual(new Date('2023-01-01T12:00:00'));
+    expect(result[1]).toEqual(new Date('2023-01-01T13:00:00'));
+    expect(result[2]).toEqual(new Date('2023-01-01T14:00:00'));
+    expect(result[3]).toEqual(new Date('2023-01-01T15:00:00'));
+    expect(result[4]).toEqual(new Date('2023-01-01T16:00:00'));
+  });
+
+  it('should handle minute intervals correctly', () => {
+    const start = new Date('2023-01-01T12:00:00');
+    const end = new Date('2023-01-01T12:10:00');
+    const interval = 'PT2M'; // 2 minute interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(6);
+    expect(result[0]).toEqual(new Date('2023-01-01T12:00:00'));
+    expect(result[1]).toEqual(new Date('2023-01-01T12:02:00'));
+    expect(result[2]).toEqual(new Date('2023-01-01T12:04:00'));
+    expect(result[3]).toEqual(new Date('2023-01-01T12:06:00'));
+    expect(result[4]).toEqual(new Date('2023-01-01T12:08:00'));
+    expect(result[5]).toEqual(new Date('2023-01-01T12:10:00'));
+  });
+
+  it('should handle second intervals correctly', () => {
+    const start = new Date('2023-01-01T12:00:00');
+    const end = new Date('2023-01-01T12:00:10');
+    const interval = 'PT2S'; // 2 second interval
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(6);
+    expect(result[0]).toEqual(new Date('2023-01-01T12:00:00'));
+    expect(result[1]).toEqual(new Date('2023-01-01T12:00:02'));
+    expect(result[2]).toEqual(new Date('2023-01-01T12:00:04'));
+    expect(result[3]).toEqual(new Date('2023-01-01T12:00:06'));
+    expect(result[4]).toEqual(new Date('2023-01-01T12:00:08'));
+    expect(result[5]).toEqual(new Date('2023-01-01T12:00:10'));
+  });
+
+  it('should handle combined date intervals correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-03-07');
+    const interval = 'P1M3D'; // 1 month and 3 days
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(3);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-02-04'));
+    expect(result[2]).toEqual(new Date('2023-03-07'));
+  });
+
+  it('should handle combined date and time intervals correctly', () => {
+    const start = new Date('2023-01-01T12:00:00');
+    const end = new Date('2023-01-01T18:30:00');
+    const interval = 'PT2H15M'; // 2 hours and 15 minutes
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(3);
+    expect(result[0]).toEqual(new Date('2023-01-01T12:00:00'));
+    expect(result[1]).toEqual(new Date('2023-01-01T14:15:00'));
+    expect(result[2]).toEqual(new Date('2023-01-01T16:30:00'));
+  });
+
+  it('should handle full ISO duration format correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2025-03-25');
+    const interval = 'P1Y2M10DT6H30M15S'; // 1 year, 2 months, 10 days, 6 hours, 30 minutes, 15 seconds
+
+    const result = generateDates(start, end, interval);
+
+    // Check first and last values
+    expect(result.length).toBeGreaterThan(0);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[result.length - 1].getTime()).toBeLessThanOrEqual(
+      new Date('2025-03-25').getTime()
+    );
+  });
+
+  it('should handle zero duration parts correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-01-05');
+    const interval = 'P0Y0M1D'; // Only 1 day, explicitly zeros for years and months
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-01-02'));
+    expect(result[2]).toEqual(new Date('2023-01-03'));
+    expect(result[3]).toEqual(new Date('2023-01-04'));
+    expect(result[4]).toEqual(new Date('2023-01-05'));
+  });
+
+  it('should return only start date when start equals end', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-01-01');
+    const interval = 'P1D';
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(1);
+    expect(result[0]).toEqual(start);
+  });
+
+  it('should handle complex intervals correctly', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-03-01');
+    const interval = 'P14D'; // 14 days
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-01-15'));
+    expect(result[2]).toEqual(new Date('2023-01-29'));
+    expect(result[3]).toEqual(new Date('2023-02-12'));
+    expect(result[4]).toEqual(new Date('2023-02-26'));
+  });
+
+  it('should throw error for invalid ISO duration format', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-01-05');
+    const invalidInterval = 'Invalid';
+
+    expect(() => {
+      generateDates(start, end, invalidInterval);
+    }).toThrow('Invalid ISO duration');
+  });
+
+  it('should handle edge case with February and leap years', () => {
+    const start = new Date('2024-01-31'); // 2024 is a leap year
+    const end = new Date('2024-04-30');
+    const interval = 'P1M'; // 1 month
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(4);
+    expect(result[0]).toEqual(new Date('2024-01-31'));
+    expect(result[1]).toEqual(new Date('2024-02-29')); // February 29 in a leap year
+    expect(result[2]).toEqual(new Date('2024-03-29'));
+    expect(result[3]).toEqual(new Date('2024-04-29'));
+  });
+
+  it('should handle different timezone dates correctly', () => {
+    // Create dates with specific timezone offset
+    const start = new Date('2023-01-01T00:00:00Z'); // UTC
+    const end = new Date('2023-01-05T00:00:00Z'); // UTC
+    const interval = 'P1D';
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(5);
+    expect(result[0].toISOString()).toBe(start.toISOString());
+    expect(result[4].toISOString()).toBe(end.toISOString());
+  });
+
+  it('should stop generating dates once passing the end date', () => {
+    const start = new Date('2023-01-01');
+    const end = new Date('2023-01-04');
+    const interval = 'P2D'; // 2 days
+
+    const result = generateDates(start, end, interval);
+
+    expect(result.length).toBe(2);
+    expect(result[0]).toEqual(new Date('2023-01-01'));
+    expect(result[1]).toEqual(new Date('2023-01-03'));
+    // It shouldn't include 2023-01-05 because it's beyond the end date
+  });
+});
+
+describe('getBiggestDurationDesignator', () => {
+  test('returns Y for year-based duration', () => {
+    expect(getBiggestDurationDesignator('P1Y')).toBe('Y');
+  });
+
+  test('returns M for month-based duration', () => {
+    expect(getBiggestDurationDesignator('P2M')).toBe('M');
+  });
+
+  test('returns W for week-based duration', () => {
+    expect(getBiggestDurationDesignator('P3W')).toBe('W');
+  });
+
+  test('returns D for day-based duration', () => {
+    expect(getBiggestDurationDesignator('P10D')).toBe('D');
+  });
+
+  test('returns TH for hour-based duration with T', () => {
+    expect(getBiggestDurationDesignator('PT5H')).toBe('TH');
+  });
+
+  test('returns TM for minute-based duration with T', () => {
+    expect(getBiggestDurationDesignator('PT30M')).toBe('TM');
+  });
+
+  test('returns TS for second-based duration with T', () => {
+    expect(getBiggestDurationDesignator('PT45S')).toBe('TS');
+  });
+
+  test('returns Y from mixed duration', () => {
+    expect(getBiggestDurationDesignator('P1Y2M10DT5H30M')).toBe('Y');
+  });
+
+  test('returns TH from time-only duration', () => {
+    expect(getBiggestDurationDesignator('PT5H30M')).toBe('TH');
+  });
+
+  test('throws error on invalid input (no P)', () => {
+    expect(() => getBiggestDurationDesignator('T5H')).toThrow(
+      'Invalid ISO duration'
+    );
+  });
+
+  test('throws error if no valid designators found', () => {
+    expect(() => getBiggestDurationDesignator('P')).toThrow(
+      'No valid designators found'
+    );
+  });
+});
+
+describe('getTimeDensityFromInterval', () => {
+  test('returns YEAR for "P1Y"', () => {
+    expect(getTimeDensityFromInterval('P1Y')).toBe(TimeDensity.YEAR);
+  });
+
+  test('returns MONTH for "P1M"', () => {
+    expect(getTimeDensityFromInterval('P1M')).toBe(TimeDensity.MONTH);
+  });
+
+  test('returns DAY for "P1W"', () => {
+    expect(getTimeDensityFromInterval('P1W')).toBe(TimeDensity.DAY);
+  });
+
+  test('returns DAY for "PT5H30M"', () => {
+    expect(getTimeDensityFromInterval('PT5H30M')).toBe(TimeDensity.DAY);
+  });
+
+  test('returns DAY for null interval', () => {
+    expect(getTimeDensityFromInterval(null)).toBe(TimeDensity.DAY);
+  });
+
+  test('returns correct density from mixed duration', () => {
+    expect(getTimeDensityFromInterval('P1Y2M10DT5H')).toBe(TimeDensity.YEAR);
+    expect(getTimeDensityFromInterval('P2M10DT5H')).toBe(TimeDensity.MONTH);
+    expect(getTimeDensityFromInterval('P10DT5H')).toBe(TimeDensity.DAY);
   });
 });

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -6,12 +6,12 @@ import {
 import axios from 'axios';
 import {
   StacDatasetData,
-  TimeDensity,
   TimelineDataset,
   DatasetStatus,
   VizDataset
 } from '../types.d.ts';
 import {
+  getTimeDensityFromInterval,
   resolveLayerTemporalExtent,
   resolveRenderParams,
   isRenderParamsApplicable
@@ -95,7 +95,9 @@ async function fetchStacDatasetById(
   );
 
   const timeDensity =
-    data['dashboard:time_density'] || time_density || TimeDensity.DAY;
+    data['dashboard:time_density'] ||
+    time_density ||
+    getTimeDensityFromInterval(data['dashboard:time_interval']);
   const commonTimeseriesParams = {
     isPeriodic: !!data['dashboard:is_periodic'],
     timeDensity: timeDensity,

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -94,9 +94,13 @@ async function fetchStacDatasetById(
     `${stacApiEndpointToUse}/collections/${stacCol}`
   );
 
+  const timeDensity =
+    data['dashboard:time_density'] || time_density || TimeDensity.DAY;
   const commonTimeseriesParams = {
     isPeriodic: !!data['dashboard:is_periodic'],
-    timeDensity: data['dashboard:time_density'] || TimeDensity.DAY
+    timeDensity: timeDensity,
+    timeInterval:
+      data['dashboard:time_interval'] || `P1${timeDensity[0].toUpperCase()}`
   };
 
   if (type === 'vector') {
@@ -119,8 +123,8 @@ async function fetchStacDatasetById(
     const lastDatetime = domain[domain.length - 1] || new Date().toISOString();
     // CMR STAC misses the dashboard specific attributes, shim these values
     return {
+      ...commonTimeseriesParams,
       isPeriodic: true,
-      timeDensity: time_density ?? TimeDensity.DAY,
       domain: [domainStart, lastDatetime]
     };
   } else {

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -1,5 +1,5 @@
 import { DataMetric } from './components/datasets/analysis-metrics';
-import { DatasetLayer, ParentDatset } from '$types/veda';
+import { DatasetLayer } from '$types/veda';
 
 export enum TimeDensity {
   YEAR = 'year',
@@ -16,6 +16,7 @@ export enum DatasetStatus {
 
 export interface StacDatasetData {
   isPeriodic: boolean;
+  timeInterval: string;
   timeDensity: TimeDensity;
   domain: string[];
   renders?: Record<string, any> | undefined;


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1463

### Description of Changes
To support custom time steps (not just 1 day, 1 month, 1 year), we're adding a `dashboard:time_interval` key to STAC collections. This is in the [ISO time duration format](https://www.digi.com/resources/documentation/digidocs/90001488-13/reference/r_iso_8601_duration_format.htm). 

This PR adds support for this new key while still being backward compatible.

Adds a function to generate valid dates based on the start/end/and the various time intervals.

### Notes & Questions About Changes
N/A

### Validation / Testing
1. Make sure the generated dates in the timeline are correct for datasets with or without `dashboard:time_interval` value and that the layers load correctly

This preview from [this other PR](https://github.com/NASA-IMPACT/veda-ui/pull/1565) shows that it works for a P7D dataset: https://deploy-preview-1565--veda-ui.netlify.app/exploration?search=&datasets=%5B%7B%22id%22%3A%22esi_4wk_layer%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A1%7D%7D%7D%5D&taxonomy=%7B%7D&date=2001-01-23T06%3A00%3A00.000Z&dateRange=