### PR TITLE
feat: Add null temporal interval handling across all data types

### DIFF
--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -86,11 +86,10 @@ export function reconcileQueryDataWithDataset(
 // Applied consistently across CMR, WMTS, WMS and other dataset types
 export function normalizeDomain(
   domain: (string | null)[] | undefined
-): string[] {
+): (string | null)[] {
   if (!domain) return [];
-  const start = domain[0] ?? new Date().toISOString();
-  const end = domain[1] ?? new Date().toISOString();
-  return [start, end];
+  const [start, end] = domain;
+  return [start, end ?? new Date().toISOString()];
 }
 
 export async function fetchStacDatasetById(

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -19,7 +19,7 @@ export interface StacDatasetData {
   isTimeless?: boolean;
   timeInterval: string;
   timeDensity: TimeDensity;
-  domain: string[];
+  domain: (string | null)[];
   renders?: Record<string, any> | undefined;
 }
 


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1819

### Description of Changes

This brings all data type handling in line with the behavior we already support for cmr datasets:

- Update `fetchStacDatasetById` to replace `null` end dates in temporal intervals with the current date
- Add unit tests for the utility functions

### Notes & Questions About Changes

### Validation / Testing

Easiest way to test this is by stubbing the STAC response in `fetchStacDatasetById`.  

1. Right after the `axios.get` call, temporarily add the below block on line 106:

```ts
if (data.extent?.temporal?.interval?.[0]) {
  data.extent.temporal.interval[0][1] = null;
}
```

2. Run the app locally (yarn dev)
3. Go to E&A and add a layer (e.g. VIIRS Black Marble)
4. The end interval in the timeline panel should be set to today, not null
5. Remove the stub block and do a smoke test with a few other layers to confirm they behave normally