### PR TITLE
fix: conditional PointsLayer and RasterPaintLayer in JSX syntax not wrapped in {}

### DIFF
--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -335,38 +335,39 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
 
   return (
     <>
-      points && (
-      <PointsLayer
-        id={id}
-        points={points}
-        zoomExtent={zoomExtent}
-        onPointsClick={onPointsClick}
-      />
-      ) mosaicUrl && (
-      <RasterPaintLayer
-        id={id}
-        tileApiEndpoint={mosaicUrl}
-        tileParams={{ assets: ['cog_default'], ...sourceParams }}
-        zoomExtent={zoomExtent}
-        hidden={hidden}
-        opacity={opacity}
-        colorMap={colorMap}
-        generatorOrder={generatorOrder}
-        reScale={reScale}
-        generatorPrefix='raster-timeseries'
-        onStatusChange={changeStatus}
-        metadataFormatter={(tilejsonData, tileParamsAsString) => {
-          const wmtsBaseUrl = mosaicUrl?.replace(
-            'tilejson.json',
-            'WMTSCapabilities.xml'
-          );
-          return {
-            xyzTileUrl: tilejsonData?.tiles[0],
-            wmtsTileUrl: `${wmtsBaseUrl}?${tileParamsAsString}`
-          };
-        }}
-      />
-      )
+      {points && (
+        <PointsLayer
+          id={id}
+          points={points}
+          zoomExtent={zoomExtent}
+          onPointsClick={onPointsClick}
+        />
+      )}
+      {mosaicUrl && (
+        <RasterPaintLayer
+          id={id}
+          tileApiEndpoint={mosaicUrl}
+          tileParams={{ assets: ['cog_default'], ...sourceParams }}
+          zoomExtent={zoomExtent}
+          hidden={hidden}
+          opacity={opacity}
+          colorMap={colorMap}
+          generatorOrder={generatorOrder}
+          reScale={reScale}
+          generatorPrefix='raster-timeseries'
+          onStatusChange={changeStatus}
+          metadataFormatter={(tilejsonData, tileParamsAsString) => {
+            const wmtsBaseUrl = mosaicUrl.replace(
+              'tilejson.json',
+              'WMTSCapabilities.xml'
+            );
+            return {
+              xyzTileUrl: tilejsonData?.tiles[0],
+              wmtsTileUrl: `${wmtsBaseUrl}?${tileParamsAsString}`
+            };
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
**Related Ticket:** closes https://github.com/NASA-IMPACT/veda-ui/issues/1719

### Description of Changes

Fixes a JSX syntax issue in the RasterTimeseries component where conditional render logic for <PointsLayer> and <RasterPaintLayer> was not wrapped in curly braces.


### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

#### Before fix:

1. Visit: https://earth.gov/ghgcenter/exploration?search=&datasets=%5B%7B%22id%22%3A%22air-sea-co2%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%5D%2C%22colorMap%22%3A%22bwr%22%2C%22scale%22%3A%7B%22min%22%3A-0.0007%2C%22max%22%3A0.0007%7D%7D%7D%2C%7B%22id%22%3A%22total-ch4%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%5D%2C%22colorMap%22%3A%22purd%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A50%7D%7D%7D%5D&taxonomy=%7B%7D&date=2022-12-01T06%3A00%3A00.000Z
2. Zoom out the map
3. Notice there is code shown under the map

<img width="491" alt="Screenshot 2025-06-17 at 09 49 00" src="https://github.com/user-attachments/assets/52cc26a3-c8d9-48e2-89dd-1917995f2d03" />


#### After the fix:

1. Visit https://deploy-preview-795--ghg-demo.netlify.app/exploration?search=&datasets=%5B%7B%22id%22%3A%22air-sea-co2%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%5D%2C%22colorMap%22%3A%22bwr%22%2C%22scale%22%3A%7B%22min%22%3A-0.0007%2C%22max%22%3A0.0007%7D%7D%7D%2C%7B%22id%22%3A%22total-ch4%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%5D%2C%22colorMap%22%3A%22purd%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A50%7D%7D%7D%5D&taxonomy=%7B%7D&date=2021-11-30T23%3A00%3A00.000Z
2. Zoom out the map
3. Verify that the text doesn't appear