### PR TITLE
feat: Add props to control the visibility of the PageHero, NavWrapper and footer in the veda UI

### DIFF
--- a/app/scripts/components/common/layout-root/index.tsx
+++ b/app/scripts/components/common/layout-root/index.tsx
@@ -10,7 +10,6 @@ import { useDeepCompareEffect } from 'use-deep-compare';
 import styled from 'styled-components';
 import { Outlet } from 'react-router';
 import { reveal } from '@devseed-ui/animation';
-import { NavLink } from 'react-router-dom';
 import {
   getBannerFromVedaConfig,
   getCookieConsentFromVedaConfig,
@@ -81,7 +80,7 @@ function LayoutRoot(props: { children?: ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const { title, thumbnail, description, hideFooter } =
+  const { title, thumbnail, description, hideFooter, hideNav } =
     useContext(LayoutRootContext);
 
   const truncatedTitle =
@@ -99,15 +98,18 @@ function LayoutRoot(props: { children?: ReactNode }) {
       {siteAlertContent && (
         <SiteAlert appTitle={siteAlertContent.title} {...siteAlertContent} />
       )}
-      <NavWrapper
-        mainNavItems={mainNavItems}
-        subNavItems={subNavItems}
-        logo={
-          <Logo
-            linkProperties={{ LinkElement: Link, pathAttributeKeyName: 'to' }}
-          />
-        }
-      />
+      {!hideNav && (
+        <NavWrapper
+          mainNavItems={mainNavItems}
+          subNavItems={subNavItems}
+          logo={
+            <Logo
+              linkProperties={{ LinkElement: Link, pathAttributeKeyName: 'to' }}
+            />
+          }
+        />
+      )}
+
       <PageBody id={PAGE_BODY_ID} tabIndex={-1}>
         <Outlet />
         {children}

--- a/app/scripts/components/user-pages/index.tsx
+++ b/app/scripts/components/user-pages/index.tsx
@@ -11,18 +11,26 @@ import { resourceNotFound } from '$components/uhoh';
 
 function UserPages(props: { id: any }) {
   const page = getOverride(props.id);
-
   const params = useParams();
 
   if (!page) throw resourceNotFound();
 
+  const { hideHero, hideNav, hideFooter } = page.data;
+
   return (
     <PageMainContent>
-      <LayoutProps title={page.data.title} />
-      <PageHero
-        title={page.data.title || 'Page title is missing'}
+      <LayoutProps
+        title={page.data.title}
         description={page.data.description}
+        hideFooter={hideFooter}
+        hideNav={hideNav}
       />
+      {!hideHero && (
+        <PageHero
+          title={page.data.title || 'Page title is missing'}
+          description={page.data.description}
+        />
+      )}
       <ContentOverride with={props.id} {...params}>
         <FoldProse>
           <p>Content for this page comes from the relevant mdx file.</p>


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1674

### Description of Changes
Add support for hiding `NavWrapper`, `PageHero` and `PageFooter` via frontmatter flags (hideNav, hideHero, hideFooter) in custom user MDX pages.

This enables instance-level customization via veda-config.

Example usage in a custom page from the instance side: https://github.com/NASA-IMPACT/veda-config/pull/851/files#diff-c560b51533d557b1479e089ad4132b940cf5febeebc3bc24e39103efb5a7dd93R2


### Notes & Questions About Changes


### Validation / Testing

I've set up a custom page in veda-config to quickly test the new props:

1. Visit https://deploy-preview-851--visex.netlify.app/
2. Click on Exploration Tools in the nav bar -> Wildfire visualization
3. You should only see `Hello from the custom page!` text shown on the page, w/o any page hero, navbar or footer components being shown