### PR TITLE
fix: enforce UTC timezone when running jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:scripts": "eslint app/scripts/",
     "lint:css": "stylelint 'app/styles/**/**' 'app/scripts/**/*.(js|ts|tsx|jsx)'",
     "ts-check": "yarn tsc --noEmit --skipLibCheck",
-    "test": "jest",
+    "test": "TZ=UTC jest",
     "pretest:e2e": "node test/playwright/generateTestData.js",
     "test:e2e": "yarn playwright test",
     "release": "release-it --",


### PR DESCRIPTION

When running `yarn test` locally on a machine with a timezone other than UTC, `data-utils.spec.ts` fails.

This change enforces running Jest tests in UTC, since the test dates are hardcoded in UTC.

How to test: Run `yarn test` locally with and without this change, the latter should fail.

Ready for review.
