### PR TITLE
fix: Separate out hooks from Raster time series, Make RasterPaintLayer to use it

### DIFF
--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -4,21 +4,30 @@ import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 import { BaseTimeseriesProps } from '../types';
 import { RasterPaintLayer } from './raster-paint-layer';
+import { useLayerStatus, STATUS_KEY } from './raster-timeseries';
 import { userTzDate2utcString } from '$utils/date';
 
 export function CMRTimeseries(props: BaseTimeseriesProps) {
-  const { date, sourceParams } = props;
+  const { id, date, sourceParams, onStatusChange } = props;
   const start_datetime = userTzDate2utcString(startOfDay(date));
   const end_datetime = userTzDate2utcString(endOfDay(date));
   const tileParams = {
     datetime: `${start_datetime}/${end_datetime}`,
     ...sourceParams
   };
+
+  const { changeStatus } = useLayerStatus({
+    id,
+    onStatusChange,
+    layersToTrack: [STATUS_KEY.Layer]
+  });
+
   return (
     <RasterPaintLayer
       {...props}
       tileParams={tileParams}
       generatorPrefix='cmr-timeseries'
+      onStatusChange={changeStatus}
     />
   );
 }

--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -19,7 +19,7 @@ export function CMRTimeseries(props: BaseTimeseriesProps) {
   const { changeStatus } = useLayerStatus({
     id,
     onStatusChange,
-    layersToTrack: [STATUS_KEY.Layer]
+    requestsToTrack: []
   });
 
   return (

--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -4,7 +4,7 @@ import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 import { BaseTimeseriesProps } from '../types';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useLayerStatus, STATUS_KEY } from './raster-timeseries';
+import { useLayerStatus } from './raster-timeseries';
 import { userTzDate2utcString } from '$utils/date';
 
 export function CMRTimeseries(props: BaseTimeseriesProps) {

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -5,7 +5,7 @@ import { RasterSourceSpecification, RasterLayerSpecification } from 'mapbox-gl';
 import { BaseGeneratorParams } from '../types';
 import useMapStyle from '../hooks/use-map-style';
 import useGeneratorParams from '../hooks/use-generator-params';
-import { STATUS_KEY, useLayerStatus } from './raster-timeseries';
+import { STATUS_KEY } from './raster-timeseries';
 
 import { ActionStatus, S_SUCCEEDED } from '$utils/status';
 
@@ -17,7 +17,10 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   tileParams: Record<string, any>;
   generatorPrefix?: string;
   reScale?: { min: number; max: number };
-  onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
+  onStatusChange?: (params: {
+    status: ActionStatus;
+    context: STATUS_KEY;
+  }) => void;
 }
 
 export function RasterPaintLayer(props: RasterPaintLayerProps) {
@@ -36,12 +39,6 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
   const { updateStyle } = useMapStyle();
   const [minZoom] = zoomExtent ?? [0, 20];
   const generatorId = `${generatorPrefix}-${id}`;
-
-  const { changeStatus } = useLayerStatus({
-    id,
-    onStatusChange,
-    layersToTrack: [STATUS_KEY.Layer]
-  });
 
   const updatedTileParams = useMemo(() => {
     return {
@@ -125,7 +122,8 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
         layers,
         params: generatorParams
       });
-      changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.Layer });
+      if (onStatusChange)
+        onStatusChange({ status: S_SUCCEEDED, context: STATUS_KEY.Layer });
     },
     // sourceParams not included, but using a stringified version of it to
     // detect changes (haveSourceParamsChanged)

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -5,6 +5,9 @@ import { RasterSourceSpecification, RasterLayerSpecification } from 'mapbox-gl';
 import { BaseGeneratorParams } from '../types';
 import useMapStyle from '../hooks/use-map-style';
 import useGeneratorParams from '../hooks/use-generator-params';
