### PR TITLE
feat: Draft support for multi layer/date selectors in the the MapBlock

### DIFF
--- a/mock/stories/air-quality-and-covid-19.stories.mdx
+++ b/mock/stories/air-quality-and-covid-19.stories.mdx
@@ -17,178 +17,32 @@ taxonomy:
       - Covid 19
 ---
 
-<ScrollytellingBlock>
-  <Chapter
-    center={[0, 0]}
-    zoom={2}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    ## Going through changes
-    When governments began implementing shutdowns at the start of the COVID-19 pandemic, scientists wondered how the atmosphere would respond to the sudden change in human behavior.
-  </Chapter>
-  <Chapter
-    center={[-83.0059, 34.3382]}
-    zoom={4.5}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2020-03-01'
-  >
-    With people largely confined to their homes to slow the spread of the novel coronavirus, scientists expected there were likely to be fewer cars, planes, and ships burning and emitting fossil fuels.
-  </Chapter>
-  <Chapter
-    center={[117.5001, 28.7899]}
-    zoom={4}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2020-03-01'
-  >
-    As the pandemic has progressed, these scenarios have largely played out: during the strictest lockdown periods, locations around the world experienced substantial reductions in transportation-related fossil fuel emissions. The impacts on specific air pollutants have been varied and dependent on their lifespan in the atmosphere.
-  </Chapter>
-  <Chapter
-    center={[6.7151, 47.3183]}
-    zoom={4}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2020-03-01'
-  >
-    Those pollutants with short lifespans, such as nitrogen dioxide (NO2), decreased dramatically and quickly along with emissions.
-  </Chapter>
-  <Chapter
-    center={[0, 0]}
-    zoom={2}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    Today, air quality levels are beginning to approach pre-pandemic levels, and scientists are just beginning to dive into the new measurements collected throughout this unprecedented time.
-  </Chapter>
-  <Chapter
-    center={[-74.0236, 40.7234]}
-    zoom={12}
-    showBaseMap={true}
-  >
-    ## What Makes Air Quality Good or Bad?
+<Block type='full'>
+  <Prose>
+    ## Test switchable layers from datasets
 
