### PR TITLE
feat: Wrap components with Widgets

### DIFF
--- a/app/scripts/components/common/mdx-content.js
+++ b/app/scripts/components/common/mdx-content.js
@@ -20,6 +20,7 @@ import {
 } from '$components/common/blocks/lazy-components';
 import { NotebookConnectCalloutBlock } from '$components/common/notebook-connect';
 import SmartLink, { CustomLink } from '$components/common/smart-link';
+import { Widget } from '$libs';
 
 function MdxContent(props) {
   const pageMdx = useMdxPageLoader(props.loader);
@@ -46,7 +47,8 @@ function MdxContent(props) {
           Link: SmartLink,
           a: CustomLink,
           Table: LazyTable,
-          Embed: LazyEmbed
+          Embed: LazyEmbed,
+          Widget
         }}
       >
         <pageMdx.MdxContent {...(props.throughProps || {})} />

--- a/app/scripts/components/common/widget/__snapshots__/widget.test.tsx.snap
+++ b/app/scripts/components/common/widget/__snapshots__/widget.test.tsx.snap
@@ -9,9 +9,9 @@ exports[`FullscreenWidget matches snapshot 1`] = `
     class="padding-2 display-flex flex-justify space-between flex-align-center"
     data-testid="widget-header"
   >
-    <h6>
+    <h4>
       Test Fullscreen Widget
-    </h6>
+    </h4>
     <button
       class="usa-button usa-button--outline margin-0 margin-left-3"
       data-testid="widget-toggle"

--- a/app/scripts/components/common/widget/header.tsx
+++ b/app/scripts/components/common/widget/header.tsx
@@ -48,7 +48,7 @@ const Header = ({
       className='padding-2 display-flex flex-justify space-between flex-align-center'
       data-testid='widget-header'
     >
-      {isExpanded ? <h1>{heading}</h1> : <h6>{heading}</h6>}
+      {isExpanded ? <h1>{heading}</h1> : <h4>{heading}</h4>}
 
       <USWDSButton
         type='button'

--- a/app/scripts/libs/index.ts
+++ b/app/scripts/libs/index.ts
@@ -61,7 +61,8 @@ export {
   PageHeader,
   PageFooter,
   DefaultCard,
-  FlagCard
+  FlagCard,
+  Widget
 } from './uswds-components';
 
 export { PageHero, LegacyGlobalStyles };

--- a/app/scripts/libs/uswds-components.ts
+++ b/app/scripts/libs/uswds-components.ts
@@ -3,5 +3,6 @@ import PageFooter from '$components/common/page-footer';
 
 import DefaultCard from '$components/common/card/uswds-cards/default-card';
 import FlagCard from '$components/common/card/uswds-cards/flag-card';
+import { FullpageModalWidget as Widget } from '$components/common/widget';
 
-export { PageHeader, PageFooter, DefaultCard, FlagCard };
+export { PageHeader, PageFooter, DefaultCard, FlagCard, Widget };

--- a/mock/datasets/nighttime-lights.data.mdx
+++ b/mock/datasets/nighttime-lights.data.mdx
@@ -81,6 +81,8 @@ Nightlights data are collected by the [Visible Infrared Radiometer Suite (VIIRS)
 
 <Block type='full'>
 <Figure>
+  <Widget heading='Monthly no2'>
+  <div className="position-relative">
   <Map
     datasetId='sandbox'
     layerId='no2-monthly'
@@ -93,6 +95,8 @@ Nightlights data are collected by the [Visible Infrared Radiometer Suite (VIIRS)
   >
     Images of the cities of Wuhan (left) and Hefei (top right) before and after COVID-19 related shutdowns were enacted.
   </Caption> 
+  </div>
+  </Widget>
 </Figure>
 <Prose>
 ## Interpreting the data

--- a/mock/datasets/sandbox.data.mdx
+++ b/mock/datasets/sandbox.data.mdx
@@ -215,6 +215,8 @@ Vestibulum justo ante, bibendum at vehicula sit amet, dignissim sit amet augue. 
 </Block>
 <Block>
 <Figure>
+  <Widget heading="Monthly no2">
+  <div className="position-relative">
   <Map
     datasetId='no2'
     layerId='no2-monthly'
@@ -229,5 +231,7 @@ Vestibulum justo ante, bibendum at vehicula sit amet, dignissim sit amet augue. 
   >
     Comparison of the household composition and disability score for New Orleans, LA between 2014 and 2016.
   </Caption>
+  </div>
+  </Widget>
 </Figure>
 </Block>

--- a/mock/stories/air-quality-and-covid-19.stories.mdx
+++ b/mock/stories/air-quality-and-covid-19.stories.mdx
@@ -198,6 +198,8 @@ taxonomy:
     They are comparing the on-the-ground sensor information from NASA's [Pandora Project](https://pandora.gsfc.nasa.gov/ "Explore the Pandora Project") with satellite information from TROPOMI. So far, they have found that nitrogen dioxide hotspots in Atlanta shifted from the airport, shown here, to the city center from April-June 2020. By September, however, satellites revealed the airport had reemerged as a dominant nitrogen dioxide emission source.
   </Prose>
   <Figure>
+    <Widget heading="no2 monthly">
+    <div className="position-relative">
     <Map
       datasetId='no2'
       layerId='no2-monthly'
@@ -213,11 +215,15 @@ taxonomy:
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     </Caption> 
+    </div>
+    </Widget>
   </Figure>
 </Block>
 
 <Block type='full'>
   <Figure>
+    <Widget heading="no2 monthly">
+    <div className="position-relative">
     <Map
       datasetId='no2'
       layerId='no2-monthly'
@@ -232,6 +238,8 @@ taxonomy:
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     </Caption> 
+    </div>
+    </Widget>
   </Figure>
   <Prose>
     They are comparing the on-the-ground sensor information from NASA's [Pandora Project](https://pandora.gsfc.nasa.gov/ "Explore the Pandora Project") with satellite information from TROPOMI. So far, they have found that nitrogen dioxide hotspots in Atlanta shifted from the airport, shown here, to the city center from April-June 2020.
@@ -243,6 +251,8 @@ taxonomy:
     By September, however, satellites revealed the airport had reemerged as a dominant nitrogen dioxide emission source.
   </Prose>
   <Figure>
+    <Widget heading="no2 monthly 2019-09-01 vs. 2020-09-01">
+    <div className="position-relative">
     <Map
       datasetId='no2'
       layerId='no2-monthly'
@@ -257,11 +267,15 @@ taxonomy:
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     </Caption> 
+    </div>
+    </Widget>
   </Figure>
 </Block>
 
 <Block type='full'>
   <Figure>
+    <Widget heading="no2 monthly 2020-02-01">
+    <div className="position-relative">
     <Map
       datasetId='no2'
       layerId='no2-monthly-2'
@@ -275,6 +289,8 @@ taxonomy:
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
     </Caption> 
+    </div>
+    </Widget>
   </Figure>
   <Prose>
     ## Seeing Rebounds in NO2

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "$context": "~/app/scripts/context",
     "$data-layer": "~/app/scripts/data-layer",
     "$uswds": "~/app/scripts/components/common/uswds",
+    "$libs": "~/app/scripts/libs",
     "$test": "~/test",
     "$static": "~/static"
   },


### PR DESCRIPTION
**Related Ticket:** #1523

### Description of Changes
This change exports the Fullpage Modal Widgets as `<Widget />` from the library and adds it to the MDX Content components. The `<Widget />` is then used in some .mdx datasets and stories to wrap around the Map block components.

Due to the constraints of our current MDX parser, I couldn't wrap the entire `<Figure />` component with `<Widget />`, which would have been the preferred approach. Instead, as a workaround, I placed `<Widget />` inside `<Figure />`, wrapping all of its content. While this approach works, it introduces an issue with the absolutely positioned FigureAttribution (the small "i" icon in the top-right corner), which requires a relatively positioned parent. To address this, I added an extra `<div className="position-relative">`.

**Note**: I intentionally did not add styles to the <Widget /> component just to accommodate the way <Figure /> is structured.

Additionally, I updated the header tag from h6 to h4, following design instructions.

### Questions About Changes
1. Widget Composition:

- Should the Widget be an optional wrapper that MDX creators can choose to add?
- Or should the Widget be a fixed element within certain components (e.g., <Figure />) so that it always gets included when those elements are used?

2. MDX Parser Adjustments:

- If we go with the first option (making Widget optional), should we modify our MDX parser to allow <Widget /> as a child element?
- Or, should <Widget /> wrap only the content inside <Figure /> instead of the entire <Figure /> component anyways? 

3. Future Direction:

- Are we keeping <Figure /> and other legacy MDX components long-term, or are they expected to be replaced with USWDS components eventually?

Would love feedback on these decisions before finalizing the approach!

### Validation / Testing
See how widgets appear on https://deploy-preview-1564--veda-ui.netlify.app/data-catalog/nighttime-lights or https://deploy-preview-1564--veda-ui.netlify.app/stories/air-quality-and-covid-19