### PR TITLE
fix: Namespace custom style

### DIFF
--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -1,10 +1,6 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
 
 .veda-banner {
-  .usa-banner__button:after {
-    top: 3px;
-  }
-
   .banner--left-aligned {
     & .usa-banner__inner,
     & .usa-banner__content {

--- a/app/scripts/components/common/banner/banner.scss
+++ b/app/scripts/components/common/banner/banner.scss
@@ -1,12 +1,14 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
 
-.usa-banner__button:after {
-  top: 3px;
-}
+.veda-banner {
+  .usa-banner__button:after {
+    top: 3px;
+  }
 
-.banner--left-aligned {
-  & .usa-banner__inner,
-  & .usa-banner__content {
-    margin: 0;
+  .banner--left-aligned {
+    & .usa-banner__inner,
+    & .usa-banner__content {
+      margin: 0;
+    }
   }
 }

--- a/app/scripts/components/common/banner/index.tsx
+++ b/app/scripts/components/common/banner/index.tsx
@@ -107,36 +107,46 @@ export default function Banner({
   } as GuidanceContent;
 
   return (
-    <USWDSBanner
-      aria-label={ariaLabel ?? DEFAULT_HEADER_TEXT}
-      className={`${className} ${!uswdsHeaderActive && 'banner--left-aligned'}`}
-    >
-      <USWDSBannerHeader
-        isOpen={isOpen}
-        flagImg={
-          <USWDSBannerFlag
-            src={flagImgSrc ?? DEFAULT_FLAG_SRC}
-            alt={flagImgAlt ?? DEFAULT_FLAG_ALT}
-          />
-        }
-        headerText={headerText ?? DEFAULT_HEADER_TEXT}
-        headerActionText={headerActionText ?? DEFAULT_HEADER_ACTION_TEXT}
+    <div className='veda-banner'>
+      <USWDSBanner
+        aria-label={ariaLabel ?? DEFAULT_HEADER_TEXT}
+        className={`${className} ${
+          !uswdsHeaderActive && 'banner--left-aligned'
+        }`}
       >
-        <USWDSBannerButton
+        <USWDSBannerHeader
           isOpen={isOpen}
-          onClick={() => setIsOpen((prev) => !prev)}
-          aria-controls={contentId}
+          flagImg={
+            <USWDSBannerFlag
+              src={flagImgSrc ?? DEFAULT_FLAG_SRC}
+              alt={flagImgAlt ?? DEFAULT_FLAG_ALT}
+            />
+          }
+          headerText={headerText ?? DEFAULT_HEADER_TEXT}
+          headerActionText={headerActionText ?? DEFAULT_HEADER_ACTION_TEXT}
         >
-          {headerActionText ?? DEFAULT_HEADER_ACTION_TEXT}
-        </USWDSBannerButton>
-      </USWDSBannerHeader>
+          <USWDSBannerButton
+            isOpen={isOpen}
+            onClick={() => setIsOpen((prev) => !prev)}
+            aria-controls={contentId}
+          >
+            {headerActionText ?? DEFAULT_HEADER_ACTION_TEXT}
+          </USWDSBannerButton>
+        </USWDSBannerHeader>
 
-      <USWDSBannerContent id={contentId} isOpen={isOpen}>
-        <div className='grid-row grid-gap-6'>
-          <GuidanceBlock content={leftContent} className='tablet:grid-col-6' />
-          <GuidanceBlock content={rightContent} className='tablet:grid-col-6' />
-        </div>
-      </USWDSBannerContent>
-    </USWDSBanner>
+        <USWDSBannerContent id={contentId} isOpen={isOpen}>
+          <div className='grid-row grid-gap-6'>
+            <GuidanceBlock
+              content={leftContent}
+              className='tablet:grid-col-6'
+            />
+            <GuidanceBlock
+              content={rightContent}
+              className='tablet:grid-col-6'
+            />
+          </div>
+        </USWDSBannerContent>
+      </USWDSBanner>
+    </div>
   );
 }

--- a/app/scripts/components/common/form/checkable-filter/checkable-filter.scss
+++ b/app/scripts/components/common/form/checkable-filter/checkable-filter.scss
@@ -1,5 +1,6 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
-
-.usa-accordion__button {
-  height: themeVars.$veda-uswds-spacing-6;
+.veda {
+  .usa-accordion__button {
+    height: themeVars.$veda-uswds-spacing-6;
+  }
 }

--- a/app/scripts/components/common/form/checkable-filter/checkable-filter.scss
+++ b/app/scripts/components/common/form/checkable-filter/checkable-filter.scss
@@ -1,5 +1,5 @@
 @use '$styles/veda-ui-theme-vars.scss' as themeVars;
-.veda {
+.veda-filter {
   .usa-accordion__button {
     height: themeVars.$veda-uswds-spacing-6;
   }

--- a/app/scripts/components/common/form/checkable-filter/index.tsx
+++ b/app/scripts/components/common/form/checkable-filter/index.tsx
@@ -90,7 +90,7 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
         <div
           key={id}
           id='veda-checkbox-container'
-          className={`border-2px radius-md  margin-bottom-105 ${
+          className={`veda border-2px radius-md  margin-bottom-105 ${
             checked
               ? 'border-primary-light bg-primary-lighter'
               : 'border-base-light'

--- a/app/scripts/components/common/form/checkable-filter/index.tsx
+++ b/app/scripts/components/common/form/checkable-filter/index.tsx
@@ -90,7 +90,7 @@ export default function CheckableFilters(props: CheckableFiltersProps) {
         <div
           key={id}
           id='veda-checkbox-container'
-          className={`veda border-2px radius-md  margin-bottom-105 ${
+          className={`veda-filter border-2px radius-md  margin-bottom-105 ${
             checked
               ? 'border-primary-light bg-primary-lighter'
               : 'border-base-light'


### PR DESCRIPTION
**Related Ticket:** part of #1233 

Overwritten style of `.usa-accordion__button` is impacting other components of VEDA (ex. Banner). 
This should not have any visible impact on legacy instances. (Since legacy instances compile css per pages anyway.)