### PR TITLE
ci: Release action follow-up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,4 +79,4 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "Check action page to see the details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  text: "*VEDA UI Release failed*: Check action page to see the details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,6 @@ permissions:
 
 jobs:
   release:
-    # Trigger events regardless of weekindex if it is manually triggered 
-    if: ${{github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest
     steps:
       - name: Generate a token

--- a/.release-it.js
+++ b/.release-it.js
@@ -22,7 +22,7 @@ function groupCommitsByCategory(logs) {
   // Loop through each prefix to find conventional commit pattern ex. feat: , feat(card):, feat(card)! including some edge cases
   Object.entries(prefixes).forEach(([prefix, category]) => {
     const regex = new RegExp(
-      `^(((Initial commit)|(Merge [^\r\n]+(\s)[^\r\n]+((\s)((\s)[^\r\n]+)+)*(\s)?)|^((${prefix})(\([\w\-]+\))?!?: [^\r\n]+((\s)((\s)[^\r\n]+)+)*))(\s)?)$`
+      `^(${prefix}(\([\w\-]+\))?!?: [^\r\n]+((\s)((\s)[^\r\n]+)+)*)(\s?)$`
     );
     const matches = logs.filter((l) => l.match(regex));
     grouped[category] = [...matches, ...grouped[category]];


### PR DESCRIPTION
**Related Ticket:** #1525
- [x] Delete v6.2.0

### Description of Changes
- Removing the condition that was blocking the weekly release 
- Simplify Regex (We don't need merge.. and initial commit for our change logs)
- Edit notification text 

### Notes & Questions About Changes
**This change should be accompanied with repo settings** 
- It seems that requiring staus check makes force-push fail. To allow github action to bypass this rule, we need to use Ruleset (Settings > Rules > Rulesets), not the branch protection rule. (I already went through this process.)

### Validation / Testing
I applied the same ruleset for this branch, and tested the release action: https://github.com/NASA-IMPACT/veda-ui/releases/tag/v6.2.0