### PR TITLE
chore: Add script to ease local development between veda-ui and next-veda-ui

### DIFF
--- a/docs/development/REGISTRY.md
+++ b/docs/development/REGISTRY.md
@@ -1,25 +1,58 @@
 ## Library build
 
-As VEDA-UI is trying to become a registry, there are several things that developers need to be aware of.
+As VEDA-UI evolves into a standalone library consumed by multiple projects, there are several things that developers need to be aware of.
 
-### Local Development
+### Local development
 
-Build locally first with the command below.
+We now provide a script to streamline local development between `veda-ui` and `next-veda-ui`.
+
+#### Option 1: Scripted setup (Recommended)
+
+If you have both `veda-ui` and `next-veda-ui` cloned in sibling directories (e.g., `~/dev/veda-ui` and `~/dev/next-veda-ui`), run the following inside the `veda-ui` directory:
+
+```sh
+./utils/link-next.sh
 ```
+
+This script:
+- Builds `veda-ui`
+- Links it globally
+- Links it into `next-veda-ui`
+- Starts watching for changes in `veda-ui` and rebuilds automatically
+
+Once the script runs successfully, open a new terminal and start the Next.js app from within `next-veda-ui`:
+
+```sh
+npm run dev
+```
+
+You can now edit components in `veda-ui` and any changes will automatically rebuild and reflect in the running Next.js app.
+
+> **Note:** During rebuilds, you might briefly see a `Module not found: Can't resolve '/veda-ui/lib/main.css'` error in Next.js. This is expected and will resolve once the rebuild finishes.
+
+> **Troubleshooting:** If you encounter issues like `Cannot find module '@teamimpact/veda-ui'`, try deleting `node_modules` in both projects and running `yarn install` again before retrying the script.
+
+#### Option 2: Manual linking
+
+Build locally first:
+
+```sh
 yarn buildlib
 ```
 
-After successfully building the library, link the project to your local environment with the following command, executed inside the VEDA-UI directory:
+Link the library globally:
 
-```
+```sh
 yarn link
 ```
-Then change your directory to the project that is using veda-ui, which has `@teamimpact/veda-ui` as a dependency. Create a local alias for VEDA-UI by running:
-```
+
+Then, in your consumer project (e.g., `next-veda-ui`):
+
+```sh
 yarn link @teamimpact/veda-ui
 ```
 
-Your project should now use the local version of the VEDA-UI library.
+Your project should now use the local version of the `veda-ui` library.
 
 ### Build with pipeline
 
@@ -37,27 +70,29 @@ To publish the package, make sure you are authenticated with teamimpact's NPM re
 
 1. Set the scoped registry for @teamimpact:
 
-```
+```sh
 npm config set @teamimpact:registry=https://registry.npmjs.org/
 ```
 
 2. Add your authentication token for the registry:
 
-```
+```sh
 npm config set //registry.npmjs.org/:_authToken=<your-token>
 ```
-Replace <your-token> with the actual token provided to you.
+
+Replace `<your-token>` with the actual token provided to you.
 
 > **Important:** Avoid using `npm logout` while working with the registry locally. Logging out invalidates the authentication token globally, which will disrupt publishing and other registry-related actions.
 
 Before publishing live, test the process with:
 
-```
+```sh
 npm publish --dry-run
 ```
-When the package is ready to be published, you can
 
-```
+When the package is ready to be published, you can:
+
+```sh
 npm publish
 ```
 
@@ -65,12 +100,13 @@ npm publish
 
 There is currently an issue where the version number of VEDA-UI in the registry does not always match the version number of VEDA-UI when used as a submodule. Since VEDA-UI as a submodule follows a bi-weekly release schedule to support various instances, we are using pre-release tags to handle cases where additional changes need to be published without changing the version number.
 
-For example, if the current version is v5.7.0 and further changes are necessary before the next scheduled release, the registry will use a pre-release tag like v5.7.0-alpha.x.
+For example, if the current version is `v5.7.0` and further changes are necessary before the next scheduled release, the registry will use a pre-release tag like `v5.7.0-alpha.x`.
 
 To check the latest version in the registry and ensure proper versioning, run:
 
