### PR TITLE
chore: allow out of range rescale values

### DIFF
--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -55,13 +55,13 @@ describe('colorRangeSlider should render with correct content.', () => {
 
     fireEvent.change(minInput, { target: { value: -0.1 } });
     expect(
-      screen.getByText('Please enter a value between 0 and 0.3')
+      screen.getByText('Warning: The provided values are outside the recommended range [0, 0.3]')
     ).toBeInTheDocument();
     const maxInput = screen.getByTestId('maxInput');
 
     fireEvent.change(maxInput, { target: { value: 0.4 } });
     expect(
-      screen.getByText('Please enter a value between 0 and 0.3')
+      screen.getByText('Warning: The provided values are outside the recommended range [0, 0.3]')
     ).toBeInTheDocument();
   });
 });

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/colorRangeSlider.spec.tsx
@@ -42,6 +42,7 @@ describe('colorRangeSlider should render with correct content.', () => {
       screen.getByText('Please enter a value less than 0.263')
     ).toBeInTheDocument();
   });
+
   it('Shows error when number entered below min', () => {
     const maxInput = screen.getByTestId('maxInput');
 
@@ -55,13 +56,17 @@ describe('colorRangeSlider should render with correct content.', () => {
 
     fireEvent.change(minInput, { target: { value: -0.1 } });
     expect(
-      screen.getByText('Warning: The provided values are outside the recommended range [0, 0.3]')
+      screen.getByText(
+        'Warning: The provided values are outside the recommended range [0, 0.3]'
+      )
     ).toBeInTheDocument();
     const maxInput = screen.getByTestId('maxInput');
 
     fireEvent.change(maxInput, { target: { value: 0.4 } });
     expect(
-      screen.getByText('Warning: The provided values are outside the recommended range [0, 0.3]')
+      screen.getByText(
+        'Warning: The provided values are outside the recommended range [0, 0.3]'
+      )
     ).toBeInTheDocument();
   });
 });

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -278,9 +278,9 @@ export function ColorRangeSlider({
             name='max'
             data-testid='maxInput'
             className={`${textInputClasses} ${
-              inputIssue.min
+              inputIssue.max
                 ? 'border-orange text-orange'
-                : inputIssue.largerThanMax
+                : inputIssue.lessThanMin
                 ? 'border-secondary-vivid text-secondary-vivid'
                 : 'border-base-light'
             }`}

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -34,25 +34,12 @@ function validateInputIssues(
   min: number,
   max: number
 ) {
-  const issues = {
-    min: false,
-    max: false,
-    largerThanMax: false,
-    lessThanMin: false
+  return {
+    min: minVal < min || minVal > max,
+    max: maxVal < min || maxVal > max,
+    largerThanMax: minVal >= maxVal,
+    lessThanMin: maxVal <= minVal
   };
-
-  if (minVal < min || minVal > max) {
-    issues.min = true;
-  }
-  if (maxVal < min || maxVal > max) {
-    issues.max = true;
-  }
-  if (minVal >= maxVal) {
-    issues.largerThanMax = true;
-    issues.lessThanMin = true;
-  }
-
-  return issues;
 }
 
 export function ColorRangeSlider({
@@ -208,16 +195,10 @@ export function ColorRangeSlider({
               setFieldFocused(false);
             }}
             onChange={(event) => {
-              if (event.target.value != undefined) {
+              if (event.target.value !== undefined) {
                 const value = Number(event.target.value) || 0;
                 minValRef.current.actual = value;
-
-                const calculatedVal = Math.min(value, maxVal - minMaxBuffer);
-                setMinVal(calculatedVal);
-
-                setInputIssue(
-                  validateInputIssues(calculatedVal, maxVal, min, max)
-                );
+                setMinVal(value);
               }
             }}
           />
@@ -318,27 +299,10 @@ export function ColorRangeSlider({
               setFieldFocused(false);
             }}
             onChange={(event) => {
-              if (event.target.value != undefined) {
-                maxValRef.current.actual =
-                  event.target.value === '' ? 0 : event.target.value;
-                const value = Number(event.target.value);
-
-                if (value < minVal + minMaxBuffer)
-                  return setInputIssue({ ...inputIssue, lessThanMin: true });
-
-                const calculatedVal = Math.max(value, minVal + minMaxBuffer);
-                setMaxVal(calculatedVal);
-
-                if (value < min || value > max) {
-                  return setInputIssue({ ...inputIssue, max: true });
-                } else {
-                  //unsetting error
-                  return setInputIssue({
-                    ...inputIssue,
-                    max: false,
-                    lessThanMin: false
-                  });
-                }
+              if (event.target.value !== undefined) {
+                const value = Number(event.target.value) || 0;
+                maxValRef.current.actual = value;
+                setMaxVal(value);
               }
             }}
           />

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -5,7 +5,7 @@ import {
   sterlizeNumber,
   calculateStep,
   rangeCalculation,
-  displayWarningMessage,
+  displayIssueMessage,
   textInputClasses,
   thumbPosition,
   tooltiptextClasses
@@ -47,7 +47,7 @@ export function ColorRangeSlider({
   const range = useRef<HTMLDivElement>(null);
 
   const [fieldFocused, setFieldFocused] = useState(false);
-  const [inputWarning, setInputWarning] = useState({
+  const [inputIssue, setInputIssue] = useState({
     min: false,
     max: false,
     largerThanMax: false,
@@ -63,8 +63,8 @@ export function ColorRangeSlider({
   const resetWarningOnSlide = (value, slider) => {
     if (value > min || value < max) {
       slider === 'max'
-        ? setInputWarning({ ...inputWarning, max: false, lessThanMin: false })
-        : setInputWarning({ ...inputWarning, min: false, largerThanMax: false });
+        ? setInputIssue({ ...inputIssue, max: false, lessThanMin: false })
+        : setInputIssue({ ...inputIssue, min: false, largerThanMax: false });
     }
   };
 
@@ -135,7 +135,7 @@ export function ColorRangeSlider({
         min: Number(minValRef.current.actual),
         max: Number(maxValRef.current.actual)
       }); /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [maxVal, minVal, getPercent, setColorMapScale, inputWarning, max, min]);
+  }, [maxVal, minVal, getPercent, setColorMapScale, inputIssue, max, min]);
 
   return (
     <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
@@ -157,9 +157,11 @@ export function ColorRangeSlider({
             id='range slider min'
             name='min'
             className={`${textInputClasses} ${
-              inputWarning.min || inputWarning.largerThanMax
+              inputIssue.min
                 ? 'border-orange text-orange'
-                : ' border-base-light'
+                : inputIssue.largerThanMax
+                ? 'border-secondary-vivid text-secondary-vivid'
+                : 'border-base-light'
             }`}
             data-testid='minInput'
             value={
@@ -184,16 +186,17 @@ export function ColorRangeSlider({
                   event.target.value === '' ? 0 : event.target.value;
                 const value = Number(event.target.value);
 
+                if (value > maxVal - minMaxBuffer)
+                  return setInputIssue({ ...inputIssue, largerThanMax: true });
+
                 const calculatedVal = Math.min(value, maxVal - minMaxBuffer);
                 setMinVal(calculatedVal);
 
-                if (value > maxVal - minMaxBuffer)
-                  return setInputWarning({ ...inputWarning, largerThanMax: true });
                 if (value < min || value > max) {
-                  return setInputWarning({ ...inputWarning, min: true });
+                  return setInputIssue({ ...inputIssue, min: true });
                 } else {
-                  return setInputWarning({
-                    ...inputWarning,
+                  return setInputIssue({
+                    ...inputIssue,
                     min: false,
                     largerThanMax: false
                   });
@@ -275,9 +278,11 @@ export function ColorRangeSlider({
             name='max'
             data-testid='maxInput'
             className={`${textInputClasses} ${
-              inputWarning.max || inputWarning.lessThanMin
+              inputIssue.min
                 ? 'border-orange text-orange'
-                : ' border-base-light'
+                : inputIssue.largerThanMax
+                ? 'border-secondary-vivid text-secondary-vivid'
+                : 'border-base-light'
             }`}
             placeholder={
               fieldFocused
@@ -301,18 +306,18 @@ export function ColorRangeSlider({
                   event.target.value === '' ? 0 : event.target.value;
                 const value = Number(event.target.value);
 
+                if (value < minVal + minMaxBuffer)
+                  return setInputIssue({ ...inputIssue, lessThanMin: true });
+
                 const calculatedVal = Math.max(value, minVal + minMaxBuffer);
                 setMaxVal(calculatedVal);
 
-                if (value < minVal + minMaxBuffer)
-                  return setInputWarning({ ...inputWarning, lessThanMin: true });
-
                 if (value < min || value > max) {
-                  return setInputWarning({ ...inputWarning, max: true });
+                  return setInputIssue({ ...inputIssue, max: true });
                 } else {
                   //unsetting error
-                  return setInputWarning({
-                    ...inputWarning,
+                  return setInputIssue({
+                    ...inputIssue,
                     max: false,
                     lessThanMin: false
                   });
@@ -323,7 +328,7 @@ export function ColorRangeSlider({
         </div>
       </form>
 
-      {displayWarningMessage(inputWarning, min, max, maxValRef, minValRef)}
+      {displayIssueMessage(inputIssue, min, max, maxValRef, minValRef)}
     </div>
   );
 }

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -28,6 +28,33 @@ interface ColorrangeRangeSlideProps {
   setColorMapScale: (colorMapScale: colorMapScale) => void;
 }
 
+function validateInputIssues(
+  minVal: number,
+  maxVal: number,
+  min: number,
+  max: number
+) {
+  const issues = {
+    min: false,
+    max: false,
+    largerThanMax: false,
+    lessThanMin: false
+  };
+
+  if (minVal < min || minVal > max) {
+    issues.min = true;
+  }
+  if (maxVal < min || maxVal > max) {
+    issues.max = true;
+  }
+  if (minVal >= maxVal) {
+    issues.largerThanMax = true;
+    issues.lessThanMin = true;
+  }
+
+  return issues;
+}
+
 export function ColorRangeSlider({
   min,
   max,
@@ -75,11 +102,7 @@ export function ColorRangeSlider({
     let minValPrevious;
     //checking that there are no current errors with inputs
     //set the filled range bar on initial load
-    if (
-      colorMapScale &&
-      maxVal != maxValPrevious &&
-      minVal != minValPrevious
-    ) {
+    if (colorMapScale && maxVal != maxValPrevious && minVal != minValPrevious) {
       const minPercent = getPercent(minValRef.current.actual);
       const maxPercent = getPercent(maxValRef.current.actual);
 
@@ -137,6 +160,10 @@ export function ColorRangeSlider({
       }); /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [maxVal, minVal, getPercent, setColorMapScale, inputIssue, max, min]);
 
+  useEffect(() => {
+    setInputIssue(validateInputIssues(minVal, maxVal, min, max));
+  }, [minVal, maxVal, min, max]);
+
   return (
     <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
       <form className='usa-form display-flex flex-row flex-justify flex-align-center padding-bottom-1'>
@@ -182,25 +209,15 @@ export function ColorRangeSlider({
             }}
             onChange={(event) => {
               if (event.target.value != undefined) {
-                minValRef.current.actual =
-                  event.target.value === '' ? 0 : event.target.value;
-                const value = Number(event.target.value);
-
-                if (value > maxVal - minMaxBuffer)
-                  return setInputIssue({ ...inputIssue, largerThanMax: true });
+                const value = Number(event.target.value) || 0;
+                minValRef.current.actual = value;
 
                 const calculatedVal = Math.min(value, maxVal - minMaxBuffer);
                 setMinVal(calculatedVal);
 
-                if (value < min || value > max) {
-                  return setInputIssue({ ...inputIssue, min: true });
-                } else {
-                  return setInputIssue({
-                    ...inputIssue,
-                    min: false,
-                    largerThanMax: false
-                  });
-                }
+                setInputIssue(
+                  validateInputIssues(calculatedVal, maxVal, min, max)
+                );
               }
             }}
           />

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/index.tsx
@@ -148,8 +148,23 @@ export function ColorRangeSlider({
   }, [maxVal, minVal, getPercent, setColorMapScale, inputIssue, max, min]);
 
   useEffect(() => {
-    setInputIssue(validateInputIssues(minVal, maxVal, min, max));
-  }, [minVal, maxVal, min, max]);
+    const minNum = Number(minValRef.current.actual);
+    const maxNum = Number(maxValRef.current.actual);
+
+    if (minNum < min || minNum > max) {
+      setInputIssue((prev) => ({ ...prev, min: true }));
+    }
+    if (maxNum < min || maxNum > max) {
+      setInputIssue((prev) => ({ ...prev, max: true }));
+    }
+    if (minNum >= maxNum) {
+      setInputIssue((prev) => ({
+        ...prev,
+        largerThanMax: true,
+        lessThanMin: true
+      }));
+    }
+  }, []);
 
   return (
     <div className='border-bottom-1px padding-bottom-1 border-base-light width-full text-normal'>
@@ -195,10 +210,26 @@ export function ColorRangeSlider({
               setFieldFocused(false);
             }}
             onChange={(event) => {
-              if (event.target.value !== undefined) {
-                const value = Number(event.target.value) || 0;
-                minValRef.current.actual = value;
-                setMinVal(value);
+              if (event.target.value != undefined) {
+                minValRef.current.actual =
+                  event.target.value === '' ? 0 : event.target.value;
+                const value = Number(event.target.value);
+
+                if (value > maxVal - minMaxBuffer)
+                  return setInputIssue({ ...inputIssue, largerThanMax: true });
+
+                const calculatedVal = Math.min(value, maxVal - minMaxBuffer);
+                setMinVal(calculatedVal);
+
+                if (value < min || value > max) {
+                  return setInputIssue({ ...inputIssue, min: true });
+                } else {
+                  return setInputIssue({
+                    ...inputIssue,
+                    min: false,
+                    largerThanMax: false
+                  });
+                }
               }
             }}
           />
@@ -299,10 +330,26 @@ export function ColorRangeSlider({
               setFieldFocused(false);
             }}
             onChange={(event) => {
-              if (event.target.value !== undefined) {
-                const value = Number(event.target.value) || 0;
-                maxValRef.current.actual = value;
-                setMaxVal(value);
+              if (event.target.value != undefined) {
+                maxValRef.current.actual =
+                  event.target.value === '' ? 0 : event.target.value;
+                const value = Number(event.target.value);
+
+                if (value < minVal + minMaxBuffer)
+                  return setInputIssue({ ...inputIssue, lessThanMin: true });
+
+                const calculatedVal = Math.max(value, minVal + minMaxBuffer);
+                setMaxVal(calculatedVal);
+
+                if (value < min || value > max) {
+                  return setInputIssue({ ...inputIssue, max: true });
+                } else {
+                  return setInputIssue({
+                    ...inputIssue,
+                    max: false,
+                    lessThanMin: false
+                  });
+                }
               }
             }}
           />

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
@@ -40,7 +40,7 @@ export const rangeCalculation = (maxPercent, minPercent, range) => {
   return;
 };
 
-export const displayWarningMessage = (
+export const displayIssueMessage = (
   inputError,
   min,
   max,
@@ -52,7 +52,7 @@ export const displayWarningMessage = (
   if (inputError.max || inputError.min) {
     return (
       <p className='text-orange'>
-        Warning: The provided values are outside the range {min} and {max}
+        {`Warning: The provided values are outside the recommended range [${min}, ${max}]`}
       </p>
     );
   }
@@ -62,8 +62,8 @@ export const displayWarningMessage = (
 
   if (inputError.largerThanMax) {
     return (
-      <p className='text-orange'>
-        Warning: The max rescale {maxValRef.current.actual} is larger than the suggested max of {max}
+      <p className='text-secondary-vivid'>
+        Please enter a value less than {maxValRef.current.actual}
       </p>
     );
   }
@@ -73,8 +73,8 @@ export const displayWarningMessage = (
 
   if (inputError.lessThanMin) {
     return (
-      <p className='text-orange'>
-        Warning: The min rescale {minValRef.current.actual} is less than the suggested min of {min}
+      <p className='text-secondary-vivid'>
+        Please enter a value larger than {minValRef.current.actual}
       </p>
     );
   }

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
@@ -10,6 +10,7 @@ export const textInputClasses =
 export const thumbPosition = `position-absolute pointer-events width-card height-0 outline-0`;
 export const tooltiptextClasses =
   'text-no-wrap text-white text-center radius-lg padding-x-105 padding-y-05 position-absolute z-1 bottom-205';
+
 export const calculateStep = (max, min, digitCount) => {
   const numericDistance = max - min;
   if (numericDistance >= 100) {
@@ -23,13 +24,12 @@ export const calculateStep = (max, min, digitCount) => {
     }
     digitCount.current = decimalPoints + 2;
 
-    //adding a default buffer for granular control
+    // adding a default buffer for granular control
     return Math.pow(10, (decimalPoints + 2) * -1);
   }
 };
 
-//Calculate the range
-
+// Calculate the range
 export const rangeCalculation = (maxPercent, minPercent, range) => {
   const thumbWidth = 20;
   if (range.current) {
@@ -47,23 +47,30 @@ export const displayIssueMessage = (
   maxValRef,
   minValRef
 ) => {
-  const messages: JSX.Element[] = [
-    (inputError.max || inputError.min) && (
-      <p key='range' className='text-orange'>
+  // error message for min/max input that is outside min/max of colormap
+  if (inputError.max || inputError.min) {
+    return (
+      <p className='text-orange'>
         {`Warning: The provided values are outside the recommended range [${min}, ${max}]`}
       </p>
-    ),
-    inputError.largerThanMax && (
-      <p key='larger' className='text-secondary-vivid'>
+    );
+  }
+
+  // error message for max input that is less than current min
+  if (inputError.largerThanMax) {
+    return (
+      <p className='text-secondary-vivid'>
         Please enter a value less than {maxValRef.current.actual}
       </p>
-    ),
-    inputError.lessThanMin && (
-      <p key='less' className='text-secondary-vivid'>
+    );
+  }
+
+  // error message for min input that is larger than current max
+  if (inputError.lessThanMin) {
+    return (
+      <p className='text-secondary-vivid'>
         Please enter a value larger than {minValRef.current.actual}
       </p>
-    )
-  ].filter(Boolean) as JSX.Element[];
-
-  return <>{messages}</>;
+    );
+  }
 };

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
@@ -47,35 +47,23 @@ export const displayIssueMessage = (
   maxValRef,
   minValRef
 ) => {
-  // error message for min input that is outside min max of color map
-
-  if (inputError.max || inputError.min) {
-    return (
-      <p className='text-orange'>
+  const messages: JSX.Element[] = [
+    (inputError.max || inputError.min) && (
+      <p key='range' className='text-orange'>
         {`Warning: The provided values are outside the recommended range [${min}, ${max}]`}
       </p>
-    );
-  }
-  {
-    /* error message for max input that is less than current min */
-  }
-
-  if (inputError.largerThanMax) {
-    return (
-      <p className='text-secondary-vivid'>
+    ),
+    inputError.largerThanMax && (
+      <p key='larger' className='text-secondary-vivid'>
         Please enter a value less than {maxValRef.current.actual}
       </p>
-    );
-  }
-  {
-    /* error message for min input that is larger than current max */
-  }
-
-  if (inputError.lessThanMin) {
-    return (
-      <p className='text-secondary-vivid'>
+    ),
+    inputError.lessThanMin && (
+      <p key='less' className='text-secondary-vivid'>
         Please enter a value larger than {minValRef.current.actual}
       </p>
-    );
-  }
+    )
+  ].filter(Boolean) as JSX.Element[];
+
+  return <>{messages}</>;
 };

--- a/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
+++ b/app/scripts/components/exploration/components/datasets/colorRangeSlider/utils.tsx
@@ -40,7 +40,7 @@ export const rangeCalculation = (maxPercent, minPercent, range) => {
   return;
 };
 
-export const displayErrorMessage = (
+export const displayWarningMessage = (
   inputError,
   min,
   max,
@@ -51,8 +51,8 @@ export const displayErrorMessage = (
 
   if (inputError.max || inputError.min) {
     return (
-      <p className='text-secondary-vivid'>
-        Please enter a value between {min} and {max}
+      <p className='text-orange'>
+        Warning: The provided values are outside the range {min} and {max}
       </p>
     );
   }
@@ -62,8 +62,8 @@ export const displayErrorMessage = (
 
   if (inputError.largerThanMax) {
     return (
-      <p className='text-secondary-vivid'>
-        Please enter a value less than {maxValRef.current.actual}
+      <p className='text-orange'>
+        Warning: The max rescale {maxValRef.current.actual} is larger than the suggested max of {max}
       </p>
     );
   }
@@ -73,8 +73,8 @@ export const displayErrorMessage = (
 
   if (inputError.lessThanMin) {
     return (
-      <p className='text-secondary-vivid'>
-        Please enter a value larger than {minValRef.current.actual}
+      <p className='text-orange'>
+        Warning: The min rescale {minValRef.current.actual} is less than the suggested min of {min}
       </p>
     );
   }

--- a/mock/datasets/data-from-ghg.data.mdx
+++ b/mock/datasets/data-from-ghg.data.mdx
@@ -58,6 +58,7 @@ layers:
       - 0
       - 20
     sourceParams:
+      colormap_name: viridis
       assets: npp
       rescale:
         - 0


### PR DESCRIPTION
**Related Ticket:** https://github.com/US-GHG-Center/ghgc-architecture/issues/748

### Description of Changes
Allow users to use out of range values for rescale in colormap

### Notes & Questions About Changes
not sure what the messaging for the warning should be?

### Validation / Testing
Tested manually in the [pr preview](https://deploy-preview-1821--veda-ui.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22casa-gfed-co2-flux%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%2C%22colorMap%22%3A%22viridis%22%2C%22scale%22%3A%7B%22min%22%3A0%2C%22max%22%3A0.5%7D%7D%7D%5D&taxonomy=%7B%7D&search=&date=2017-12-01T06%3A00%3A00.000Z)