### PR TITLE
fix: nasa-impact/veda-config#865 handling of unexpected date format

### DIFF
--- a/app/scripts/components/common/map/utils.ts
+++ b/app/scripts/components/common/map/utils.ts
@@ -252,7 +252,11 @@ const dateFormats = {
 };
 
 export function formatSingleDate(date: Date, timeDensity?: TimeDensity) {
-  return format(date, dateFormats[timeDensity || 'day']);
+  const dFormat =
+    timeDensity && dateFormats[timeDensity]
+      ? dateFormats[timeDensity]
+      : dateFormats['day'];
+  return format(date, dFormat);
 }
 
 export function formatCompareDate(


### PR DESCRIPTION
**Related Ticket:** nasa-impact/veda-config#865

### Description of Changes
How we shim the default value for timeDensity, doesn't work when the returned value for timeDensity is incorrect. (In this case, timeDensity value was returned as `daily`, not `day`). This PR handles it. 

### Notes & Questions About Changes
The dataset still depends on the default fallback, while it has to use the correct value returned from the backend. The data needs to be ingested with the correct value for `dashboard:time_density` (day, instead of daily) 

### Validation / Testing
 PR to generate a preview: https://github.com/NASA-IMPACT/veda-config/pull/867
Preview link: https://deploy-preview-867--visex.netlify.app/data-catalog/GPM_3IMERGDF.v07