### PR TITLE
fix: Pin down react compare image

### DIFF
--- a/package.json
+++ b/package.json
@@ -226,7 +226,7 @@
     "qs-state-hook": "^2.0.0",
     "react": "^18.2.0",
     "react-calendar": "^5.0.0",
-    "react-compare-image": "^3.1.0",
+    "react-compare-image": "~3.1.0",
     "react-cool-dimensions": "^2.0.7",
     "react-dom": "^18.2.0",
     "react-draggable": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13800,9 +13800,9 @@ react-calendar@^5.0.0:
     get-user-locale "^2.2.1"
     warning "^4.0.0"
 
-react-compare-image@^3.1.0:
+react-compare-image@~3.1.0:
   version "3.1.0"
-  resolved "http://verdaccio.ds.io:4873/react-compare-image/-/react-compare-image-3.1.0.tgz#effa6dda23fed0700d41f71b5158f75208b61aa7"
+  resolved "https://registry.npmjs.org/react-compare-image/-/react-compare-image-3.1.0.tgz#effa6dda23fed0700d41f71b5158f75208b61aa7"
   integrity sha512-47ISXkAx9KXA0rjgbQvaFK5AVbxVwP1XjTQEgsmMDN8bWpONVg/IoYmelRBdMs9gQICQCIw1se/cLENEBwHWlQ==
 
 react-cool-dimensions@^2.0.7:


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/next-veda-ui/issues/86

### Description of Changes
React Comare Image has a bug on v3.5.5 : https://github.com/tam315/react-compare-image/issues/122 . Pinning down the package version until it resolves. 

### Test
See how ComareImage component not working on Water Insight instance: https://deploy-preview-2--water-insight.netlify.app/stories/ogallala-aquifer.stories
Either link this package, or add pinned down version of react-compare-image to resolution . (https://github.com/NASA-IMPACT/next-veda-ui/issues/86#issuecomment-3132489452)