+import { STATUS_KEY, useLayerStatus } from './raster-timeseries';
+
+import { ActionStatus, S_SUCCEEDED } from '$utils/status';
 
 interface RasterPaintLayerProps extends BaseGeneratorParams {
   id: string;
@@ -14,6 +17,7 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   tileParams: Record<string, any>;
   generatorPrefix?: string;
   reScale?: { min: number; max: number };
+  onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
 }
 
 export function RasterPaintLayer(props: RasterPaintLayerProps) {
@@ -26,11 +30,18 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     opacity,
     colorMap,
     reScale,
-    generatorPrefix = 'raster'
+    generatorPrefix = 'raster',
+    onStatusChange
   } = props;
   const { updateStyle } = useMapStyle();
   const [minZoom] = zoomExtent ?? [0, 20];
   const generatorId = `${generatorPrefix}-${id}`;
+
+  const { changeStatus } = useLayerStatus({
+    id,
+    onStatusChange,
+    layersToTrack: [STATUS_KEY.Layer]
+  });
 
   const updatedTileParams = useMemo(() => {
     return {
@@ -114,6 +125,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
         layers,
         params: generatorParams
       });
+      changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.Layer });
     },
     // sourceParams not included, but using a stringified version of it to
     // detect changes (haveSourceParamsChanged)

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -57,7 +57,8 @@ export function useLayerStatus({
   requestsToTrack = []
 }: UseLayersParams) {
   const initialStatuses = {
-    global: S_IDLE as ActionStatus, // Global flag to mark that all layers are loaded
+    // Global flag to track all the requests
+    global: (requestsToTrack.length ? S_IDLE : S_SUCCEEDED) as ActionStatus,
     ...requestsToTrack.reduce(
       (acc, context) => ({
         ...acc,
@@ -72,7 +73,6 @@ export function useLayerStatus({
   const changeStatus = useCallback(
     ({ status, context }: { status: ActionStatus; context: STATUS_KEY }) => {
       statuses.current[context] = status;
-
       const layersToCheck = requestsToTrack.map(
         (context) => statuses.current[context]
       );

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -37,99 +37,81 @@ import {
 // Whether or not to print the request logs.
 const LOG = true;
 
-enum STATUS_KEY {
+export enum STATUS_KEY {
   Global,
   Layer,
   StacSearch
 }
 
-interface Statuses {
-  [STATUS_KEY.Global]: ActionStatus;
-  [STATUS_KEY.Layer]: ActionStatus;
-  [STATUS_KEY.StacSearch]: ActionStatus;
+interface UseLayersParams {
+  id: string;
+  onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
+  layersToTrack: STATUS_KEY[];
 }
 
-export function RasterTimeseries(props: RasterTimeseriesProps) {
-  const {
-    id,
-    stacCol,
-    date,
-    sourceParams,
-    zoomExtent,
-    bounds,
-    onStatusChange,
-    isPositionSet,
-    hidden,
-    opacity,
-    stacApiEndpoint,
-    tileApiEndpoint,
-    colorMap,
-    reScale,
-    envApiStacEndpoint,
-    envApiRasterEndpoint
-  } = props;
+// Some layers are consist of more than one layer
+// (ex. markers for low zoom, rasters for high zoom)
+// Check all the layers if they are loaded
+export function useLayerStatus({
+  id,
+  onStatusChange,
+  layersToTrack = []
+}: UseLayersParams) {
+  const initialStatuses = {
+    global: S_IDLE as ActionStatus, // Global flag to mark that all layers are loaded
+    ...layersToTrack.reduce(
+      (acc, context) => ({
+        ...acc,
+        [context]: S_IDLE
+      }),
+      {}
+    )
+  };
 
-  const { current: mapInstance } = useMaps();
-
-  const theme = useTheme();
-  const { updateStyle } = useMapStyle();
-
-  const minZoom = zoomExtent?.[0] ?? 0;
-  const generatorId = `raster-timeseries-${id}`;
-
-  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint ?? '';
-  const tileApiEndpointToUse = tileApiEndpoint ?? envApiRasterEndpoint ?? '';
-
-  // Status tracking.
-  // A raster timeseries layer has a base layer and may have markers.
-  // The status is succeeded only if all requests succeed.
-  const statuses = useRef<Statuses>({
-    [STATUS_KEY.Global]: S_IDLE,
-    [STATUS_KEY.Layer]: S_IDLE,
-    [STATUS_KEY.StacSearch]: S_IDLE
-  });
+  const statuses = useRef(initialStatuses);
 
   const changeStatus = useCallback(
-    ({
-      status,
-      context
-    }: {
-      status: ActionStatus;
-      context: STATUS_KEY.StacSearch | STATUS_KEY.Layer;
-    }) => {
-      // Set the new status
+    ({ status, context }: { status: ActionStatus; context: STATUS_KEY }) => {
       statuses.current[context] = status;
 
-      const layersToCheck = [
-        statuses.current[STATUS_KEY.StacSearch],
-        statuses.current[STATUS_KEY.Layer]
-      ];
+      const layersToCheck = layersToTrack.map(
+        (context) => statuses.current[context]
+      );
 
-      let newStatus = statuses.current[STATUS_KEY.Global];
-      // All must succeed to be considered successful.
+      let newStatus = statuses.current.global;
+      // All layers must succeed to be considered successful.
       if (layersToCheck.every((s) => s === S_SUCCEEDED)) {
         newStatus = S_SUCCEEDED;
-
-        // One failed status is enough for all.
-        // Failed takes priority over loading.
       } else if (layersToCheck.some((s) => s === S_FAILED)) {
         newStatus = S_FAILED;
-        // One loading status is enough for all.
       } else if (layersToCheck.some((s) => s === S_LOADING)) {
         newStatus = S_LOADING;
       } else if (layersToCheck.some((s) => s === S_IDLE)) {
         newStatus = S_IDLE;
       }
 
-      // Only emit on status change.
+      // Only emit when layers statuses change
       if (newStatus !== statuses.current[STATUS_KEY.Global]) {
         statuses.current[STATUS_KEY.Global] = newStatus;
         onStatusChange?.({ status: newStatus, id });
       }
     },
-    [id, onStatusChange]
+    [id, onStatusChange, layersToTrack]
   );
 
+  return {
+    changeStatus,
+    statuses: statuses.current
+  };
+}
+
+export function useStacResponse({
+  id,
+  changeStatus,
+  stacCol,
+  date,
+  stacApiEndpointToUse
+}) {
   //
   // Load stac collection features
   //
@@ -226,6 +208,18 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     return points;
   }, [stacCollection]);
 
+  return [stacCollection, points];
+}
+
+function useMosaicUrl({
+  id,
+  stacCol,
+  date,
+  colorMap,
+  stacCollection,
+  changeStatus,
+  tileApiEndpointToUse
+}) {
   //
   // Tiles
   //
@@ -346,6 +340,61 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     // resulted in a race condition when adding the source to the map leading to
     // an error.
   ]);
+  return [mosaicUrl];
+}
+
+export function RasterTimeseries(props: RasterTimeseriesProps) {
+  const {
+    id,
+    stacCol,
+    date,
+    sourceParams,
+    zoomExtent,
+    bounds,
+    onStatusChange,
+    isPositionSet,
+    hidden,
+    opacity,
+    stacApiEndpoint,
+    tileApiEndpoint,
+    colorMap,
+    reScale,
+    envApiStacEndpoint,
+    envApiRasterEndpoint
+  } = props;
+
+  const { updateStyle } = useMapStyle();
+
+  const { current: mapInstance } = useMaps();
+  const minZoom = zoomExtent?.[0] ?? 0;
+  const generatorId = `raster-timeseries-${id}`;
+
+  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint ?? '';
+  const tileApiEndpointToUse = tileApiEndpoint ?? envApiRasterEndpoint ?? '';
+
+  const { changeStatus } = useLayerStatus({
+    id,
+    onStatusChange,
+    layersToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
+  });
+
+  const [stacCollection, points] = useStacResponse({
+    id,
+    changeStatus,
+    stacCol,
+    date,
+    stacApiEndpointToUse
+  });
+
+  const [mosaicUrl] = useMosaicUrl({
+    id,
+    stacCol,
+    date,
+    colorMap,
+    stacCollection,
+    changeStatus,
+    tileApiEndpointToUse
+  });
 
   //
   // Generate Mapbox GL layers and sources for raster timeseries

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -32,7 +32,7 @@ export function ZarrTimeseries(props: BaseTimeseriesProps) {
   const { changeStatus } = useLayerStatus({
     id,
     onStatusChange,
-    layersToTrack: [STATUS_KEY.Layer]
+    requestsToTrack: []
   });
   return (
     <RasterPaintLayer

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { BaseTimeseriesProps } from '../types';
 import { useZarr } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
+import { useLayerStatus, STATUS_KEY } from './raster-timeseries';
 
 export function ZarrTimeseries(props: BaseTimeseriesProps) {
   const {
@@ -28,10 +29,16 @@ export function ZarrTimeseries(props: BaseTimeseriesProps) {
     datetime: date,
     ...sourceParams
   };
+  const { changeStatus } = useLayerStatus({
+    id,
+    onStatusChange,
+    layersToTrack: [STATUS_KEY.Layer]
+  });
   return (
     <RasterPaintLayer
       {...props}
       tileParams={tileParams}
+      onStatusChange={changeStatus}
       generatorPrefix='zarr-timeseries'
     />
   );

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BaseTimeseriesProps } from '../types';
 import { useZarr } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useLayerStatus, STATUS_KEY } from './raster-timeseries';
+import { useLayerStatus } from './raster-timeseries';
 
 export function ZarrTimeseries(props: BaseTimeseriesProps) {
   const {


### PR DESCRIPTION
**Related Ticket:** #1545 

### Description of Changes
I am splitting #1545 out since the PR will get pretty big. As a first step, I separated out some hooks from RasterTimeseries, and shared it with RasterPaintLayer (This will resolve Scrollytelling issue with Zarr layers) 

I will split out Marker layer next, and then eventually Make RasterTimeseries to use RasterPaintLayer as a last step.


You can find what type of layers a dataset uses through `type` attribute of a dataset (ex.https://github.com/NASA-IMPACT/veda-config/blob/develop/datasets/GPM_3IMERGDF.data.mdx - this one is `cmr` type). Most of them are `raster`, which uses raster-timeseries-layer. 

CMR layer example: https://deploy-preview-1580--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22GPM_3IMERGDF.v07%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22gnbu%22%7D%7D%5D&taxonomy=%7B%7D&search=


RasterTimeSeries example (with markers layer) : https://deploy-preview-1580--veda-ui.netlify.app/exploration?datasets=%5B%7B"id"%3A"nightlights-hd-monthly"%2C"settings"%3A%7B"isVisible"%3Atrue%2C"opacity"%3A100%2C"analysisMetrics"%3A%5B%7B"id"%3A"mean"%2C"label"%3A"Average"%2C"chartLabel"%3A"Average"%2C"themeColor"%3A"infographicB"%7D%2C%7B"id"%3A"std"%2C"label"%3A"St+Deviation"%2C"chartLabel"%3A"St+Deviation"%2C"themeColor"%3A"infographicD"%7D%5D%2C"colorMap"%3A"inferno"%2C"scale"%3A%7B"min"%3A0%2C"max"%3A255%7D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2022-02-28T15%3A00%3A00.000Z

RasterTimeSeries: https://deploy-preview-1580--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22no2-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22min%22%2C%22label%22%3A%22Min%22%2C%22chartLabel%22%3A%22Min%22%2C%22themeColor%22%3A%22infographicA%22%2C%22style%22%3A%7B%22strokeDasharray%22%3A%222+2%22%7D%7D%2C%7B%22id%22%3A%22max%22%2C%22label%22%3A%22Max%22%2C%22chartLabel%22%3A%22Max%22%2C%22themeColor%22%3A%22infographicC%22%2C%22style%22%3A%7B%22strokeDasharray%22%3A%222+2%22%7D%7D%5D%2C%22colorMap%22%3A%22coolwarm%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A15000000000000000%7D%7D%7D%2C%7B%22id%22%3A%22no2-monthly-2%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22coolwarm%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A15000000000000000%7D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2022-11-30T15%3A00%3A00.000Z&dateRange=
