### PR TITLE
feat: Set up sandbox page for custom map

### DIFF
--- a/app/scripts/components/sandbox/custom-map/index.tsx
+++ b/app/scripts/components/sandbox/custom-map/index.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Map, { MapControls } from '$components/common/map';
+import { Basemap } from '$components/common/map/style-generators/basemap';
+
+import {
+  NavigationControl,
+  ScaleControl
+} from '$components/common/map/controls';
+import MapCoordsControl from '$components/common/map/controls/coords';
+import { useBasemap } from '$components/common/map/controls/hooks/use-basemap';
+import { VedaUIProvider } from '$context/veda-ui-provider';
+
+const SandboxCustomMap: React.FC = () => {
+  const { mapBasemapId, labelsOption, boundariesOption } = useBasemap();
+  return (
+    <div>
+      <h2>Exploration Map</h2>
+      <p>This is the Exploration Map component.</p>
+      <div
+        style={{
+          height: '300px',
+          width: '100%',
+          position: 'relative'
+        }}
+      >
+        <VedaUIProvider
+          config={{
+            envMapboxToken: process.env.MAPBOX_TOKEN ?? '',
+            envApiStacEndpoint: process.env.API_STAC_ENDPOINT ?? '',
+            envApiRasterEndpoint: process.env.API_RASTER_ENDPOINT ?? '',
+            envApiCMREndpoint: process.env.API_CMR_ENDPOINT ?? ''
+          }}
+        >
+          <Map id='sandbox-map'>
+            <Basemap
+              basemapStyleId={mapBasemapId}
+              labelsOption={labelsOption}
+              boundariesOption={boundariesOption}
+            />
+            <MapControls>
+              <ScaleControl />
+              <MapCoordsControl />
+              <NavigationControl />
+              {/* Add any map controls you want here */}
+            </MapControls>
+          </Map>
+        </VedaUIProvider>
+      </div>
+    </div>
+  );
+};
+
+export default SandboxCustomMap;

--- a/app/scripts/components/sandbox/custom-map/index.tsx
+++ b/app/scripts/components/sandbox/custom-map/index.tsx
@@ -41,7 +41,6 @@ const SandboxCustomMap: React.FC = () => {
               <ScaleControl />
               <MapCoordsControl />
               <NavigationControl />
-              {/* Add any map controls you want here */}
             </MapControls>
           </Map>
         </VedaUIProvider>

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -22,6 +22,7 @@ import CustomLayer from './customlayer';
 import Pagination from './pagination';
 import Widgets from './widgets';
 import SandboxUswdsCards from './cards';
+import SandboxCustomMap from './custom-map';
 import {
   FullscreenWidget,
   FullpageModalWidget
@@ -127,6 +128,11 @@ const pages = [
     id: 'custom-layer',
     name: 'Custom Layer',
     component: CustomLayer
+  },
+  {
+    id: 'custom-map',
+    name: 'Custom Exploration Map',
+    component: SandboxCustomMap
   }
 ];
 


### PR DESCRIPTION
**Related Tickets:**

* #1793

This adds a sandbox page to showcase a custom map composed of individual map components, enabling customization of map controls and other behaviors.

@hanbyul-here It seems we can use this approach for the Water Insights tool. Is there a specific reason we need to use `ExplorationMap` directly? Our understanding (@AliceR and I) of #1793 was that we needed to decouple the AOI control from the map, but it looks like that's already the case with this approach.
