### PR TITLE
fix: use utils.isExternalLink logic for same-domain external apps

### DIFF
--- a/app/scripts/context/veda-ui-provider.tsx
+++ b/app/scripts/context/veda-ui-provider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, ReactNode, useContext } from 'react';
 import { DATASETS_PATH, STORIES_PATH } from '$utils/routes';
-import { isExternalLink } from '$utils/url';
+import * as utils from '$utils/utils';
 
 interface EnvironmentConfig {
   envMapboxToken: string;
@@ -95,7 +95,7 @@ export function VedaUIProvider({ config, children }: VedaUIProviderProps) {
   const Link: React.FC<LinkProps> = ({ to, children, ...props }) => {
     const { LinkComponent, linkProps } = navigation;
 
-    if (isExternalLink(to)) {
+    if (utils.isExternalLink(to)) {
       return (
         <a href={to} target='_blank' rel='noopener noreferrer' {...props}>
           {children}

--- a/app/scripts/utils/url.ts
+++ b/app/scripts/utils/url.ts
@@ -1,10 +1,6 @@
 import React from 'react';
 import { LinkProps } from 'react-router-dom';
 
-export function isExternalLink(link: string): boolean {
-  return /^https?:\/\//.test(link) && !link.includes(window.location.hostname);
-}
-
 export const getLinkProps = (
   linkTo: string,
   as?: React.ForwardRefExoticComponent<
@@ -18,10 +14,10 @@ export const getLinkProps = (
     ? {
         href: linkTo,
         to: linkTo,
-        ...{ target: '_blank', rel: 'noopener noreferrer' },
+        ...{ target: '_blank', rel: 'noopener noreferrer' }
       }
     : {
         ...(as ? { as: as } : {}),
-        to: linkTo,
+        to: linkTo
       };
 };

--- a/app/scripts/utils/utils.test.ts
+++ b/app/scripts/utils/utils.test.ts
@@ -1,0 +1,40 @@
+import { isExternalLink } from './utils';
+
+/**
+ * These tests validate the current simple implementation of `isExternalLink`,
+ * which now only checks if a URL starts with `http://` or `https://`.
+ *
+ * We intentionally stopped checking if the link is on the same domain,
+ * because we have external apps (e.g., Mobile Climate Mapper) that are hosted
+ * under the same domain (like `earth.gov/mobile-climate-mapper`) but
+ * are separate from the React app (VEDA).
+ *
+ * Treating these as "external" allows opening them in a new tab instead
+ * of using React Router's internal `<Link>` handling, which would otherwise
+ * break with URLs like:
+ *   https://earth.gov/visit/https://earth.gov/mobile-climate-mapper/
+ *
+ * This utility is therefore protocol-based, not domain-based, by design.
+ *
+ */
+describe('isExternalLink (basic protocol check)', () => {
+  it('returns true for external http link', () => {
+    expect(isExternalLink('http://example.com')).toBe(true);
+  });
+
+  it('returns true for https link on same domain', () => {
+    expect(isExternalLink('https://localhost:3000')).toBe(true);
+  });
+
+  it('returns true for same-hostname subpath', () => {
+    expect(isExternalLink('https://localhost/foo')).toBe(true);
+  });
+
+  it('returns false for relative link', () => {
+    expect(isExternalLink('/stories/123')).toBe(false);
+  });
+
+  it('returns false for mailto', () => {
+    expect(isExternalLink('mailto:test@example.com')).toBe(false);
+  });
+});


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1578

### Description of Changes

See issue above for context.

- Refactored to use `utils.isExternalLink`
- Removed the previous util from url.ts

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

1. Pull branch locally in veda-ui
2. Go to mock/stories/external-link-example.stories.mdx
3. Change the url prop from to https://developmentseed.org to http://localhost:9000/stories 
4. Click on the card, it should open the url and in a new tab
5. Switch to the main branch
6. Test the same
7. Once you do step 4, notice how the link is broken (it appends the url to the current url)
 




