### PR TITLE
fix: gas-tags-not-showing

### DIFF
--- a/app/scripts/components/stories/hub/hub-content.tsx
+++ b/app/scripts/components/stories/hub/hub-content.tsx
@@ -153,6 +153,7 @@ export default function HubContent(props: HubContentProps) {
           {displayStories.map((d) => {
             const pubDate = new Date(d.pubDate);
             const topics = getTaxonomy(d, TAXONOMY_TOPICS)?.values;
+            const gases = getTaxonomy(d, 'Gas')?.values; // Retrieve the Gas taxonomy
             return (
               <li key={d.id}>
                 <Card
@@ -219,6 +220,37 @@ export default function HubContent(props: HubContentProps) {
                                   disabled={search.length < 3}
                                 >
                                   {t.name}
+                                </TextHighlight>
+                              </Pill>
+                            </dd>
+                          ))}
+                        </CardTopicsList>
+                      ) : null}
+                      {gases?.length ? ( // Render Gas pills
+                        <CardTopicsList>
+                          <dt>Gas</dt>
+                          {gases.map((g) => (
+                            <dd key={g.id}>
+                              <Pill
+                                as={Link}
+                                to={`${storiesCatalogPath}?${
+                                  FilterActions.TAXONOMY
+                                }=${encodeURIComponent(
+                                  JSON.stringify({ Gas: g.id })
+                                )}`}
+                                onClick={() => {
+                                  onAction(FilterActions.TAXONOMY, {
+                                    key: 'Gas',
+                                    value: g.id
+                                  });
+                                  browseControlsHeaderRef.current?.scrollIntoView();
+                                }}
+                              >
+                                <TextHighlight
+                                  value={search}
+                                  disabled={search.length < 3}
+                                >
+                                  {g.name}
                                 </TextHighlight>
                               </Pill>
                             </dd>


### PR DESCRIPTION
**Related Ticket:** [NASA-IMPACT/veda-ui#1597](https://github.com/NASA-IMPACT/veda-ui/issues/1597)

### Description of Changes
This pull request resolves the issue where the "Gas" taxonomy pills (e.g., `CH₄`, `CO₂`) were not being rendered in the footer of story cards. The following changes were made:
- Updated the `HubContent` component to retrieve the "Gas" taxonomy using the `getTaxonomy` function.
- Added conditional rendering logic to display the "Gas" pills in the footer of each story card if the taxonomy values exist.
- Ensured that each gas pill links to a filtered view of stories based on the selected gas.

### Notes & Questions About Changes
- The `getTaxonomy` function was already available and used to retrieve taxonomy data for "Topics." It was reused to fetch the "Gas" taxonomy.
- The rendering logic for the "Gas" pills mirrors the existing logic for "Topics" pills, ensuring consistency in design and functionality.
- No additional styles were added, as the existing `CardTopicsList` and `Pill` components were sufficient for rendering the pills.

### Validation / Testing [Link : [deploy preview](https://deploy-preview-754--ghg-demo.netlify.app/stories?taxonomy=%7B%22Gas%22%3A%22ch%E2%82%84%22%7D)]
- Validate that the "Gas" pills (e.g., `CH₄`, `CO₂`) are displayed in the footer of story cards when the "Gas" taxonomy is present in the story metadata.
- Verify that clicking on a gas pill filters the stories by the selected gas and updates the URL query parameters accordingly.
- Ensure that the addition of "Gas" pills does not affect the rendering or functionality of "Topics" pills or other card elements.

