### PR TITLE
fix: Use colormap from legend when no colormap is provided in sourceParams

### DIFF
--- a/app/scripts/components/common/map/layer-legend.tsx
+++ b/app/scripts/components/common/map/layer-legend.tsx
@@ -347,22 +347,21 @@ export const LayerGradientGraphic = (props: LayerLegendGradient) => {
   );
 };
 
-export const LayerGradientColormapGraphic = (props: Omit<LayerLegendGradient, 'stops' | 'type'>) => {
-  const { colorMap = DEFAULT_COLORMAP, ...otherProps } = props;
-  const colormapResult = findColormapByName(colorMap);
+export const LayerGradientColormapGraphic = (props: Omit<LayerLegendGradient, 'type'>) => {
+  const { colorMap, stops: defaultStops, ...otherProps } = props;
 
-  const { foundColorMap, isReversed } = colormapResult;
-  const stops = Object.values(foundColorMap)
-  .filter(value => Array.isArray(value) && value.length === 4)
-  .map((value) => {
-    return `rgba(${(value as number[]).join(',')})`;
-  });
+  const processedStops = React.useMemo(() => {
+    if (!colorMap) return defaultStops;
 
-  const processedStops = isReversed
-  ? stops.reduceRight((acc, stop) => [...acc, stop], [])
-  : stops;
+    const { foundColorMap, isReversed } = findColormapByName(colorMap);
+    const stops = Object.values(foundColorMap)
+      .filter(value => Array.isArray(value) && value.length === 4)
+      .map(value => `rgba(${(value as number[]).join(',')})`);
 
-  return <LayerGradientGraphic type='gradient' stops={processedStops} {...otherProps} />;
+    return isReversed ? [...stops].reverse() : stops;
+  }, [colorMap, defaultStops]);
+
+  return <LayerGradientGraphic type='gradient' {...otherProps} stops={processedStops} />;
 };
 
 export const findColormapByName = (name: string) => {

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -128,9 +128,12 @@ export default function DataLayerCard(props: CardProps) {
     onClickLayerInfo
   } = props;
   const layerInfo = dataset.data.info;
-  const [min, max] = datasetLegend?.type === 'gradient' && datasetLegend.min != null && datasetLegend.max != null
-    ? [datasetLegend.min, datasetLegend.max]
-    : dataset.data.sourceParams?.rescale || [0, 1];
+  const [min, max] =
+    datasetLegend?.type === 'gradient' &&
+    datasetLegend.min != null &&
+    datasetLegend.max != null
+      ? [datasetLegend.min, datasetLegend.max]
+      : dataset.data.sourceParams?.rescale || [0, 1];
   const [isColorMapOpen, setIsColorMapOpen] = useState(false);
   const triggerRef = useRef<HTMLDivElement | null>(null);
 
@@ -155,7 +158,8 @@ export default function DataLayerCard(props: CardProps) {
   const showConfigurableCmap =
     showConfigurableColorMap &&
     dataset.status === 'success' &&
-    datasetLegend?.type === 'gradient' && colorMap;
+    datasetLegend?.type === 'gradient' &&
+    colorMap;
   const showNonConfigurableCmap =
     !showConfigurableColorMap && datasetLegend?.type === 'gradient';
 
@@ -244,8 +248,8 @@ export default function DataLayerCard(props: CardProps) {
               className='colormap-options'
               content={
                 <ColormapOptions
-                  min={min}
-                  max={max}
+                  min={Number(min)}
+                  max={Number(max)}
                   colorMap={colorMap}
                   setColorMap={setColorMap}
                   setColorMapScale={setColorMapScale}

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -128,7 +128,9 @@ export default function DataLayerCard(props: CardProps) {
     onClickLayerInfo
   } = props;
   const layerInfo = dataset.data.info;
-  const [min, max] = dataset.data.sourceParams?.rescale || [0, 1];
+  const [min, max] = datasetLegend?.type === 'gradient' && datasetLegend.min != null && datasetLegend.max != null
+    ? [datasetLegend.min, datasetLegend.max]
+    : dataset.data.sourceParams?.rescale || [0, 1];
   const [isColorMapOpen, setIsColorMapOpen] = useState(false);
   const triggerRef = useRef<HTMLDivElement | null>(null);
 
@@ -153,7 +155,7 @@ export default function DataLayerCard(props: CardProps) {
   const showConfigurableCmap =
     showConfigurableColorMap &&
     dataset.status === 'success' &&
-    datasetLegend?.type === 'gradient';
+    datasetLegend?.type === 'gradient' && colorMap;
   const showNonConfigurableCmap =
     !showConfigurableColorMap && datasetLegend?.type === 'gradient';
 
@@ -233,6 +235,7 @@ export default function DataLayerCard(props: CardProps) {
             ref={triggerRef}
           >
             <LayerGradientColormapGraphic
+              stops={datasetLegend.stops}
               min={min}
               max={max}
               colorMap={colorMap}
@@ -266,6 +269,7 @@ export default function DataLayerCard(props: CardProps) {
         )}
         {showNonConfigurableCmap && (
           <LayerGradientColormapGraphic
+            stops={datasetLegend.stops}
             min={min}
             max={max}
             colorMap={colorMap}

--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -161,8 +161,7 @@ export default function DataLayerCard(props: CardProps) {
     datasetLegend?.type === 'gradient' &&
     colorMap;
   const showNonConfigurableCmap =
-    !showConfigurableColorMap && datasetLegend?.type === 'gradient';
-
+    !showConfigurableCmap && datasetLegend?.type === 'gradient';
   return (
     <>
       <DatasetInfo className={isVisible ? 'layerShown' : 'layerHidden'}>

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -76,16 +76,8 @@ layers:
       min: 0
       max: 0.3
       stops:
-        - '#F7F4F9'
-        - '#E9E3F0'
-        - '#D9C3DF'
-        - '#CDA0CD'
-        - '#D57ABA'
-        - '#E34A9F'
-        - '#DF2179'
-        - '#C10E51'
-        - '#92003F'
-        - '#67001F'
+        - '#000000'
+        - '#FFFFFF'
     info:
       source: NASA
       spatialExtent: Global


### PR DESCRIPTION
### Issues
1. when no colormap is provided, the `raster` data type/titiler uses greyscale; but the UI shows the default colormap `viridis`
2. when no colormap is provided because non `raster` data type doesn't use the colormap `sourceParams`, it still uses the default `viridis` colormap instead of reading from the `legend`

### Description of Changes
When no colormap is provided, the colormap is generated from the `legend` property instead of using a default colormap, which doesn't always make sense.

### Notes & Questions About Changes
should we always allow "raster" data type to be configurable?

### Validation / Testing
[preview link](https://deploy-preview-1563--veda-ui.netlify.app/exploration?search=&datasets=%5B%7B%22id%22%3A%22casa-gfed-co2-flux%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&date=2017-12-01T06%3A00%3A00.000Z)
[mdx file](https://github.com/NASA-IMPACT/veda-ui/blob/fefe3ed70ad08924565620b40c724d8353e02b23/mock/datasets/data-from-ghg.data.mdx?plain=1#L46-L85)
