### PR TITLE
feat: create a MultiLayerMapBlock

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -113,10 +113,7 @@ interface MapBlockProps {
   projectionId?: ProjectionOptions['id'];
   projectionCenter?: ProjectionOptions['center'];
   projectionParallels?: ProjectionOptions['parallels'];
-  allowProjectionChange?: boolean;
   basemapId?: BasemapId;
-  datasetId?: string;
-  layerId?: string;
   onLayerDataUpdate?: (layerData: VizDatasetSuccess | null) => void;
   isMapMessageEnabled?: boolean;
   navigationControlPosition?:

--- a/app/scripts/components/common/blocks/lazy-components.js
+++ b/app/scripts/components/common/blocks/lazy-components.js
@@ -9,6 +9,7 @@ import Table, { tableHeight } from '$components/common/table';
 import CompareImage from '$components/common/blocks/images/compare';
 
 import Map, { mapHeight } from '$components/common/blocks/block-map';
+import MultiLayerMapBlock from '$components/common/blocks/multilayer-block-map';
 import Embed from '$components/common/blocks/embed';
 import {
   ScrollytellingBlock,
@@ -50,6 +51,18 @@ export function LazyMap(props) {
       once
     >
       <Map {...props} datasets={veda_faux_module_datasets} />
+    </LazyLoad>
+  );
+}
+
+export function LazyMultilayerMap(props) {
+  return (
+    <LazyLoad
+      placeholder={<LoadingSkeleton height={mapHeight} />}
+      offset={100}
+      once
+    >
+      <MultiLayerMapBlock {...props} datasets={veda_faux_module_datasets} />
     </LazyLoad>
   );
 }

--- a/app/scripts/components/common/blocks/lazy-components.js
+++ b/app/scripts/components/common/blocks/lazy-components.js
@@ -152,12 +152,22 @@ export function LazyMap({
   );
 }
 
-export function LazyMultilayerMap({ datasetId, layerId, ...otherProps }) {
-  const [selectedLayerId, setSelectedLayerId] = useState(layerId);
+export function LazyMultilayerMap({
+  datasetId,
+  defaultLayerId,
+  defaultDateTime,
+  ...otherProps
+}) {
+  const [selectedLayerId, setSelectedLayerId] = useState(defaultLayerId);
+  const [selectedDateTime, setSelectedDateTime] = useState(defaultDateTime);
 
   useEffect(() => {
-    setSelectedLayerId(layerId);
-  }, [layerId]);
+    setSelectedLayerId(defaultLayerId);
+  }, [defaultLayerId]);
+
+  useEffect(() => {
+    setSelectedDateTime(defaultDateTime);
+  }, [defaultDateTime]);
 
   const { baseDataLayer } = useMapLayers(
     datasetId,
@@ -175,6 +185,10 @@ export function LazyMultilayerMap({ datasetId, layerId, ...otherProps }) {
     setSelectedLayerId(newLayerId);
   };
 
+  const handleDateChange = (newDate) => {
+    setSelectedDateTime(newDate);
+  };
+
   return (
     <LazyLoad
       placeholder={<LoadingSkeleton height={mapHeight} />}
@@ -183,11 +197,12 @@ export function LazyMultilayerMap({ datasetId, layerId, ...otherProps }) {
     >
       <MultiLayerMapBlock
         {...otherProps}
-        datasetId={datasetId}
-        layerId={selectedLayerId}
+        selectedLayerId={selectedLayerId}
         baseDataLayer={baseDataLayer}
         availableLayers={availableLayers}
+        dateTime={selectedDateTime}
         onLayerChange={handleLayerChange}
+        onDateChange={handleDateChange}
       />
     </LazyLoad>
   );
@@ -195,7 +210,6 @@ export function LazyMultilayerMap({ datasetId, layerId, ...otherProps }) {
 
 export function LazyCompareImage(props) {
   return (
-    // We don't know the height of image, passing an arbitrary number (200) for placeholder height
     <LazyLoad placeholder={<LoadingSkeleton height={200} />} offset={50} once>
       <CompareImage {...props} />
     </LazyLoad>
@@ -239,5 +253,6 @@ LazyMap.propTypes = {
 
 LazyMultilayerMap.propTypes = {
   datasetId: T.string.isRequired,
-  layerId: T.string.isRequired
+  defaultLayerId: T.string.isRequired,
+  defaultDateTime: T.string
 };

--- a/app/scripts/components/common/blocks/multilayer-block-map.tsx
+++ b/app/scripts/components/common/blocks/multilayer-block-map.tsx
@@ -1,16 +1,17 @@
 import React, { useMemo, useState, useEffect } from 'react';
-import {
-  Icon,
-  Select,
-  TextInput,
-  InputSuffix,
-  InputGroup
-} from '@trussworks/react-uswds';
+
 import Calendar from 'react-calendar';
 import * as dateFns from 'date-fns';
 import type { Value } from 'react-calendar/dist/cjs/shared/types';
 import type { BasemapId } from '../map/controls/map-options/basemap';
 import MapBlock from './block-map';
+import {
+  USWDSIcon as Icon,
+  USWDSSelect as Select,
+  USWDSTextInput as TextInput,
+  USWDSInputSuffix as InputSuffix,
+  USWDSInputGroup as InputGroup
+} from '$uswds';
 import type { ProjectionOptions } from '$types/veda';
 import type { VizDatasetSuccess } from '$components/exploration/types.d.ts';
 import type { DatasetLayer } from '$types/veda';

--- a/app/scripts/components/common/blocks/multilayer-block-map.tsx
+++ b/app/scripts/components/common/blocks/multilayer-block-map.tsx
@@ -8,7 +8,6 @@ import {
 } from '@trussworks/react-uswds';
 import Calendar from 'react-calendar';
 import * as dateFns from 'date-fns';
-import type { PropsWithChildren } from 'react';
 import type { Value } from 'react-calendar/dist/cjs/shared/types';
 import type { BasemapId } from '../map/controls/map-options/basemap';
 import MapBlock from './block-map';
@@ -22,7 +21,7 @@ import './multilayer-map.scss';
 interface MultiLayerMapBlockProps {
   baseDataLayer?: VizDatasetSuccess | null;
   availableLayers?: DatasetLayer[];
-  layerId: string;
+  selectedLayerId: string;
   dateTime?: string;
   center?: [number, number];
   zoom?: number;
@@ -32,12 +31,13 @@ interface MultiLayerMapBlockProps {
   basemapId?: BasemapId;
   excludeLayers?: string[];
   onLayerChange?: (layerId: string) => void;
+  onDateChange?: (date: string) => void;
 }
 
 export default function MultiLayerMapBlock({
   baseDataLayer,
   availableLayers = [],
-  layerId,
+  selectedLayerId,
   dateTime,
   center,
   zoom,
@@ -46,21 +46,16 @@ export default function MultiLayerMapBlock({
   projectionParallels,
   basemapId,
   excludeLayers = [],
-  onLayerChange
-}: PropsWithChildren<MultiLayerMapBlockProps>) {
-  const [selectedLayerId, setSelectedLayerId] = useState(layerId);
+  onLayerChange,
+  onDateChange
+}: MultiLayerMapBlockProps) {
   const [selectedDate, setSelectedDate] = useState(dateTime);
   const [calendarDate, setCalendarDate] = useState(
     dateTime ? new Date(dateTime) : null
   );
   const [showCalendar, setShowCalendar] = useState(false);
-
   const [currentLayerData, setCurrentLayerData] =
     useState<VizDatasetSuccess | null>(baseDataLayer || null);
-
-  useEffect(() => {
-    setSelectedLayerId(layerId);
-  }, [layerId]);
 
   useEffect(() => {
     setSelectedDate(dateTime);
@@ -98,9 +93,13 @@ export default function MultiLayerMapBlock({
     }
 
     if (date && !isNaN(date.getTime())) {
+      const newDateString = dateFns.format(date, 'yyyy-MM-01');
       setCalendarDate(date);
-      setSelectedDate(dateFns.format(date, 'yyyy-MM-01'));
+      setSelectedDate(newDateString);
       setShowCalendar(false);
+      if (onDateChange) {
+        onDateChange(newDateString);
+      }
     }
   };
 
@@ -110,7 +109,6 @@ export default function MultiLayerMapBlock({
 
   const handleLayerSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const newLayerId = e.target.value;
-    setSelectedLayerId(newLayerId);
     if (onLayerChange) {
       onLayerChange(newLayerId);
     }

--- a/app/scripts/components/common/blocks/multilayer-block-map.tsx
+++ b/app/scripts/components/common/blocks/multilayer-block-map.tsx
@@ -1,0 +1,192 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  Icon,
+  Select,
+  TextInput,
+  InputSuffix,
+  InputGroup
+} from '@trussworks/react-uswds';
+import Calendar from 'react-calendar';
+import * as dateFns from 'date-fns';
+import type { PropsWithChildren } from 'react';
+import type { Value } from 'react-calendar/dist/cjs/shared/types';
+import type { BasemapId } from '../map/controls/map-options/basemap';
+import MapBlock from './block-map';
+import type { VedaData, DatasetData, ProjectionOptions } from '$types/veda';
+import type { VizDatasetSuccess } from '$components/exploration/types.d.ts';
+
+import 'react-calendar/dist/Calendar.css';
+import './multilayer-map.scss';
+
+export default function MultiLayerMapBlock({
+  datasets,
+  datasetId,
+  layerId,
+  dateTime,
+  center,
+  zoom,
+  projectionId,
+  projectionCenter,
+  projectionParallels,
+  basemapId,
+  excludeLayers = []
+}: PropsWithChildren<{
+  datasets: VedaData<DatasetData>;
+  datasetId: string;
+  layerId: string;
+  dateTime?: string;
+  center?: [number, number];
+  zoom?: number;
+  projectionId?: ProjectionOptions['id'];
+  projectionCenter?: ProjectionOptions['center'];
+  projectionParallels?: ProjectionOptions['parallels'];
+  basemapId?: BasemapId;
+  excludeLayers?: string[];
+}>) {
+  const [selectedLayerId, setSelectedLayerId] = useState(layerId);
+  const [selectedDate, setSelectedDate] = useState(dateTime);
+  const [calendarDate, setCalendarDate] = useState(
+    dateTime ? new Date(dateTime) : null
+  );
+  const [showCalendar, setShowCalendar] = useState(false);
+
+  const [currentLayerData, setCurrentLayerData] =
+    useState<VizDatasetSuccess | null>(null);
+
+  useEffect(() => {
+    setSelectedLayerId(layerId);
+  }, [layerId]);
+
+  useEffect(() => {
+    setSelectedDate(dateTime);
+    setCalendarDate(dateTime ? new Date(dateTime) : null);
+  }, [dateTime]);
+
+  const availableLayers = useMemo(() => {
+    return (
+      datasets[datasetId]?.data.layers?.filter(
+        (layer) => !excludeLayers.includes(layer.id)
+      ) ?? []
+    );
+  }, [datasets, datasetId, excludeLayers]);
+
+  const dateDomain = useMemo(() => {
+    return currentLayerData?.data.domain ?? [];
+  }, [currentLayerData]);
+
+  const maxDetail = useMemo(() => {
+    const td = currentLayerData?.data.timeDensity;
+    if (td === 'year') return 'year';
+    if (td === 'month') return 'year';
+    return 'month';
+  }, [currentLayerData]);
+
+  const handleDateChange = (value: Value) => {
+    if (!value) return;
+
+    let date: Date | null = null;
+
+    if (value instanceof Date) {
+      date = value;
+    } else if (Array.isArray(value) && value[0] instanceof Date) {
+      date = value[0];
+    }
+
+    if (date && !isNaN(date.getTime())) {
+      setCalendarDate(date);
+      setSelectedDate(dateFns.format(date, 'yyyy-MM-01'));
+      setShowCalendar(false);
+    }
+  };
+
+  const handleLayerDataUpdate = (layerData: VizDatasetSuccess | null) => {
+    setCurrentLayerData(layerData);
+  };
+
+  return (
+    <div className='multilayer-map position-relative'>
+      <MapBlock
+        datasets={datasets}
+        datasetId={datasetId}
+        layerId={selectedLayerId}
+        dateTime={selectedDate}
+        center={center}
+        zoom={zoom}
+        projectionId={projectionId}
+        projectionCenter={projectionCenter}
+        projectionParallels={projectionParallels}
+        basemapId={basemapId}
+        onLayerDataUpdate={handleLayerDataUpdate}
+        isMapMessageEnabled={false}
+      />
+
+      <div className='position-absolute top-3 left-3 z-200 radius-md shadow-lg'>
+        <div className='grid-row grid-gap-1'>
+          {availableLayers.length > 1 && (
+            <div>
+              <Select
+                id='layer-select'
+                name='layer-select'
+                className='truncate-select padding-1 padding-right-3 margin-top-0'
+                value={selectedLayerId}
+                onChange={(e) => setSelectedLayerId(e.target.value)}
+              >
+                {availableLayers.map((layer) => (
+                  <option
+                    key={layer.id}
+                    value={layer.id}
+                    title={layer.name || layer.id}
+                  >
+                    {layer.name || layer.id}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          )}
+
+          {dateDomain.length > 0 && (
+            <div className='position-relative'>
+              <InputGroup className='margin-top-0'>
+                <TextInput
+                  id='date-picker'
+                  name='date-picker'
+                  readOnly
+                  type='text'
+                  className='padding-1 cursor-pointer margin-top-0'
+                  value={
+                    calendarDate
+                      ? dateFns.format(calendarDate, 'yyyy-MM-dd')
+                      : ''
+                  }
+                  onClick={() => setShowCalendar(!showCalendar)}
+                />
+                <InputSuffix
+                  className='display-flex'
+                  style={{ pointerEvents: 'none' }}
+                >
+                  <Icon.CalendarToday />
+                </InputSuffix>
+              </InputGroup>
+              {showCalendar && (
+                <div className='position-absolute top-100 left-0 margin-top-1 z-300'>
+                  <Calendar
+                    onChange={handleDateChange}
+                    value={calendarDate}
+                    minDate={new Date(dateDomain[0])}
+                    maxDate={new Date(dateDomain[dateDomain.length - 1])}
+                    maxDetail={maxDetail}
+                    selectRange={false}
+                    nextLabel={<Icon.NavigateNext />}
+                    prevLabel={<Icon.NavigateBefore />}
+                    next2Label={<Icon.NavigateFarNext />}
+                    prev2Label={<Icon.NavigateFarBefore />}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/scripts/components/common/blocks/multilayer-map.scss
+++ b/app/scripts/components/common/blocks/multilayer-map.scss
@@ -1,8 +1,3 @@
-.multilayer-map .mapboxgl-ctrl-top-left {
-    top: 42px;
-    left: -8px;
-}
-
 .truncate-select {
   max-width: 30ch;
   text-overflow: ellipsis;

--- a/app/scripts/components/common/blocks/multilayer-map.scss
+++ b/app/scripts/components/common/blocks/multilayer-map.scss
@@ -1,0 +1,11 @@
+.multilayer-map .mapboxgl-ctrl-top-left {
+    top: 42px;
+    left: -8px;
+}
+
+.truncate-select {
+  max-width: 30ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}

--- a/app/scripts/components/common/mdx-content.js
+++ b/app/scripts/components/common/mdx-content.js
@@ -15,6 +15,7 @@ import {
   LazyCompareImage,
   LazyScrollyTelling,
   LazyMap,
+  LazyMultilayerMap,
   LazyTable,
   LazyEmbed
 } from '$components/common/blocks/lazy-components';
@@ -40,6 +41,7 @@ function MdxContent(props) {
           Chapter,
           Image,
           Map: LazyMap,
+          MultilayerMap: LazyMultilayerMap,
           ScrollytellingBlock: LazyScrollyTelling,
           Chart: LazyChart,
           CompareImage: LazyCompareImage,

--- a/app/scripts/components/sandbox/customlayer/index.tsx
+++ b/app/scripts/components/sandbox/customlayer/index.tsx
@@ -145,10 +145,12 @@ export default function CustomLayerDemo() {
   const [info, setInfo] = useState('');
 
   const { baseDataLayer, compareDataLayer: derivedCompare } = useMapLayers(
+    'no2',
     'no2-monthly',
     veda_faux_module_datasets,
     true
   );
+
   const compareDataLayer = derivedCompare;
 
   return (

--- a/app/scripts/components/sandbox/customlayer/index.tsx
+++ b/app/scripts/components/sandbox/customlayer/index.tsx
@@ -150,7 +150,6 @@ export default function CustomLayerDemo() {
             <BlockMap
               datasetId='no2'
               layerId='no2-monthly'
-              datasets={veda_faux_module_datasets}
               center={[111.383, 42.465]}
               zoom={4}
               dateTime='2019-06-01'

--- a/app/scripts/components/sandbox/customlayer/index.tsx
+++ b/app/scripts/components/sandbox/customlayer/index.tsx
@@ -15,6 +15,7 @@ import useMapStyle from '$components/common/map/hooks/use-map-style';
 import useMaps from '$components/common/map/hooks/use-maps';
 import useGeneratorParams from '$components/common/map/hooks/use-generator-params';
 import useLayerInteraction from '$components/common/map/hooks/use-layer-interaction';
+import { useMapLayers } from '$components/common/blocks/lazy-components';
 
 export function GeoJSONLayer(props) {
   const { id, geojsonURL, onClick } = props;
@@ -142,14 +143,22 @@ export function GeoJSONLayer(props) {
 
 export default function CustomLayerDemo() {
   const [info, setInfo] = useState('');
+
+  const { baseDataLayer, compareDataLayer: derivedCompare } = useMapLayers(
+    'no2-monthly',
+    veda_faux_module_datasets,
+    true
+  );
+  const compareDataLayer = derivedCompare;
+
   return (
     <GridContainer>
       <Grid row gap={3}>
         <Grid col={12} className='margin-top-2 margin-bottom-3'>
           <div style={{ width: '800px' }}>
             <BlockMap
-              datasetId='no2'
-              layerId='no2-monthly'
+              baseDataLayer={baseDataLayer}
+              compareDataLayer={compareDataLayer}
               center={[111.383, 42.465]}
               zoom={4}
               dateTime='2019-06-01'

--- a/app/scripts/components/sandbox/legacy/map-block/index.js
+++ b/app/scripts/components/sandbox/legacy/map-block/index.js
@@ -25,8 +25,6 @@ function SandboxMapBlock() {
             dateTime='2020-03-01'
             compareDateTime='2018-03-01'
             projectionId='equirectangular'
-            allowProjectionChange
-            isComparing={true}
           />
         </Wrapper>
       </Constrainer>

--- a/app/scripts/components/sandbox/legacy/mdx-editor/index.tsx
+++ b/app/scripts/components/sandbox/legacy/mdx-editor/index.tsx
@@ -7,9 +7,14 @@ import { ContentBlockProse } from '$styles/content-block';
 import Image, { Caption } from '$components/common/blocks/images';
 import { Chapter } from '$components/common/blocks/scrollytelling/chapter';
 import { NotebookConnectCalloutBlock } from '$components/common/notebook-connect';
-import { LazyMap, LazyScrollyTelling, LazyChart, LazyCompareImage} from '$components/common/blocks/lazy-components';
+import {
+  LazyMap,
+  LazyMultilayerMap,
+  LazyScrollyTelling,
+  LazyChart,
+  LazyCompareImage
+} from '$components/common/blocks/lazy-components';
 import SmartLink from '$components/common/smart-link';
-
 
 const components = {
   h1: (props) => <h1 style={{ color: 'tomato' }} {...props} />,
@@ -21,6 +26,7 @@ const components = {
   Chapter,
   Image,
   Map: LazyMap,
+  MultilayerMap: LazyMultilayerMap,
   ScrollytellingBlock: LazyScrollyTelling,
   Chart: LazyChart,
   CompareImage: LazyCompareImage,
@@ -28,7 +34,7 @@ const components = {
   Link: SmartLink
 };
 
-export const MDX_LOCAL_STORAGE_KEY = "MDX_EDITOR";
+export const MDX_LOCAL_STORAGE_KEY = 'MDX_EDITOR';
 export const MDX_SOURCE_DEFAULT = `<Block>
   <Prose>
     ### Your markdown header
@@ -46,22 +52,22 @@ export const MDX_SOURCE_DEFAULT = `<Block>
       dateTime='2020-02-01'
       compareDateTime='2022-02-01'
     />
-    <Caption 
-      attrAuthor='NASA' 
+    <Caption
+      attrAuthor='NASA'
       attrUrl='https://nasa.gov/'
     >
       Levels in 10¹⁵ molecules cm⁻². Darker colors indicate higher nitrogen dioxide (NO₂) levels associated and more activity. Lighter colors indicate lower levels of NO₂ and less activity.
-    </Caption> 
+    </Caption>
   </Figure>
   <Prose>
     ## Seeing Rebounds in NO2
-  
+
     After the initial shock of COVID-related shutdowns in the spring, communities worldwide began to reopen and gradually increase mobility. Cars returned to the road, and travel restrictions slowly eased. These resumptions corresponded with relative increases in nitrogen dioxide levels and other air pollutants, as air quality levels began to return to pre-pandemic levels.
-    
+
     This demonstrates how quickly atmospheric nitrogen dioxide responds to reductions in emissions. They will persist as long as emissions persist and decline rapidly if emissions are reduced.
-    
+
     NASA scientists will continue to monitor nitrogen dioxide levels and long-term trends around the world. NASA is expected to launch its [Tropospheric Emissions: Monitoring of Pollution (TEMPO)](http://tempo.si.edu/overview.html "Explore the TEMPO instrument") instrument in 2022, which will provide hourly, high-resolution measurements of nitrogen dioxide, ozone, and other air pollutants across North America, improving future air quality forecasts.
-    
+
     [Explore How COVID-19 Is Affecting Earth's Climate](/covid19/stories/climate/climate-change-and-covid "Explore How COVID-19 Is Affecting Earth's Climate")
   </Prose>
 </Block>
@@ -74,7 +80,10 @@ export default function MDXEditorWrapper() {
   return (
     <PageMainContent>
       <article>
-        <MDXEditor initialSource={savedSource ?? MDX_SOURCE_DEFAULT} components={components} />
+        <MDXEditor
+          initialSource={savedSource ?? MDX_SOURCE_DEFAULT}
+          components={components}
+        />
       </article>
     </PageMainContent>
   );

--- a/app/scripts/components/sandbox/legacy/mdx-page/page.mdx
+++ b/app/scripts/components/sandbox/legacy/mdx-page/page.mdx
@@ -8,7 +8,6 @@
       datasetId='no2'
       layerId='no2-monthly'
       dateTime='2018-03-01'
-      isComparing={true}
       compareLabel='Overriding label'
       projectionId='globe'
     />
@@ -26,8 +25,6 @@
       dateTime='2020-03-01'
       compareDateTime='2018-03-01'
       projectionId='equirectangular'
-      allowProjectionChange
-      isComparing={true}
     />
     <Caption>Comparing dates set manually</Caption>
   </Figure>
@@ -42,8 +39,6 @@
       compareDateTime='2018-03-01'
       compareLabel='overriding compare label'
       projectionId='equirectangular'
-      allowProjectionChange
-      isComparing={true}
     />
     <Caption>Comparing dates set manually</Caption>
   </Figure>
@@ -221,18 +216,18 @@ per conubia nostra, per inceptos himenaeos.
 <Prose>
 ## CB Prose Beta
 
-<Image 
-  src="http://via.placeholder.com/1256x328?text=align-left" 
-  align="left" 
-  alt="Media example"   
-  attr="tux" 
+<Image
+  src="http://via.placeholder.com/1256x328?text=align-left"
+  align="left"
+  alt="Media example"
+  attr="tux"
   attrAuthor="penguin"
   attrUrl="https://linux.org"
 />
-<Image src="http://via.placeholder.com/1256x328?text=align-left" 
-  align="left" 
-  alt="Media example"   
-  attr="tux" 
+<Image src="http://via.placeholder.com/1256x328?text=align-left"
+  align="left"
+  alt="Media example"
+  attr="tux"
   attrAuthor="penguin"
   attrUrl="https://linux.org"
 />
@@ -280,7 +275,7 @@ per conubia nostra, per inceptos himenaeos.
 <Block>
 <Prose>
 ## CB Prose+Figure Alpha
-          
+
 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum
 vel tristique sapien, non suscipit lacus. Mauris vestibulum bibendum
 sem eget pellentesque. Cras viverra urna felis, non placerat felis
@@ -302,10 +297,10 @@ felis vel nisi lobortis, quis blandit mauris accumsan.
     src='https://picsum.photos/id/1002/2048/1620'
     alt='Generic placeholder by lorem picsum'
     />
-    <Caption 
-      attrAuthor='somebody' 
+    <Caption
+      attrAuthor='somebody'
       attrUrl='https://developmentseed.org'
-    /> 
+    />
   </Figure>
 </Block>
 
@@ -315,10 +310,10 @@ felis vel nisi lobortis, quis blandit mauris accumsan.
     src='https://picsum.photos/id/1002/2048/1620'
     alt='Generic placeholder by lorem picsum'
     />
-    <Caption 
-      attrAuthor='somebody' 
+    <Caption
+      attrAuthor='somebody'
       attrUrl='https://developmentseed.org'
-    /> 
+    />
   </Figure>
   <Prose>
   ## CB Prose+Figure Beta
@@ -367,10 +362,10 @@ felis vel nisi lobortis, quis blandit mauris accumsan.
     src='https://picsum.photos/id/1002/2048/1620'
     alt='Generic placeholder by lorem picsum'
     />
-    <Caption 
-      attrAuthor='somebody' 
+    <Caption
+      attrAuthor='somebody'
       attrUrl='https://developmentseed.org'
-    /> 
+    />
   </Figure>
 </Block>
 
@@ -381,10 +376,10 @@ felis vel nisi lobortis, quis blandit mauris accumsan.
     src='https://picsum.photos/id/1002/2048/1620'
     alt='Generic placeholder by lorem picsum'
     />
-    <Caption 
-      attrAuthor='somebody' 
+    <Caption
+      attrAuthor='somebody'
       attrUrl='https://developmentseed.org'
-    /> 
+    />
   </Figure>
 <Prose>
 ## CB Prose+Figure Delta

--- a/app/scripts/libs/index.ts
+++ b/app/scripts/libs/index.ts
@@ -38,6 +38,7 @@ export {
   Block,
   Image,
   MapBlock,
+  MultilayerMapBlock,
   ScrollytellingBlock,
   Figure,
   Prose,

--- a/app/scripts/libs/mdx-components.ts
+++ b/app/scripts/libs/mdx-components.ts
@@ -1,5 +1,6 @@
 export { default as Block } from '$components/common/blocks';
 export { default as MapBlock } from '$components/common/blocks/block-map';
+export { default as MultilayerMapBlock } from '$components/common/blocks/multilayer-block-map';
 export { default as Chart } from '$components/common/chart/block';
 export { default as Table } from '$components/common/table';
 export { default as Embed } from '$components/common/blocks/embed';

--- a/app/scripts/uswds/index.tsx
+++ b/app/scripts/uswds/index.tsx
@@ -32,7 +32,12 @@ export {
 export { USWDSGridContainer, USWDSGrid } from './grid';
 export { USWDSHeader, USWDSHeaderTitle } from './header';
 export { USWDSIcon } from './icon';
-export { USWDSTextInput, USWDSTextInputMask } from './input';
+export {
+  USWDSTextInput,
+  USWDSTextInputMask,
+  USWDSInputSuffix,
+  USWDSInputGroup
+} from './input';
 export { USWDSLink } from './link';
 export { USWDSMenu } from './menu';
 export { USWDSNavMenuButton } from './nav-menu-button';
@@ -41,3 +46,4 @@ export { USWDSPagination } from './pagination';
 export { USWDSSiteAlert } from './site-alert';
 export { USWDSSearch } from './search';
 export { USWDSTag } from './tag';
+export { USWDSSelect } from './select';

--- a/app/scripts/uswds/input.tsx
+++ b/app/scripts/uswds/input.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { TextInput, TextInputMask } from '@trussworks/react-uswds';
+import {
+  TextInput,
+  TextInputMask,
+  InputSuffix,
+  InputGroup
+} from '@trussworks/react-uswds';
 
 export function USWDSTextInput(props) {
   return <TextInput {...props} />;
@@ -7,4 +12,12 @@ export function USWDSTextInput(props) {
 
 export function USWDSTextInputMask(props) {
   return <TextInputMask {...props} />;
+}
+
+export function USWDSInputSuffix(props) {
+  return <InputSuffix {...props} />;
+}
+
+export function USWDSInputGroup(props) {
+  return <InputGroup {...props} />;
 }

--- a/app/scripts/uswds/select.tsx
+++ b/app/scripts/uswds/select.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Select } from '@trussworks/react-uswds';
+
+export function USWDSSelect(props) {
+  return <Select {...props} />;
+}

--- a/docs/content/MDX_BLOCKS.md
+++ b/docs/content/MDX_BLOCKS.md
@@ -29,12 +29,12 @@ Understanding of MDX is not required to write contents for Veda dashboard, but y
 <tr>
 <td>
 
-![How blocks look on story page](./media/prose-figure.jpg)   
+![How blocks look on story page](./media/prose-figure.jpg)
  </td>
- <td > 
- 
- ![blocks with each layout name labeled.](./media/prose-figure-w-quotation.jpg)   
-  </td> 
+ <td >
+
+ ![blocks with each layout name labeled.](./media/prose-figure-w-quotation.jpg)
+  </td>
 </tr>
 </table>
 
@@ -51,7 +51,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 </tr>
 <tr>
   <td> Default Prose Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block>
@@ -61,17 +61,17 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
       Your markdown contents comes here.
     </Prose>
   </Block>
-  ```  
-  </td> 
-  <td>  
+  ```
+  </td>
+  <td>
 
-  ![Screenshot of Default Prose Block](./media/block-default-prose.jpg)   
+  ![Screenshot of Default Prose Block](./media/block-default-prose.jpg)
   </td>
 </tr>
 
 <tr>
   <td> Wide Prose Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block type='wide'>
@@ -81,9 +81,9 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
       Your markdown contents comes here.
     </Prose>
   </Block>
-  ```  
-  </td> 
-  <td>  
+  ```
+  </td>
+  <td>
 
   ![Screenshot of Wide Prose Block](./media/block-wide-prose.jpg)
   </td>
@@ -91,7 +91,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Wide Figure Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block type='wide'>
@@ -102,8 +102,8 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
   </Block>
   ```
 
-  </td> 
-  <td>  
+  </td>
+  <td>
 
   ![Screenshot of Wide Figure Block](./media/block-wide-figure.jpg)
   </td>
@@ -111,7 +111,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Full Figure Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block type='full'>
@@ -121,8 +121,8 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
     </Figure>
   </Block>
   ```
-  </td> 
-  <td>  
+  </td>
+  <td>
 
   ![Screenshot of Full Figure Block](./media/block-full-figure.jpg)
   </td>
@@ -130,7 +130,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Prose Figure Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block>
@@ -143,9 +143,9 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
     </Figure>
   </Block>
   ```
-  </td> 
-  <td>  
-  
+  </td>
+  <td>
+
   ![Screenshot of Prose Figure Block](./media/block-prose-figure.jpg)
   </td>
 </tr>
@@ -153,7 +153,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Figure Prose Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block>
@@ -166,8 +166,8 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
     </Prose>
   </Block>
   ```
-  </td> 
-  <td>  
+  </td>
+  <td>
 
   ![Screenshot of Figure Prose Block](./media/block-figure-prose.jpg)
   </td>
@@ -175,7 +175,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Prose Full Figure Block </td>
-  <td> 
+  <td>
 
   ```jsx
   <Block type='full'>
@@ -188,8 +188,8 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
     </Figure>
   </Block>
   ```
-  </td> 
-  <td>  
+  </td>
+  <td>
 
   ![Screenshot of prose full figure Block](./media/block-prose-full-figure.jpg)
   </td>
@@ -197,7 +197,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 <tr>
   <td> Full Figure Prose Block </td>
-  <td> 
+  <td>
 
 
   ```jsx
@@ -211,8 +211,8 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
     </Prose>
   </Block>
   ```
-  </td> 
-  <td>  
+  </td>
+  <td>
 
   ![Screenshot of full figure prose Block](./media/block-full-figure-prose.jpg)
   </td>
@@ -223,7 +223,7 @@ Layouts do work in any size of screen, but this documentation mainly addresses h
 
 To create a bridge between the different types of content in the VEDA dashboard it may be necessary to create a link from one to another. One example of this would be linking to a dataset page from a story.
 
-Since the dashboard may be made available under different domains at different times (for example staging environment and then production) it is a good idea to use relative links.  
+Since the dashboard may be made available under different domains at different times (for example staging environment and then production) it is a good idea to use relative links.
 This is not possible with normal markdown links, but you can use the `Link` component for this purpose.
 
 Example:
@@ -244,7 +244,7 @@ You can also use the `Link` component for external links, but it is not required
 
 ⚠️ This feature is still under development and may change at any time. ⚠️
 
-When necessary, it is possible to include a callout to link to a dataset usage. This callout allows the user to add some custom text and define which dataset the callout is for. **Note that the linked dataset must have a [usage configuration](./CONTENT.md#datasets) defined on its file**.  
+When necessary, it is possible to include a callout to link to a dataset usage. This callout allows the user to add some custom text and define which dataset the callout is for. **Note that the linked dataset must have a [usage configuration](./CONTENT.md#datasets) defined on its file**.
 
 When the user clicks the button a modal will appear with the usage information.
 
@@ -269,11 +269,11 @@ When the user clicks the button a modal will appear with the usage information.
     </NotebookConnectCallout>
   ```
   </td>
-  <td> 
- 
+  <td>
+
   ![Screenshot of notebook callout](./media/dataset-usage-callout.png)
 
-  The information on the modal is derived from the [usage configuration](./CONTENT.md#datasets) and it is not customizable.  
+  The information on the modal is derived from the [usage configuration](./CONTENT.md#datasets) and it is not customizable.
 
   ![Screenshot of notebook callout modal](./media/dataset-usage-callout-modal.png)
   </td>
@@ -299,7 +299,7 @@ The `NotebookConnectCallout` is meant to be used in a `<Prose>` component like a
 </Block>
 ```
 
-## Image 
+## Image
 
 To offer rich visual and better experience, Veda dashboard offers `Image` component, which is a wrapper for `<img/>` HTML tag. You can use `Image` component to display any kind of image. Depending on where Image is used (is it inside of `Prose` as an inline image? or inside of `Figure`?), there are additional attributes you need to pass.
 
@@ -316,7 +316,7 @@ Also you can pass any attribute that you can use with `<img />` HTML element and
 
 ### Inline image & Figure image
 
-`Image` component can take different attributes depending on its context.  
+`Image` component can take different attributes depending on its context.
 
 When `Image` is used in `Prose`, it is inline image ad should be used when you need to put an image inside of `Prose`.
 
@@ -330,27 +330,27 @@ When `Image` is used in `Prose`, it is inline image ad should be used when you n
   <td>
 
   ```jsx
-    <Image 
-      src="http://via.placeholder.com/256x128?text=align-left" 
-      alt="Media example" 
-      align="left" 
-      caption="example caption" 
+    <Image
+      src="http://via.placeholder.com/256x128?text=align-left"
+      alt="Media example"
+      align="left"
+      caption="example caption"
       attrAuthor="example author"
       attrUrl="https://example.com"
       width="256"
     />
   ```
   </td>
-  <td> 
- 
+  <td>
+
   ![Screenshot of inline Image component](./media/image-inline.jpg)
   </td>
   </tr>
 </table>
 
 
-When `Image` is used in `Figure`, it is Figure image.  
-You can replace `attr` option with `<Caption>` component if your image is used in `Figure` block. In this way, you can display rich text as Caption. 
+When `Image` is used in `Figure`, it is Figure image.
+You can replace `attr` option with `<Caption>` component if your image is used in `Figure` block. In this way, you can display rich text as Caption.
 
 <table>
   <tr>
@@ -365,21 +365,21 @@ You can replace `attr` option with `<Caption>` component if your image is used i
   <Block type="full>
     <Figure>
       <Image
-        src="http://via.placeholder.com/1200x800?text=figure" 
+        src="http://via.placeholder.com/1200x800?text=figure"
         alt='description for image'
       />
-      <Caption 
-        attrAuthor='Development Seed' 
+      <Caption
+        attrAuthor='Development Seed'
         attrUrl='https://developmentseed.org'
       >
         This is an image. This is <a href="link">a link</a>.
-      </Caption> 
+      </Caption>
     </Figure>
   </Block>
   ```
   </td>
-  <td> 
- 
+  <td>
+
   ![Screenshot of full figure Image component](./media/image-figure.jpg)
   </td>
   </tr>
@@ -400,11 +400,11 @@ For example, if you put an image `image.jpg` inside of the folder where your mdx
 ```jsx
 <Image
   src={new URL('./img.jpg', import.meta.url).href}
-  align="left" 
-  attr="tux" 
+  align="left"
+  attr="tux"
   attrAuthor="penguin"
   attrUrl="https://linux.org"
-  width="256" 
+  width="256"
 />
 ```
 
@@ -436,18 +436,18 @@ Syntax for Chart used in Wide Figure Block looks like this. Check how the data i
   <Figure>
     <Chart
       dataPath={new URL('./example.csv', import.meta.url).href}
-      dateFormat="%m/%d/%Y" 
-      idKey='County' 
-      xKey='Test Date' 
-      yKey='New Positives' 
+      dateFormat="%m/%d/%Y"
+      idKey='County'
+      xKey='Test Date'
+      yKey='New Positives'
       highlightStart = '12/10/2021'
       highlightEnd = '01/20/2022'
       highlightLabel = 'Omicron'
     />
-    <Caption 
-      attrAuthor='attribution for wide figure block, chart' 
+    <Caption
+      attrAuthor='attribution for wide figure block, chart'
       attrUrl='https://developmentseed.org'
-    /> 
+    />
   </Figure>
 </Block>
 ```
@@ -481,7 +481,7 @@ Syntax for Chart used in Wide Figure Block looks like this. Check how the data i
 
 | Option | Type | Default | Description|
 |---|---|---|---|
-| datasetId | string | `''` | `id` defined in dataset mdx. |
+| datasetId | string | `''` | `id` defined in dataset mdx (deprecated, kept for backward compatibility with legacy instances). Previously used to scope which dataset the layer came from. Now ignored internally; layer selection is based on layerId. You can safely omit it unless you are migrating existing content. |
 | layerId | string | `''` | `id` for layer to display. The layer should be a part of the dataset above. |
 | dateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. When omitted, the very first available dateTime for the dataset will be displayed |
 | compareDateTime | string | `''` | Optional. This string should follow `yyyy-mm-dd` format. A date should only be specified if you wish to display the comparison slider |
@@ -489,7 +489,6 @@ Syntax for Chart used in Wide Figure Block looks like this. Check how the data i
 | projectionId | string | `mercator` | The id of the [projection](./frontmatter/layer.md#projections) to load. |
 | projectionCenter | [int, int] | `''` | Projection center for Conic projections |
 | projectionParallels | [int, int] | `''` | Projection parallels for Conic projections |
-| allowProjectionChange | boolean | `true` | Whether or not the user can change the position using a projection selector dropdown added to the map |
 
 Syntax for Map, which displays `nightlights-hd-monthly` layer from `sandbox` dataset in full figure block looks like this:
 
@@ -514,7 +513,7 @@ Syntax for Map, which displays `nightlights-hd-monthly` layer from `sandbox` dat
 
 ![](./media/scrollytelling.png)
 
-The Scrollytelling feature of Veda is map based and allows you to define different `Chapters` where each chapter corresponds to a map position and layer being displayed.  
+The Scrollytelling feature of Veda is map based and allows you to define different `Chapters` where each chapter corresponds to a map position and layer being displayed.
 As the user scrolls the chapter content comes into view on top of the map which will animate to a specific position.
 
 The scrollytelling is defined as a series os `Chapters` inside the `ScrollytellingBlock`.
@@ -559,7 +558,7 @@ The scrollytelling is defined as a series os `Chapters` inside the `Scrollytelli
 | projectionParallels | [int, int] | Projection parallels for Conic projections |
 
 
-🧑‍🎓 **Notes on projections**  
+🧑‍🎓 **Notes on projections**
 - As with other properties, the user is not allowed to change the projection used in a chapter
 - Once a chapter with a set projection is reached, that projection will be used on subsequent chapters, until one specifies a different projection.
 

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -317,10 +317,10 @@ layers:
   <Figure>
     <MultilayerMap
       datasetId='casagfed-carbonflux-monthgrid-v3'
-      layerId='casa-gfed-co2-flux'
+      defaultLayerId='casa-gfed-co2-flux'
       center={[-120.5, 37.2]}
       zoom={5.5}
-      dateTime='2017-10-31'
+      defaultDateTime='2017-10-31'
     />
   </Figure>
 </Block>

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -313,4 +313,14 @@ layers:
     - [US GHG Center Data Intake Processing and Verification Report](https://us-ghg-center.github.io/ghgc-docs/processing_and_verification_reports/casagfed-carbonflux-monthgrid-v3_Processing%20and%20Verification%20Report.html)
 
   </Prose>
+
+  <Figure>
+    <MultilayerMap
+      datasetId='casagfed-carbonflux-monthgrid-v3'
+      layerId='casa-gfed-co2-flux'
+      center={[-120.5, 37.2]}
+      zoom={5.5}
+      dateTime='2017-10-31'
+    />
+  </Figure>
 </Block>


### PR DESCRIPTION
**Closes:** https://github.com/NASA-IMPACT/veda-ui/issues/1777

### Description of Changes

This PR implements the ability to toggle between multiple layers and select dates using the `MapBlock` component.

Changes:

1. Created `MultiLayerMapBlock` component that wraps `MapBlock` with layer and date selection controls
2. Refactored `MapBlock` architecture to accept prepared layer data (`baseDataLayer`, `compareDataLayer`) instead of full datasets
3. Added controls for layer switching and date selection that adjust based on reconciled STAC metadata
4. Enhanced lazy wrapper components (`LazyMap`, `LazyMultilayerMap`) to handle data preparation and maintain backward compatibility with existing usage of the `MapBlock`
5. Chunks longer titles in the layer select box with an ellipsis (...) if the layer name is bigger than 30 characters
6. The designs had no map controls (e.g zoom buttons, scale etc), but I kept them for consistency

Example usage of the LazyMultilayerMap wrapper in the existing mdx files:

```
   <MultilayerMap
      datasetId='casagfed-carbonflux-monthgrid-v3'
      defaultLayerId='casa-gfed-co2-flux'
      center={[-120.5, 37.2]}
      zoom={5.5}
      defaultDateTime='2017-10-31'
      excludeLayers={['deprecated-layer']}
    />
```

or the MultilayerMap React component directly:

```
<MultiLayerMapBlock
  baseDataLayer={someBaseDataLayerObject}
  availableLayers={someAvailableLayersArray}
  selectedLayerId="casa-gfed-co2-flux"
  dateTime="2017-10-31"
  center={[-120.5, 37.2]}
  zoom={5.5}
  onLayerChange={(newLayerId) => console.log('Layer changed to', newLayerId)}
  onDateChange={(newDate) => console.log('Date changed to', newDate)}
/>
```
 
### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

Example using the new multi layer map block (note the last 2 layers don't seem to work, there's probably something wrong with the dataset I chose to test with): https://deploy-preview-1808--veda-ui.netlify.app/data-catalog/casagfed-carbonflux-monthgrid-v3

Some things to verify:

- Layer selection triggers STAC metadata fetching
- Date picker adapts to dataset time density
- Backward compatibility maintained for the MapBlock
- Works in both stories and dataset pages