-```
+```sh
 npm view @teamimpact/veda-ui version
 ```
 
-Currently, developers manually update the version number in the package.json file to publish with pre-release tags (instead of using npm tag) because a formal release cycle for the library has not yet been established.
+Currently, developers manually update the version number in the `package.json` file to publish with pre-release tags (instead of using `npm tag`) because a formal release cycle for the library has not yet been established.
+

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "jest",
     "pretest:e2e": "node test/playwright/generateTestData.js",
     "test:e2e": "yarn playwright test",
-    "release": "release-it --"
+    "release": "release-it --",
+    "watch:buildlib": "chokidar \"app/scripts/**/*\" -c \"yarn buildlib\" --initial"
   },
   "targets": {
     "veda-app": {
@@ -83,6 +84,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-styled-components": "^1.13.3",
     "buffer": "^6.0.3",
+    "chokidar-cli": "^3.0.0",
     "conventional-changelog-conventionalcommits": "^8.0.0",
     "conventional-recommended-bump": "^10.0.0",
     "dedent": "^0.7.0",

--- a/utils/link-next.sh
+++ b/utils/link-next.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This script automates the local development workflow between veda-ui and next-veda-ui.
+# It builds the veda-ui library, links it globally, links it into the Next.js project,
+# and starts a file watcher to rebuild the library on changes.
+#
+# Assumes that the veda-ui and next-veda-ui folders are siblings, i.e. located at the same directory level.
+# If they are not, the NEXT_DIR path in this script must be modified manually.
+#
+# Usage:
+# 1) Start the Next.js project (e.g. with `yarn dev` or `npm run dev`) in a separate terminal first
+# 2) Then run this script (`./utils/link-next.sh`) from the veda-ui/utils directory in a separate terminal
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VEDA_UI_DIR="$SCRIPT_DIR/.."
+NEXT_DIR="$VEDA_UI_DIR/../next-veda-ui"
+
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+NC="\033[0m"
+
+echo -e "${GREEN}Starting veda-ui link script...${NC}"
+
+if [ ! -d "$NEXT_DIR" ]; then
+  echo -e "${RED}next-veda-ui folder not found at: $NEXT_DIR${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Building veda-ui library...${NC}"
+cd "$VEDA_UI_DIR"
+yarn buildlib
+if [ $? -ne 0 ]; then
+  echo -e "${RED}Failed to build veda-ui library${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Running yarn link in veda-ui...${NC}"
+yarn link
+if [ $? -ne 0 ]; then
+  echo -e "${RED}yarn link failed in veda-ui${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Linking veda-ui in next-veda-ui...${NC}"
+cd "$NEXT_DIR"
+yarn link @teamimpact/veda-ui
+if [ $? -ne 0 ]; then
+  echo -e "${RED}Failed to link @teamimpact/veda-ui in Next.js project${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}Watching for changes in veda-ui and rebuilding...${NC}"
+cd "$VEDA_UI_DIR"
+./node_modules/.bin/chokidar "app/scripts/**/*" -c "yarn buildlib" --initial &
+WATCH_PID=$!
+
+echo -e "${GREEN}Link setup complete. Verifying...${NC}"
+NODE_SCRIPT="require.resolve('@teamimpact/veda-ui')"
+if node -e "$NODE_SCRIPT"; then
+  echo -e "${GREEN}Link verified successfully${NC}"
+else
+  echo -e "${RED}Link verification failed. Please check manually${NC}"
+fi
+
+echo -e "\n${GREEN}To unlink later, run the following:${NC}"
+echo -e "cd $NEXT_DIR && yarn unlink @teamimpact/veda-ui"
+echo -e "cd $VEDA_UI_DIR && yarn unlink"
+
+echo -e "${GREEN}Watching for changes (PID $WATCH_PID). Press Ctrl+C to stop.${NC}"
+wait $WATCH_PID

--- a/utils/link-next.sh
+++ b/utils/link-next.sh
@@ -49,6 +49,9 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+echo -e "${GREEN}Cleaning .next cache in next-veda-ui...${NC}"
+rm -rf "$NEXT_DIR/.next"
+
 echo -e "${GREEN}Watching for changes in veda-ui and rebuilding...${NC}"
 cd "$VEDA_UI_DIR"
 ./node_modules/.bin/chokidar "app/scripts/**/*" -c "yarn buildlib" --initial &

--- a/utils/link-next.sh
+++ b/utils/link-next.sh
@@ -34,8 +34,16 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+echo -e "${GREEN}Cleaning previous links (if any)...${NC}"
+cd "$VEDA_UI_DIR"
+yarn unlink || true
+cd "$NEXT_DIR"
+yarn unlink @teamimpact/veda-ui || true
+
 echo -e "${GREEN}Running yarn link in veda-ui...${NC}"
+cd "$VEDA_UI_DIR"
 yarn link
+
 if [ $? -ne 0 ]; then
   echo -e "${RED}yarn link failed in veda-ui${NC}"
   exit 1
@@ -58,8 +66,8 @@ cd "$VEDA_UI_DIR"
 WATCH_PID=$!
 
 echo -e "${GREEN}Link setup complete. Verifying...${NC}"
-NODE_SCRIPT="require.resolve('@teamimpact/veda-ui')"
-if node -e "$NODE_SCRIPT"; then
+cd "$NEXT_DIR"
+if node -e "require.resolve('@teamimpact/veda-ui')" > /dev/null 2>&1; then
   echo -e "${GREEN}Link verified successfully${NC}"
 else
   echo -e "${RED}Link verification failed. Please check manually${NC}"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5149,6 +5149,11 @@ ansi-regex@^2.0.0:
   resolved "http://verdaccio.ds.io:4873/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
 
+ansi-regex@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.1.tgz#164daac87ab2d6f6db3a29875e2d1766582dabed"
+  integrity sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==
+
 ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "http://verdaccio.ds.io:4873/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
@@ -5159,7 +5164,7 @@ ansi-regex@^6.0.1:
   resolved "http://verdaccio.ds.io:4873/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
   integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
 
-ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "http://verdaccio.ds.io:4873/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -6120,7 +6125,17 @@ cheerio@^1.0.0-rc.10:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
-"chokidar@>=3.0.0 <4.0.0":
+chokidar-cli@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chokidar-cli/-/chokidar-cli-3.0.0.tgz#29283666063b9e167559d30f247ff8fc48794eb7"
+  integrity sha512-xVW+Qeh7z15uZRxHOkP93Ux8A0xbPzwK4GaqD8dQOYc34TlkqUhVSS59fK36DOp5WdJlrRzlYSy02Ht99FjZqQ==
+  dependencies:
+    chokidar "^3.5.2"
+    lodash.debounce "^4.0.8"
+    lodash.throttle "^4.1.1"
+    yargs "^13.3.0"
+
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.5.2:
   version "3.6.0"
   resolved "http://verdaccio.ds.io:4873/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -6257,6 +6272,15 @@ cliui@^3.2.0:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
     wrap-ansi "^2.0.0"
+
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
 
 cliui@^8.0.1:
   version "8.0.1"
@@ -7640,6 +7664,11 @@ emoji-regex@^10.3.0:
   resolved "http://verdaccio.ds.io:4873/emoji-regex/-/emoji-regex-10.4.0.tgz#03553afea80b3975749cfcb36f776ca268e413d4"
   integrity sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==
 
+emoji-regex@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
+  integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "http://verdaccio.ds.io:4873/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
@@ -8400,6 +8429,13 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "http://verdaccio.ds.io:4873/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -8673,7 +8709,7 @@ get-caller-file@^1.0.1:
   resolved "http://verdaccio.ds.io:4873/get-caller-file/-/get-caller-file-1.0.3.tgz#f978fa4c90d1dfe7ff2d6beda2a515e713bdcf4a"
   integrity sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==
 
-get-caller-file@^2.0.5:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "http://verdaccio.ds.io:4873/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -9828,6 +9864,11 @@ is-fullwidth-code-point@^1.0.0:
   integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
+
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  integrity sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"
@@ -11142,6 +11183,14 @@ load-json-file@^1.0.0:
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "http://verdaccio.ds.io:4873/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -11220,6 +11269,11 @@ lodash.once@^4.1.1:
   version "4.1.1"
   resolved "http://verdaccio.ds.io:4873/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
+lodash.throttle@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
+  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
 
 lodash.truncate@^4.4.2:
   version "4.4.2"
@@ -12813,7 +12867,7 @@ p-finally@^1.0.0:
   resolved "http://verdaccio.ds.io:4873/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
   integrity sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "http://verdaccio.ds.io:4873/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -12826,6 +12880,13 @@ p-limit@^3.0.2, p-limit@^3.1.0:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -13077,6 +13138,11 @@ path-exists@^2.0.0:
   integrity sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=
   dependencies:
     pinkie-promise "^2.0.0"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -14474,6 +14540,11 @@ require-main-filename@^1.0.1:
   resolved "http://verdaccio.ds.io:4873/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "http://verdaccio.ds.io:4873/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -15221,6 +15292,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^3.0.0, string-width@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
+  integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+  dependencies:
+    emoji-regex "^7.0.1"
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^5.1.0"
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "http://verdaccio.ds.io:4873/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
@@ -15299,6 +15379,13 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
   dependencies:
     ansi-regex "^2.0.0"
+
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
+  integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+  dependencies:
+    ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
@@ -16596,6 +16683,11 @@ which-module@^1.0.0:
   resolved "http://verdaccio.ds.io:4873/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
   integrity sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=
 
+which-module@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.1.tgz#776b1fe35d90aebe99e8ac15eb24093389a4a409"
+  integrity sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==
+
 which@^1.2.14, which@^1.3.1:
   version "1.3.1"
   resolved "http://verdaccio.ds.io:4873/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -16656,6 +16748,15 @@ wrap-ansi@^2.0.0:
   dependencies:
     string-width "^1.0.1"
     strip-ansi "^3.0.1"
+
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
 
 wrap-ansi@^6.2.0:
   version "6.2.0"
@@ -16760,6 +16861,11 @@ y18n@^3.2.1:
   resolved "http://verdaccio.ds.io:4873/y18n/-/y18n-3.2.2.tgz#85c901bd6470ce71fc4bb723ad209b70f7f28696"
   integrity sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==
 
+y18n@^4.0.0:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
+
 y18n@^5.0.5:
   version "5.0.8"
   resolved "http://verdaccio.ds.io:4873/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
@@ -16785,6 +16891,14 @@ yargs-parser@21.1.1, yargs-parser@>=5.0.0-security.0, yargs-parser@^21.1.1:
   resolved "http://verdaccio.ds.io:4873/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
+yargs-parser@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.2.tgz#130f09702ebaeef2650d54ce6e3e5706f7a4fb38"
+  integrity sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^18.1.3:
   version "18.1.3"
   resolved "http://verdaccio.ds.io:4873/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
@@ -16800,6 +16914,22 @@ yargs-parser@^5.0.1:
   dependencies:
     camelcase "^3.0.0"
     object.assign "^4.1.0"
+
+yargs@^13.3.0:
+  version "13.3.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
+  integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.2"
 
 yargs@^17.3.1:
   version "17.7.2"


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1549

### Description of Changes
Adds a `link-next.sh` script to make local linking and development between veda-ui into next-veda-ui easier. The script builds the veda-ui library, links it globally, links it into the Next.js project and watches for changes in veda-ui to re-trigger `yarn buildlib`.

### Notes & Questions About Changes

1. Assumes both repos are in sibling directories
2. One caveat is that during rebuilds, you may briefly see a `Module not found: Can't resolve '/veda-ui/lib/main.css'` error in Next.js. This happens because each new `yarn buildlib` clears the previous build. The error will resolve once the rebuild completes

### Validation / Testing

Make sure you run `yarn` to install the new dependency added in the project.

1. Open a terminal and run the script `./utils/link-next.sh` in the veda-ui directory
3. Once it's done, open another terminal and run the next-veda-ui project (`npm run dev` in the next-veda-ui directory)
4. Make sure you're using the main branch in the next-veda-ui project for this test
5. Open `http://localhost:3000/` in your browser
6. Change something in a veda-ui component used in Next.js (e.g. add an extra className 'test' to the `usa-navbar`)
7. Verify that the library is rebuilt and the change is visible in Next.js
