### PR TITLE
fix: Pass optional disabled prop to useSlidingStickyHeader

### DIFF
--- a/app/scripts/components/common/layout-root/context.tsx
+++ b/app/scripts/components/common/layout-root/context.tsx
@@ -3,7 +3,7 @@ import React, {
   useState,
   Dispatch,
   SetStateAction,
-  ReactNode,
+  ReactNode
 } from 'react';
 import { useLocation } from 'react-router';
 import { useSlidingStickyHeader } from '$utils/use-sliding-sticky-header';
@@ -31,8 +31,9 @@ export function LayoutRootContextProvider({
   // Put the header size and visibility status in the context so that children
   // elements can access them for positioning purposes.
   const location = useLocation().pathname;
+  const hideNav = layoutProps.hideNav;
   const { isHeaderHidden, headerHeight, wrapperHeight } =
-    useSlidingStickyHeader(location);
+    useSlidingStickyHeader(location, hideNav);
 
   const ctx = {
     ...layoutProps,

--- a/app/scripts/utils/use-sliding-sticky-header.ts
+++ b/app/scripts/utils/use-sliding-sticky-header.ts
@@ -11,7 +11,10 @@ interface SlidingStickyHeaderResults {
   wrapperHeight: number;
 }
 
-export function useSlidingStickyHeader(pathname?: string): SlidingStickyHeaderResults {
+export function useSlidingStickyHeader(
+  pathname?: string,
+  disabled = false
+): SlidingStickyHeaderResults {
   const [isHidden, setHidden] = useState(false);
   const [headerHeight, setHeaderHeight] = useState(0);
   const [wrapperHeight, setWrapperHeight] = useState(0);
@@ -23,22 +26,24 @@ export function useSlidingStickyHeader(pathname?: string): SlidingStickyHeaderRe
   const prevPathname = usePreviousValue(pathname);
 
   useEffect(() => {
+    if (disabled) return;
+
     const pageChanged = prevPathname !== pathname;
     if (pageChanged) {
       setHidden(false);
       setHeaderHeight(0);
       setWrapperHeight(0);
     }
-  }, [pathname, prevPathname]);
+  }, [pathname, prevPathname, disabled]);
 
   useEffect(() => {
+    if (disabled || !navWrapperElement) return;
+
     let ticking = false;
     let prevY = window.scrollY;
     let scrollUpDelta = 0;
 
     // navWrapperElement should be mounted before the hook
-    if (!navWrapperElement) return;
-
     // When the element mounts the <Suspense> element is still in the DOM and
     // the page has display: none. The result is that any measurement of the
     // header would be 0. By using an IntersectionObserver we are able to get
@@ -48,7 +53,7 @@ export function useSlidingStickyHeader(pathname?: string): SlidingStickyHeaderRe
         observer.unobserve(navWrapperElement);
 
         // Initial height.
-        // Get the height of the header and he wrapper. Both are needed because in
+        // Get the height of the header and the wrapper. Both are needed because in
         // some pages the wrapper contains the local nav as well.
         const headerHeightQueried =
           document.querySelector<HTMLElement>(`#${HEADER_ID}`)?.offsetHeight ||
@@ -63,7 +68,7 @@ export function useSlidingStickyHeader(pathname?: string): SlidingStickyHeaderRe
     });
     observer.observe(navWrapperElement);
 
-    function tick(currY) {
+    function tick(currY: number) {
       const wrapperEl = document.querySelector<HTMLElement>(
         `#${HEADER_WRAPPER_ID}`
       );
@@ -140,7 +145,7 @@ export function useSlidingStickyHeader(pathname?: string): SlidingStickyHeaderRe
       window.removeEventListener('scroll', onViewportPositionChange);
       window.removeEventListener('resize', onViewportPositionChange);
     };
-  }, [navWrapperElement]);
+  }, [navWrapperElement, disabled]);
 
   return { isHeaderHidden: isHidden, headerHeight, wrapperHeight };
 }


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1688

### Description of Changes
Add a `disabled` boolean prop to the `useSlidingStickyHeader` hook to allow consumers to explicitly opt out of sticky header behavior (eg when `hideNav` is true). The `LayoutRootContextProvider` now passes `hideNav` to the hook to prevent unnecessary effects / measurements when the nav is intentionally hidden (otherwise the whole page would break when resizing the screen for example)

### Notes & Questions About Changes
I opted for this guard behavior inside the hook via a disabled flag because it seemed a simpler solution than conditionally using the hook. In the case of the latter, I think we'll violate the rules of hooks (that they shouldn't be called conditionally).

### Validation / Testing

You can confirm that no errors are thrown already using the veda-config preview deployment for the WildfireExplorer:

1. Go to https://deploy-preview-851--visex.netlify.app/
2. Click on "Exploration Tools" -> "Wildfire Visualization"
3. The page should render properly when you try to resize the screen