### PR TITLE
ci: adding update-version dispatch to next-veda-ui in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
           repositories: |
             veda-ui
             veda-config
+            next-veda-ui
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -55,6 +56,9 @@ jobs:
         run: yarn release  --ci --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set Version Variable
+        id: set-version
+        run: echo "VERSION=$(npm pkg get version)" >> $GITHUB_ENV
       - name: Publish package to NPM
         run: |
           yarn buildlib
@@ -68,6 +72,13 @@ jobs:
           repository: nasa-impact/veda-config
           event-type: update-version
           client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": "${{ steps.git-release.outputs.VERSION_NUMBER }}"}'
+      - name: Trigger version update in Template Instance
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{steps.generate-token.outputs.token}}
+          repository: nasa-impact/next-veda-ui
+          event-type: update-version
+          client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": ${{ env.VERSION }}}'
   notify:
     # If any of job fails
     if: failure() 


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1419
### Description of Changes
This adds PR adds the dispatch workflow to next-veda-ui to be able to bump the version of veda-ui.
This PR goes hand in hand with this [workflow](https://github.com/NASA-IMPACT/next-veda-ui/blob/main/.github/workflows/update-version.yml) in next-veda-ui which had been merged directly to `main` already for testing.

Successful runs/tests:


### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