-    Cities are easy to spot from space. Choose any large, urban area around the world, and you’re likely to see similar things: dense population centers, complex webs of highways and, more often than not, smog.
-  </Chapter>
-  <Chapter
-    center={[116.2573785, 39.9387995]}
-    zoom={11}
-    showBaseMap={true}
-  >
-    Smog is the hazy curtain of air that often hangs over cities. It occurs when nitrogen dioxide produced from fossil fuel emissions from gasoline in cars or coal in powerplants chemically reacts with sunlight and other pollutants like carbon monoxide (CO). Thick smog is harmful to breathe and can significantly reduce visibility.
-  </Chapter>
-  <Chapter
-    center={[-118.2797798, 33.8236594]}
-    zoom={10}
-    showBaseMap={true}
-  >
-    During lockdowns, satellites observed sharp reductions in nitrogen dioxide emissions in cities around the world, and smog began to vanish. Skies were bluer, air was cleaner, and, in some places, views previously obscured by air pollution were suddenly revealed.
-  </Chapter>
-  <Chapter
-    center={[-118.2797798, 33.8236594]}
-    zoom={10}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    In Los Angeles, NASA scientists detected that nitrogen dioxide levels fell by more than 30% during the height of COVID-related shutdowns. Other large cities around the world experienced similar reductions.
-  </Chapter>
-  <Chapter
-    center={[119.7456, 36.3007]}
-    zoom={5.5}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    ## Cities Experiencing Clearer Air During Lockdowns
-
-    When Chinese authorities suspended travel and closed businesses in late January 2020 in response to the novel coronavirus, Beijing’s local nitrogen dioxide levels fell dramatically. In February 2020, concentrations fell by nearly 30% compared to the previous five-year average.
-  </Chapter>
-  <Chapter
-    center={[-77.0436, -12.0366]}
-    zoom={7.25}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    Cities across South America experienced similar declines in nitrogen dioxide. Lima, Peru had some of the most substantial reductions, with nitrogen dioxide levels falling approximately 70% below normal levels.
-  </Chapter>
-  <Chapter
-    center={[0, 0]}
-    zoom={2}
-    datasetId='no2'
-    layerId='no2-monthly-diff'
-    datetime='2021-03-01'
-  >
-    ## Like Flipping a Switch: Lockdowns and NO2
-
-    Nitrogen dioxide is only one component of air quality: sulfur dioxide (SO2), ozone (O3), formaldehyde (CH2O), and carbon monoxide, along with a host of other atmospheric constituents, also influence the quality of the air we breathe. The difference in nitrogen dioxide is that it has a relatively short lifetime in the atmosphere; once it’s emitted, it only lasts a few hours before it disappears.
-    
-    Therefore, once communities entered shutdowns, and people’s mobility was severely restricted, the effect on nitrogen dioxide concentrations was the equivalent of flipping a switch. That is not, however, the case with all air pollutants.
-  </Chapter>
-  <Chapter
-    center={[1.2918, 53.0754]}
-    zoom={3.25}
-    datasetId='no2'
-    layerId='no2-monthly'
-    datetime='2019-01-01'
-  >
-    ## Seasonal Changes in NO2
-
-    Even with the strong correlation between nitrogen dioxide and the combustion of fossil fuels, atmospheric concentrations of nitrogen dioxide naturally fluctuate throughout the year, and weather patterns also influence its concentrations.
-  </Chapter>
-  <Chapter
-    center={[1.2918, 53.0754]}
-    zoom={3.25}
-    datasetId='no2'
-    layerId='no2-monthly'
-    datetime='2019-06-01'
-  >
-    For example, nitrogen dioxide typically falls dramatically during spring and summer months, and rain and wind increase its dispersion, lowering local concentrations. During the COVID-19 pandemic, NASA scientists have been able to attribute the observed changes in nitrogen dioxide to changes in our behavior, and they have been careful to account for any impacts on air pollution that are the result of natural weather variations.
-  </Chapter>
-  <Chapter
-    center={[0, 0]}
-    zoom={2}
-    datasetId='no2'
-    layerId='no2-monthly'
-    datetime='2019-06-01'
-  >
-    ## Seeing Air Pollution from Space
-
-    NASA has used the [Ozone Monitoring Instrument (OMI)](https://aura.gsfc.nasa.gov/omi.html "Explore the OMI product") aboard the Aura satellite to observe global nitrogen dioxide levels since 2004. A joint endeavor between NASA, the Royal Netherlands Meteorological Institute (KNMI) and the Finnish Meteorological Institute (FMI), OMI's longer data record provides important context with which to compare any changes observed during the pandemic.
-    
-    NASA scientists are also leveraging other space-based instruments from international partners to study changes in nitrogen dioxide during the pandemic. These include the [TROPOspheric Monitoring Instrument (TROPOMI)](http://www.tropomi.eu/ "Explore the TROPOMI product") aboard the European Commission’s Copernicus Sentinel-5P satellite. Launched in 2016, TROPOMI provides higher resolution observations than OMI.
-  </Chapter>
-  <Chapter
-    center={[-117.9304, 33.7801]}
-    zoom={9}
-    datasetId='nighttime-lights'
-    layerId='nightlights-hd-monthly'
-    datetime='2020-02-01'
-  >
-    ## Reinforcing Measurements: Nighttime Lights
-
-    Changes in nighttime lights during the pandemic can also be tied to changes in nitrogen dioxide levels if the data are properly processed and interpreted. This is because nitrogen dioxide is primarily emitted from burning fossil fuels, and highways light up on nighttime satellite imagery when vehicles are present. 
-    
-    Here we see the illuminated web of highways connecting the Los Angeles metropolitan region.
-  
-    Researchers are using night light observations to track variations in energy use, migration, and transportation in response to social distancing and shutdown measures during the pandemic.
-  </Chapter>
-  <Chapter
-    center={[-117.9304, 33.7801]}
-    zoom={9}
-    datasetId='nighttime-lights'
-    layerId='nightlights-hd-monthly'
-    datetime='2020-02-01'
-  >
-    These data, collected by the [Visible Infrared Imaging Radiometer Suite (VIIRS)](https://www.jpss.noaa.gov/viirs.html "Explore the VIIRS product") instrument aboard the joint NASA-National Oceanic and Atmospheric Administration (NOAA) Suomi-National Polar-orbiting Partnership (NPP) satellite, correlate with changes seen in car traffic on the ground – and, therefore, nitrogen dioxide reductions.
-
-    While this research is still ongoing, the 31% reduction in nitrogen dioxide levels in Los Angeles during the height of pandemic-related lockdowns compared to recent years seems to correspond with a 15% reduction in nighttime lights over highways during the same period.
-  </Chapter>
-</ScrollytellingBlock>
+  </Prose>
+  <Figure>
+    <Map
+      datasetId='casagfed-carbonflux-monthgrid-v3'
+      layerId='casa-gfed-co2-flux'
+      center={[-120.5, 37.2]}
+      zoom={5.5}
+      dateTime='2017-10-31'
+      enableLayerSelector
+      enableDateSelector
+    />
+    <Map
+      datasetId='no2'
+      layerId='no2-monthly-2'
+      center={[120.11, 34.95]}
+      zoom={4.5}
+      dateTime='2020-02-01'
+      enableLayerSelector
+      enableDateSelector
+    />
+  </Figure>
+</Block>
 
 <Block type='full'>
   <Prose>
@@ -209,12 +63,12 @@ taxonomy:
       compareDateTime='2020-04-01'
       basemapId='dark'
     />
-    <Caption 
-      attrAuthor='NASA' 
+    <Caption
+      attrAuthor='NASA'
       attrUrl='https://nasa.gov/'
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    </Caption> 
+    </Caption>
     </div>
     </Widget>
   </Figure>
@@ -232,12 +86,12 @@ taxonomy:
       dateTime='2019-06-01'
       compareDateTime='2020-06-01'
     />
-    <Caption 
-      attrAuthor='NASA' 
+    <Caption
+      attrAuthor='NASA'
       attrUrl='https://nasa.gov/'
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    </Caption> 
+    </Caption>
     </div>
     </Widget>
   </Figure>
@@ -261,12 +115,12 @@ taxonomy:
       dateTime='2019-09-01'
       compareDateTime='2020-09-01'
     />
-    <Caption 
-      attrAuthor='NASA' 
+    <Caption
+      attrAuthor='NASA'
       attrUrl='https://nasa.gov/'
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    </Caption> 
+    </Caption>
     </div>
     </Widget>
   </Figure>
@@ -283,22 +137,22 @@ taxonomy:
       zoom={4.5}
       dateTime='2020-02-01'
     />
-    <Caption 
-      attrAuthor='NASA' 
+    <Caption
+      attrAuthor='NASA'
       attrUrl='https://nasa.gov/'
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    </Caption> 
+    </Caption>
     </div>
     </Widget>
   </Figure>
   <Prose>
     ## Seeing Rebounds in NO2
-  
+
     After the initial shock of COVID-related shutdowns in the spring, communities worldwide began to reopen and gradually increase mobility. Cars returned to the road, and travel restrictions slowly eased. These resumptions corresponded with relative increases in nitrogen dioxide levels and other air pollutants, as air quality levels began to return to pre-pandemic levels.
-    
+
     This demonstrates how quickly atmospheric nitrogen dioxide responds to reductions in emissions. They will persist as long as emissions persist and decline rapidly if emissions are reduced.
-    
-    NASA scientists will continue to monitor nitrogen dioxide levels and long-term trends around the world. NASA is expected to launch its [Tropospheric Emissions: Monitoring of Pollution (TEMPO)](http://tempo.si.edu/overview.html "Explore the TEMPO instrument") instrument in 2022, which will provide hourly, high-resolution measurements of nitrogen dioxide, ozone, and other air pollutants across North America, improving future air quality forecasts.    
+
+    NASA scientists will continue to monitor nitrogen dioxide levels and long-term trends around the world. NASA is expected to launch its [Tropospheric Emissions: Monitoring of Pollution (TEMPO)](http://tempo.si.edu/overview.html "Explore the TEMPO instrument") instrument in 2022, which will provide hourly, high-resolution measurements of nitrogen dioxide, ozone, and other air pollutants across North America, improving future air quality forecasts.
   </Prose>
 </Block>


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1777

### Description of Changes

This is a rough draft w/o styles to gather feedback on the approach of adding support for multi-layer selector and date selection for the MapBlock. The PR:

1. Adds layer picker for datasets with multiple layers that are fetched from STAC (disabled when compareDateTime is set)
2. Adds date selectior that dynamically adjusts to the `timeDensity` from STAC metadata
3. Disables new layer/date selectors when the MapBlock is in compare mode

See the first two map blocks here: https://deploy-preview-1781--veda-ui.netlify.app/stories/air-quality-and-covid-19

Notes / assumptions:

1. Only layers from the same dataset are shown in the layer selector
2. When in comparison mode, we don't need to show the new layer/date selectors
3. `timeDensity` of less than a day (e.g. '12h') is not currently supported by our calendar. To support half-day granularity, we’ll need to add an additional input below the calendar

Open questions:

1. Should we add an optional `excludeLayers` prop to allow content authors to hide specific layers?

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

See the first two map blocks here: https://deploy-preview-1781--veda-ui.netlify.app/stories/air-quality-and-covid-19
