### PR TITLE
refactor: move atom hook to where it is used in LayerMenuOptions

### DIFF
--- a/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card.tsx
@@ -16,7 +16,6 @@ import { LayerInfoLiner, LayerInfoModalData } from '../layer-info-modal';
 import LayerMenuOptions from './layer-options-menu';
 import { ColormapOptions } from './colormap-options';
 import {
-  useTimelineDatasetAtom,
   useTimelineDatasetColormap,
   useTimelineDatasetVisibility,
   useTimelineDatasetColormapScale
@@ -125,7 +124,6 @@ export default function DataLayerCard(props: CardProps) {
     onClickLayerInfo
   } = props;
 
-  const datasetAtom = useTimelineDatasetAtom(dataset.data.id);
   const datasetLegend = dataset.data.legend;
 
   const layerInfo = dataset.data.info;
@@ -242,7 +240,7 @@ export default function DataLayerCard(props: CardProps) {
                   )}
                 </TipButton>
               )}
-              <LayerMenuOptions datasetAtom={datasetAtom} />
+              <LayerMenuOptions datasetId={dataset.data.id} />
             </DatasetToolbar>
           </DatasetHeadline>
 

--- a/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
+++ b/app/scripts/components/exploration/components/datasets/layer-options-menu.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PrimitiveAtom, useAtomValue, useAtom } from 'jotai';
+import { useAtomValue, useAtom } from 'jotai';
 import styled from 'styled-components';
 import { Dropdown, DropMenu, DropMenuItem } from '@devseed-ui/dropdown';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
@@ -14,13 +14,11 @@ import {
 import { TileUrlModal } from './tile-link-modal';
 import { TipButton } from '$components/common/tip-button';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
-import { useTimelineDatasetSettings } from '$components/exploration/atoms/hooks';
+import { useTimelineDatasetAtom, useTimelineDatasetSettings } from '$components/exploration/atoms/hooks';
 import { NativeSliderInput, SliderInputProps } from '$styles/range-slider';
 import { TimelineDataset } from '$components/exploration/types.d.ts';
-
-
 interface LayerMenuOptionsProps {
-  datasetAtom: PrimitiveAtom<TimelineDataset>;
+  datasetId: TimelineDataset['data']['id']
 }
 
 // @NOTE: Class Name prefix is named after file name
@@ -60,7 +58,8 @@ const StyledDropdown = styled(Dropdown)`
 `;
 
 export default function LayerMenuOptions (props: LayerMenuOptionsProps) {
-  const { datasetAtom } = props;
+  const { datasetId } = props;
+  const datasetAtom = useTimelineDatasetAtom(datasetId);
 
   const [datasets, setDatasets] = useAtom(timelineDatasetsAtom);
   const dataset = useAtomValue(datasetAtom);


### PR DESCRIPTION
This address https://github.com/NASA-IMPACT/veda-ui/pull/1801#discussion_r2256544540.

Changes:

- Move `useTimelineDatasetAtom` to the component it is used
- Use strict type for the dataset id instead of generic `string`

This shouldn't affect any functionality. Ready for review.