### PR TITLE
fix: rescale not working

### DIFF
--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -52,7 +52,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     return {
       ...tileParams,
       ...(colorMap && { colormap_name: colorMap }),
-      ...(reScale && { reScale: Object.values(reScale) })
+      ...(reScale && { rescale: Object.values(reScale) })
     };
   }, [tileParams, colorMap, reScale]);
 


### PR DESCRIPTION
**Related Ticket:** https://github.com/US-GHG-Center/ghgc-architecture/issues/746

### Description of Changes
The tileparam name was misspelled (mis-cased?) as `reScale` instead of `rescale`, this PR fixes it so it overrides the default values from the mdx.

### Notes & Questions About Changes
N/A

### Validation / Testing
Manually change rescale values and see it change the visualization - [link](https://deploy-preview-1811--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22epa-annual-emissions_1b1a_coal_mining_underground%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22rainbow%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A2022634652958%7D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2012-01-01T06%3A00%3A00.000Z)