### PR TITLE
feat: Separate Marker Layer from RasterTimeSeries

### DIFF
--- a/app/scripts/components/common/map/hooks/use-layer-interaction.ts
+++ b/app/scripts/components/common/map/hooks/use-layer-interaction.ts
@@ -4,7 +4,7 @@ import useMaps from './use-maps';
 
 interface LayerInteractionHookOptions {
   layerId: string;
-  onClick: (features: Feature<any>[]) => void;
+  onClick?: (features: Feature<any>[]) => void;
 }
 export default function useLayerInteraction({
   layerId,
@@ -12,7 +12,7 @@ export default function useLayerInteraction({
 }: LayerInteractionHookOptions) {
   const { current: mapInstance } = useMaps();
   useEffect(() => {
-    if (!mapInstance) return;
+    if (!mapInstance || !onClick) return;
     const onPointsClick = (e) => {
       if (!e.features.length) return;
       onClick(e.features);

--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -4,7 +4,7 @@ import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 import { BaseTimeseriesProps } from '../types';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useLayerStatus } from './raster-timeseries';
+import { useRequestStatus } from './raster-timeseries';
 import { userTzDate2utcString } from '$utils/date';
 
 export function CMRTimeseries(props: BaseTimeseriesProps) {
@@ -16,7 +16,7 @@ export function CMRTimeseries(props: BaseTimeseriesProps) {
     ...sourceParams
   };
 
-  const { changeStatus } = useLayerStatus({
+  const { changeStatus } = useRequestStatus({
     id,
     onStatusChange,
     requestsToTrack: []

--- a/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/cmr-timeseries.tsx
@@ -4,7 +4,7 @@ import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 import { BaseTimeseriesProps } from '../types';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useRequestStatus } from './raster-timeseries';
+import { useRequestStatus } from './hooks';
 import { userTzDate2utcString } from '$utils/date';
 
 export function CMRTimeseries(props: BaseTimeseriesProps) {

--- a/app/scripts/components/common/map/style-generators/hooks.ts
+++ b/app/scripts/components/common/map/style-generators/hooks.ts
@@ -1,6 +1,13 @@
-import {useState, useEffect} from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { requestQuickCache } from '../utils';
-import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
+
+import {
+  ActionStatus,
+  S_FAILED,
+  S_IDLE,
+  S_LOADING,
+  S_SUCCEEDED
+} from '$utils/status';
 
 interface AssetUrlReplacement {
   from: string;
@@ -9,21 +16,27 @@ interface AssetUrlReplacement {
 interface ZarrResponseData {
   assets: {
     zarr: {
-      href: string
-    }
-  }
+      href: string;
+    };
+  };
 }
 interface CMRResponseData {
   features: {
     assets: {
       data: {
-        href: string
-      }
-    }
-  }[]
+        href: string;
+      };
+    };
+  }[];
 }
 
-export function useZarr({ id, stacCol, stacApiEndpointToUse, date, onStatusChange }){
+export function useZarr({
+  id,
+  stacCol,
+  stacApiEndpointToUse,
+  date,
+  onStatusChange
+}) {
   const [assetUrl, setAssetUrl] = useState('');
 
   useEffect(() => {
@@ -32,7 +45,7 @@ export function useZarr({ id, stacCol, stacApiEndpointToUse, date, onStatusChang
     async function load() {
       try {
         onStatusChange?.({ status: S_LOADING, id });
-        const data:ZarrResponseData = await requestQuickCache({
+        const data: ZarrResponseData = await requestQuickCache({
           url: `${stacApiEndpointToUse}/collections/${stacCol}`,
           method: 'GET',
           controller
@@ -59,17 +72,22 @@ export function useZarr({ id, stacCol, stacApiEndpointToUse, date, onStatusChang
   return assetUrl;
 }
 
-
-
-export function useCMR({ id, stacCol, stacApiEndpointToUse, date, assetUrlReplacements, stacApiEndpoint, onStatusChange }){
+export function useCMR({
+  id,
+  stacCol,
+  stacApiEndpointToUse,
+  date,
+  assetUrlReplacements,
+  stacApiEndpoint,
+  onStatusChange
+}) {
   const [assetUrl, setAssetUrl] = useState('');
 
   const replaceInAssetUrl = (url: string, replacement: AssetUrlReplacement) => {
-    const {from, to } = replacement;
+    const { from, to } = replacement;
     const cmrAssetUrl = url.replace(from, to);
     return cmrAssetUrl;
   };
-
 
   useEffect(() => {
     const controller = new AbortController();
@@ -77,19 +95,25 @@ export function useCMR({ id, stacCol, stacApiEndpointToUse, date, assetUrlReplac
     async function load() {
       try {
         onStatusChange?.({ status: S_LOADING, id });
-        if (!assetUrlReplacements) throw (new Error('CMR  layer requires asset url remplacement attributes'));
+        if (!assetUrlReplacements)
+          throw new Error(
+            'CMR  layer requires asset url remplacement attributes'
+          );
 
         // Zarr collections in _VEDA_ should have a single entrypoint (zarr or virtual zarr / reference)
         // CMR endpoints will be using individual items' assets, so we query for the asset url
         const stacApiEndpointToUse = `${stacApiEndpoint}/search?collections=${stacCol}&datetime=${date?.toISOString()}`;
 
-        const data:CMRResponseData = await requestQuickCache({
+        const data: CMRResponseData = await requestQuickCache({
           url: stacApiEndpointToUse,
           method: 'GET',
           controller
         });
 
-        const assetUrl = replaceInAssetUrl(data.features[0].assets.data.href, assetUrlReplacements);
+        const assetUrl = replaceInAssetUrl(
+          data.features[0].assets.data.href,
+          assetUrlReplacements
+        );
         setAssetUrl(assetUrl);
         onStatusChange?.({ status: S_SUCCEEDED, id });
       } catch (error) {
@@ -106,8 +130,106 @@ export function useCMR({ id, stacCol, stacApiEndpointToUse, date, assetUrlReplac
     return () => {
       controller.abort();
     };
-  }, [id, stacCol, stacApiEndpointToUse, date, assetUrlReplacements, stacApiEndpoint, onStatusChange]);
+  }, [
+    id,
+    stacCol,
+    stacApiEndpointToUse,
+    date,
+    assetUrlReplacements,
+    stacApiEndpoint,
+    onStatusChange
+  ]);
 
   return assetUrl;
+}
 
+interface UseRequestStatusParams {
+  id: string;
+  onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
+  requestsToTrack: STATUS_KEY[];
+}
+
+export enum STATUS_KEY {
+  Global,
+  Layer,
+  StacSearch
+}
+
+/**
+ * A custom hook for tracking and managing request statuses across multiple contexts.
+ *
+ * This hook maintains a centralized state for tracking the status of multiple requests.
+ * This hook was created because  some layers needing multiple requests to load the layer
+ * ex. raster-timeseries require stac (low zoom markers, metadata) & mosaic (for raster data tiling)
+
+ * It provides a global status that aggregates individual
+ * context statuses based on priority rules.
+ *
+ * Status priority rules:
+ * - If any request has failed, global status is FAILED
+ * - If any request is loading, global status is LOADING
+ * - If any request is idle, global status is IDLE
+ * - If all requests succeeded, global status is SUCCEEDED
+ *
+ * @param {UseRequestStatusParams} params - Configuration parameters
+ * @param {string|number} params.id - layer id
+ * @param {Function} [params.onStatusChange] - Callback triggered when global status changes
+ * @param {string[]} [params.requestsToTrack=[]] - Array of request keys to track status for
+ *
+ * @returns {UseRequestStatusReturn} Object containing status management utilities
+ * @returns {Function} returns.changeStatus - Function to update a specific context's status
+ * @returns {Object.<string, string>} returns.statuses - Object containing current status values
+ *
+ */
+
+export function useRequestStatus({
+  id,
+  onStatusChange,
+  requestsToTrack = []
+}: UseRequestStatusParams) {
+  const initialStatuses = {
+    // Global flag to track all the requests
+    global: (requestsToTrack.length ? S_IDLE : S_SUCCEEDED) as ActionStatus,
+    ...requestsToTrack.reduce(
+      (acc, context) => ({
+        ...acc,
+        [context]: S_IDLE
+      }),
+      {}
+    )
+  };
+
+  const statuses = useRef(initialStatuses);
+
+  const changeStatus = useCallback(
+    ({ status, context }: { status: ActionStatus; context: STATUS_KEY }) => {
+      statuses.current[context] = status;
+      const layersToCheck = requestsToTrack.map(
+        (context) => statuses.current[context]
+      );
+
+      let newStatus = statuses.current.global;
+      // All layers must succeed to be considered successful.
+      if (layersToCheck.every((s) => s === S_SUCCEEDED)) {
+        newStatus = S_SUCCEEDED;
+      } else if (layersToCheck.some((s) => s === S_FAILED)) {
+        newStatus = S_FAILED;
+      } else if (layersToCheck.some((s) => s === S_LOADING)) {
+        newStatus = S_LOADING;
+      } else if (layersToCheck.some((s) => s === S_IDLE)) {
+        newStatus = S_IDLE;
+      }
+      // Only emit when layers statuses change
+      if (newStatus !== statuses.current[STATUS_KEY.Global]) {
+        statuses.current[STATUS_KEY.Global] = newStatus;
+        onStatusChange?.({ status: newStatus, id });
+      }
+    },
+    [id, onStatusChange, requestsToTrack]
+  );
+
+  return {
+    changeStatus,
+    statuses: statuses.current
+  };
 }

--- a/app/scripts/components/common/map/style-generators/points-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/points-layer.tsx
@@ -24,7 +24,7 @@ export default function PointsLayer(props: PointsLayerProps) {
   const { id, points, zoomExtent, onPointsClick } = props;
 
   const generatorParams = useGeneratorParams({
-    generatorOrder: 1000000,
+    generatorOrder: 1000000, // on top of any  layers
     hidden: false,
     opacity: 1
   });
@@ -38,6 +38,7 @@ export default function PointsLayer(props: PointsLayerProps) {
   useEffect(() => {
     let layers: LayerSpecification[] = [];
     let sources: Record<string, SourceSpecification> = {};
+
     const pointsSourceId = `${id}-points`;
     if (points && minZoom > 0) {
       const pointsSource: GeoJSONSourceSpecification = {
@@ -77,11 +78,10 @@ export default function PointsLayer(props: PointsLayerProps) {
       layers,
       params: generatorParams
     });
-  }, [points, minZoom, generatorParams]);
-
-  //
-  // Listen to mouse events on the markers layer
-  //
+    // generator params is byproduct of id
+    // the other dependencies are unlikely to change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, points, minZoom, generatorParams]);
 
   useLayerInteraction({
     layerId: `${id}-points`,

--- a/app/scripts/components/common/map/style-generators/points-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/points-layer.tsx
@@ -1,0 +1,92 @@
+import { useEffect } from 'react';
+import {
+  LayerSpecification,
+  SourceSpecification,
+  GeoJSONSourceSpecification,
+  SymbolLayerSpecification
+} from 'mapbox-gl';
+import { useTheme } from 'styled-components';
+import { featureCollection, point } from '@turf/helpers';
+import useMapStyle from '../hooks/use-map-style';
+
+import useLayerInteraction from '../hooks/use-layer-interaction';
+import { MARKER_LAYOUT } from '../hooks/use-custom-marker';
+import useGeneratorParams from '../hooks/use-generator-params';
+
+interface PointsLayerProps {
+  id: string;
+  points: any;
+  zoomExtent?: number[];
+  onPointsClick?: (feature: any) => void;
+}
+
+export default function PointsLayer(props: PointsLayerProps) {
+  const { id, points, zoomExtent, onPointsClick } = props;
+
+  const generatorParams = useGeneratorParams({
+    generatorOrder: 1000000,
+    hidden: false,
+    opacity: 1
+  });
+
+  const { updateStyle } = useMapStyle();
+  const minZoom = zoomExtent?.[0] ?? 0;
+  const generatorId = `points-${id}`;
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    let layers: LayerSpecification[] = [];
+    let sources: Record<string, SourceSpecification> = {};
+    const pointsSourceId = `${id}-points`;
+    if (points && minZoom > 0) {
+      const pointsSource: GeoJSONSourceSpecification = {
+        type: 'geojson',
+        data: featureCollection(
+          points.map((p) => point(p.center, { bounds: p.bounds }))
+        )
+      };
+
+      const pointsLayer: SymbolLayerSpecification = {
+        type: 'symbol',
+        id: pointsSourceId,
+        source: pointsSourceId,
+        layout: {
+          ...(MARKER_LAYOUT as any),
+          'icon-allow-overlap': true
+        },
+        paint: {
+          'icon-color': theme.color?.primary,
+          'icon-halo-color': theme.color?.base,
+          'icon-halo-width': 1
+        },
+        maxzoom: minZoom,
+        metadata: {
+          layerOrderPosition: 'markers'
+        }
+      };
+      sources = {
+        [pointsSourceId]: pointsSource as SourceSpecification
+      };
+      layers = [pointsLayer];
+    }
+
+    updateStyle({
+      generatorId,
+      sources,
+      layers,
+      params: generatorParams
+    });
+  }, [points, minZoom, generatorParams]);
+
+  //
+  // Listen to mouse events on the markers layer
+  //
+
+  useLayerInteraction({
+    layerId: `${id}-points`,
+    onClick: onPointsClick
+  });
+
+  return null;
+}

--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -5,7 +5,7 @@ import { RasterSourceSpecification, RasterLayerSpecification } from 'mapbox-gl';
 import { BaseGeneratorParams } from '../types';
 import useMapStyle from '../hooks/use-map-style';
 import useGeneratorParams from '../hooks/use-generator-params';
-import { STATUS_KEY } from './raster-timeseries';
+import { STATUS_KEY } from './hooks';
 
 import { ActionStatus, S_SUCCEEDED } from '$utils/status';
 

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -502,11 +502,13 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   useFitBbox(!!isPositionSet, bounds, layerBounds);
 
   return (
-    <PointsLayer
-      id={id}
-      points={points}
-      zoomExtent={zoomExtent}
-      onPointsClick={onPointsClick}
-    />
+    points && (
+      <PointsLayer
+        id={id}
+        points={points}
+        zoomExtent={zoomExtent}
+        onPointsClick={onPointsClick}
+      />
+    )
   );
 }

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -1,17 +1,20 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import qs from 'qs';
 import {
   LayerSpecification,
   SourceSpecification,
-  GeoJSONSourceSpecification,
   LngLatBoundsLike,
   RasterLayerSpecification,
-  RasterSourceSpecification,
-  SymbolLayerSpecification
+  RasterSourceSpecification
 } from 'mapbox-gl';
 import { useTheme } from 'styled-components';
-import { featureCollection, point } from '@turf/helpers';
 import { RasterTimeseriesProps, StacFeature } from '../types';
 import useMapStyle from '../hooks/use-map-style';
 import {
@@ -21,10 +24,10 @@ import {
   requestQuickCache
 } from '../utils';
 import useFitBbox from '../hooks/use-fit-bbox';
-import useLayerInteraction from '../hooks/use-layer-interaction';
-import { MARKER_LAYOUT } from '../hooks/use-custom-marker';
 import useMaps from '../hooks/use-maps';
 import useGeneratorParams from '../hooks/use-generator-params';
+
+import PointsLayer from './points-layer';
 
 import {
   ActionStatus,
@@ -502,40 +505,6 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
         }
       }
 
-      if (points && minZoom > 0) {
-        const pointsSourceId = `${id}-points`;
-        const pointsSource: GeoJSONSourceSpecification = {
-          type: 'geojson',
-          data: featureCollection(
-            points.map((p) => point(p.center, { bounds: p.bounds }))
-          )
-        };
-
-        const pointsLayer: SymbolLayerSpecification = {
-          type: 'symbol',
-          id: pointsSourceId,
-          source: pointsSourceId,
-          layout: {
-            ...(MARKER_LAYOUT as any),
-            'icon-allow-overlap': true
-          },
-          paint: {
-            'icon-color': theme.color?.primary,
-            'icon-halo-color': theme.color?.base,
-            'icon-halo-width': 1
-          },
-          maxzoom: minZoom,
-          metadata: {
-            layerOrderPosition: 'markers'
-          }
-        };
-        sources = {
-          ...sources,
-          [pointsSourceId]: pointsSource as SourceSpecification
-        };
-        layers = [...layers, pointsLayer];
-      }
-
       updateStyle({
         generatorId,
         sources,
@@ -599,10 +568,6 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     },
     [mapInstance]
   );
-  useLayerInteraction({
-    layerId: `${id}-points`,
-    onClick: onPointsClick
-  });
 
   //
   // FitBounds when needed
@@ -613,5 +578,12 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   );
   useFitBbox(!!isPositionSet, bounds, layerBounds);
 
-  return null;
+  return (
+    <PointsLayer
+      id={id}
+      points={points}
+      zoomExtent={zoomExtent}
+      onPointsClick={onPointsClick}
+    />
+  );
 }

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BaseTimeseriesProps } from '../types';
 import { useZarr } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useRequestStatus } from './raster-timeseries';
+import { useRequestStatus } from './hooks';
 
 export function ZarrTimeseries(props: BaseTimeseriesProps) {
   const {

--- a/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/zarr-timeseries.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BaseTimeseriesProps } from '../types';
 import { useZarr } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
-import { useLayerStatus } from './raster-timeseries';
+import { useRequestStatus } from './raster-timeseries';
 
 export function ZarrTimeseries(props: BaseTimeseriesProps) {
   const {
@@ -29,7 +29,7 @@ export function ZarrTimeseries(props: BaseTimeseriesProps) {
     datetime: date,
     ...sourceParams
   };
-  const { changeStatus } = useLayerStatus({
+  const { changeStatus } = useRequestStatus({
     id,
     onStatusChange,
     requestsToTrack: []


### PR DESCRIPTION
**Related Ticket:** #1545 

### Description of Changes
Separate the Marker Layer from the RasterTimeSeries. For more context: Raster Timeseries shows markers for the dataset that have minimum zoom set up higher than the current Zoom to indicate to users where the data is. (ex.[ NightLight data](https://deploy-preview-1595--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22nightlights-hd-monthly%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22inferno%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A255%7D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2022-02-28T15%3A00%3A00.000Z): ). This PR separates these Marker Layers so that RatserTimeSeries can eventually consist of RasterPaintLayer + MarkerLayer.  I believe the Marker Layer is uncoupled enough to be used outside of the RasterTimeSeries if needed.

- Move useRequestStatus (renamed from useLayerStatus) to the hooks file 
- did some lint cleaning 🧹 

### Validation / Testing
- RasterTimeseries data should work as before. (Whether it has marker layers or not.)
