### PR TITLE
ci: Send warning when release terminated with no commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,7 @@ jobs:
       - release
     steps:
       - name: Notify failure through Slack
+        if: needs.release.outputs.NO_COMMIT != 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -98,3 +99,16 @@ jobs:
                 text:
                   type: "mrkdwn"
                   text: "*VEDA UI Release failed*: Check action page to see the details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+      - name: Notify no commit through Slack
+        if: needs.release.outputs.NO_COMMIT == 'true'
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "*VEDA UI Release skipped*: "
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "VEDA UI release was skipped as there was no commit after the last release: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    outputs: 
+      no_commit: ${{ steps.git-release.outputs.NO_COMMIT }}
     steps:
       - name: Generate a token
         id: generate-token
@@ -87,7 +89,7 @@ jobs:
       - release
     steps:
       - name: Notify failure through Slack
-        if: needs.release.outputs.NO_COMMIT != 'true'
+        if: needs.release.outputs.no_commit != 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -100,7 +102,7 @@ jobs:
                   type: "mrkdwn"
                   text: "*VEDA UI Release failed*: Check action page to see the details: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
       - name: Notify no commit through Slack
-        if: needs.release.outputs.NO_COMMIT == 'true'
+        if: needs.release.outputs.no_commit == 'true'
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -111,4 +113,4 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "VEDA UI release was skipped as there was no commit after the last release: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  text: "VEDA UI release was skipped as there are no commits after the last release: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.release-it.js
+++ b/.release-it.js
@@ -32,8 +32,10 @@ function groupCommitsByCategory(logs) {
 }
 
 module.exports = {
-  hooks: !debug && {
-    'after:release': 'echo "VERSION_NUMBER=v${version}" >> "$GITHUB_OUTPUT" '
+  hooks: {
+    ...(!debug && {
+    "before:init": 'if [ "$(git log $(git describe --tags --abbrev=0)..HEAD)" = "" ]; then echo "NO_COMMIT=true" >> "$GITHUB_OUTPUT"; exit 1; fi;',
+    'after:release': 'echo "VERSION_NUMBER=v${version}" >> "$GITHUB_OUTPUT"'})
   },
   git: {
     release: debug ? false : true,
@@ -44,7 +46,7 @@ module.exports = {
     requireCleanWorkingDir: debug ? false : true,
     requireUpstream: debug ? false : true,
     requireCommits: true,
-    requireCommitsFail: true,
+    requireCommitsFail: false,
     changelog: 'git log --pretty=format:%s ${latestTag}...HEAD' // The output will be passed to releaseNotes context.changelog
   },
   npm: {

--- a/.release-it.js
+++ b/.release-it.js
@@ -44,6 +44,7 @@ module.exports = {
     requireCleanWorkingDir: debug ? false : true,
     requireUpstream: debug ? false : true,
     requireCommits: true,
+    requireCommitsFail: true,
     changelog: 'git log --pretty=format:%s ${latestTag}...HEAD' // The output will be passed to releaseNotes context.changelog
   },
   npm: {


### PR DESCRIPTION
**Related Ticket:** #1755 

### Description of Changes
There are two changes made in this PR. 

First is adding `requireCommitsFails` as false. This will make the process to be terminated with code 0 instead of 1 (no error).

 But I thought we still want to add some types of notification when release didn't happen because there was no commit. so I used init before:init hook to save a variable (NO_COMMIT) to be used in github action. 

### Notes & Questions About Changes

Related docs
Release-it git release docs: https://github.com/release-it/release-it/blob/main/docs/git.md
Release-it require commits guide:  https://github.com/release-it/release-it/blob/main/docs/recipes/require-commits.md

### Validation / Testing

It is a bit difficult to test action on local, but at least you can see the effect of `requireCommitsFails` with command `yarn release --debug`

<img width="659" height="423" alt="Screenshot 2025-07-24 at 11 21 12 AM" src="https://github.com/user-attachments/assets/94f276e6-5871-43a2-b7a7-cc93ce62f2f5" />

(Terminating process with code 0)

You can see the action sending no commit notification through Slack in this detail page: https://github.com/NASA-IMPACT/veda-ui/actions/runs/16503520378/job/46668244093


