### PR TITLE
fix: Replace Collecticons with USWDS equivalents

### DIFF
--- a/app/scripts/components/common/loading-skeleton.tsx
+++ b/app/scripts/components/common/loading-skeleton.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import styled, { keyframes, css } from 'styled-components';
+import { Icon } from '@trussworks/react-uswds';
 import { glsp, themeVal, visuallyHidden } from '@devseed-ui/theme-provider';
-import { CollecticonChartLine } from '@devseed-ui/collecticons';
 
 import { variableGlsp } from '$styles/variable-utils';
 
@@ -224,7 +224,7 @@ export const MapLoading = (props) => {
 export const ChartLoading = (props: { message: ReactNode }) => {
   return (
     <ChartLoadingWrapper>
-      <CollecticonChartLine size='xlarge' />
+      <Icon.Assessment aria-hidden='true' />
       <p>{props.message}</p>
     </ChartLoadingWrapper>
   );

--- a/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'styled-components';
 import { extent, scaleLinear, ScaleTime, line, area, ScaleLinear } from 'd3';
 import { SVGMotionProps, AnimatePresence, motion } from 'framer-motion';
 import styled from 'styled-components';
-import { CollecticonChartLine } from '@devseed-ui/collecticons';
+import { Icon } from '@trussworks/react-uswds';
 import { themeVal } from '@devseed-ui/theme-provider';
 import {
   RIGHT_AXIS_SPACE,
@@ -113,7 +113,7 @@ export function DatasetChart(props: DatasetChartProps) {
   }, [yExtent, height]);
 
   const chartAnalysisIconTrigger: JSX.Element = (
-    <CollecticonChartLine meaningful title='View layer options' />
+    <Icon.Assessment aria-hidden='false' aria-label='View layer options' />
   );
   return (
     <div>

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item-status.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled, { css } from 'styled-components';
+import { Icon } from '@trussworks/react-uswds';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Button } from '@devseed-ui/button';
-import { CollecticonArrowLoop } from '@devseed-ui/collecticons';
 
 import { pulsingAnimation } from '$components/common/loading-skeleton';
 import {
@@ -175,7 +175,7 @@ export function DatasetTrackError(props: {
           <p>{message}</p>
           {typeof onRetryClick === 'function' ? (
             <Button variation='danger-fill' size='small' onClick={onRetryClick}>
-              Retry <CollecticonArrowLoop size='small' />
+              Retry <Icon.Autorenew aria-hidden='true' />
             </Button>
           ) : null}
         </TrackMessage>

--- a/app/scripts/components/exploration/components/map/analysis-message-control.tsx
+++ b/app/scripts/components/exploration/components/map/analysis-message-control.tsx
@@ -2,13 +2,11 @@ import React, { useCallback, useEffect } from 'react';
 import { useAtomValue } from 'jotai';
 import styled, { css } from 'styled-components';
 import { LngLatBoundsLike, MapRef } from 'react-map-gl';
+import { Icon } from '@trussworks/react-uswds';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 import { Button, createButtonStyles } from '@devseed-ui/button';
 import bbox from '@turf/bbox';
-import {
-  CollecticonChartLine,
-  CollecticonCircleInformation
-} from '@devseed-ui/collecticons';
+import { CollecticonCircleInformation } from '@devseed-ui/collecticons';
 import { timelineDatasetsAtom } from '../../atoms/datasets';
 import { selectedIntervalAtom } from '../../atoms/dates';
 
@@ -22,7 +20,6 @@ import { calcFeatCollArea } from '$components/common/map/controls/aoi/utils';
 import { formatDateRange } from '$utils/date';
 import { useAnalysisController } from '$components/exploration/hooks/use-analysis-data-request';
 import useThemedControl from '$components/common/map/controls/hooks/use-themed-control';
-import { getZoomFromBbox } from '$components/common/map/utils';
 import { AoIFeature } from '$components/common/map/types';
 import { ShortcutCode } from '$styles/shortcut-code';
 import {
@@ -353,7 +350,7 @@ function MessagesWhileNotAnalyzing(props: MessagesProps) {
 function StatusIconObsolete() {
   return (
     <MessageStatusIndicator status='obsolete'>
-      <CollecticonChartLine />
+      <Icon.Assessment aria-hidden='false' aria-label='obsolete' />
     </MessageStatusIndicator>
   );
 }
@@ -361,7 +358,7 @@ function StatusIconObsolete() {
 function StatusIconAnalyzing() {
   return (
     <MessageStatusIndicator status='analyzing'>
-      <CollecticonChartLine />
+      <Icon.Assessment aria-hidden='false' aria-label='analyzing' />
     </MessageStatusIndicator>
   );
 }
@@ -369,7 +366,7 @@ function StatusIconAnalyzing() {
 function StatusIconPreAnalyzing() {
   return (
     <MessageStatusIndicator status='info'>
-      <CollecticonChartLine />
+      <Icon.Assessment aria-hidden='false' aria-label='info' />
     </MessageStatusIndicator>
   );
 }

--- a/app/scripts/components/uhoh/fatal-error.js
+++ b/app/scripts/components/uhoh/fatal-error.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import T from 'prop-types';
 import { useLocation } from 'react-router-dom';
 import nl2br from 'react-nl2br';
-import { CollecticonArrowRight } from '@devseed-ui/collecticons';
+import { Icon } from '@trussworks/react-uswds';
 
 import UhOh from '.';
 import LayoutRoot, { LayoutProps } from '$components/common/layout-root';
@@ -109,7 +109,7 @@ function Child(props) {
             <p>
               <strong>
                 <a href={makeAbsUrl('/')} title='Go back to homepage'>
-                  <CollecticonArrowRight size='small' />
+                  <Icon.ArrowForward />
                   <span>&nbsp;Go back to homepage</span>
                 </a>
               </strong>

--- a/storybook/.storybook/preview.tsx
+++ b/storybook/.storybook/preview.tsx
@@ -9,23 +9,28 @@ import '@uswds/uswds/css/uswds.css';
 
 const preview: Preview = {
   decorators: [
-    (Story) => (
-      <VedaUIProvider
-        config={{
-          envMapboxToken: import.meta.env.MAPBOX_TOKEN ?? '',
-          envApiStacEndpoint: import.meta.env.API_STAC_ENDPOINT ?? '',
-          envApiRasterEndpoint: import.meta.env.API_RASTER_ENDPOINT ?? '',
-          envApiCMREndpoint: import.meta.env.API_CMR_ENDPOINT ?? '',
-          geoDataPath: `${import.meta.env.PUBLIC_URL ?? ''}/public/geo-data`
-        }}
-      >
-        <DevseedUiThemeProvider>
-          <ReactQueryProvider>
-            <Story />
-          </ReactQueryProvider>
-        </DevseedUiThemeProvider>
-      </VedaUIProvider>
-    )
+    (Story, context) => {
+      if (context.parameters?.withProviders) {
+        return (
+          <VedaUIProvider
+            config={{
+              envMapboxToken: import.meta.env.MAPBOX_TOKEN ?? '',
+              envApiStacEndpoint: import.meta.env.API_STAC_ENDPOINT ?? '',
+              envApiRasterEndpoint: import.meta.env.API_RASTER_ENDPOINT ?? '',
+              envApiCMREndpoint: import.meta.env.API_CMR_ENDPOINT ?? '',
+              geoDataPath: `${import.meta.env.PUBLIC_URL ?? ''}/public/geo-data`
+            }}
+          >
+            <DevseedUiThemeProvider>
+              <ReactQueryProvider>
+                <Story />
+              </ReactQueryProvider>
+            </DevseedUiThemeProvider>
+          </VedaUIProvider>
+        );
+      }
+      return <Story />;
+    }
   ],
   parameters: {
     controls: {

--- a/storybook/src/stories/basemap-example.stories.tsx
+++ b/storybook/src/stories/basemap-example.stories.tsx
@@ -40,7 +40,8 @@ const meta: Meta<typeof BaseMapExample> = {
   title: 'Components/BaseMapExample',
   component: BaseMapExample,
   parameters: {
-    layout: 'fullscreen'
+    layout: 'fullscreen',
+    withProviders: true
   },
   tags: ['autodocs']
 };

--- a/storybook/src/stories/uswds-icons.stories.tsx
+++ b/storybook/src/stories/uswds-icons.stories.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Meta } from '@storybook/react-vite';
+import { Icon } from '@trussworks/react-uswds';
+
+export default {
+  title: 'USWDS/Icons',
+  component: Icon.ArrowForward,
+  args: {
+    size: 5,
+    color: 'teal',
+    'aria-hidden': 'true'
+  },
+  argTypes: {
+    size: {
+      control: { type: 'select' },
+      options: [3, 4, 5, 6, 7, 8, 9],
+      description: 'Icon size',
+      table: {
+        type: { summary: '3 | 4 | 5 | 6 | 7 | 8 | 9' },
+        defaultValue: { summary: '5' }
+      }
+    }
+  }
+} as Meta;
+
+export const ArrowForward = (args) => <Icon.ArrowForward {...args} />;
+export const Autorenew = (args) => <Icon.Autorenew {...args} />;
+export const Assessment = (args) => (
+  <Icon.Assessment
+    {...args}
+    aria-hidden='false'
+    aria-label='View layer options'
+  />
+);
+
+export const AllIcons = (args) => (
+  <div style={{ display: 'flex', gap: 24, flexWrap: 'wrap' }}>
+    <Icon.ArrowForward {...args} />
+    <Icon.Autorenew {...args} />
+    <Icon.Assessment {...args} />
+  </div>
+);


### PR DESCRIPTION
**Related Ticket:** _#1814_

### Description of Changes
This replaces the devseed-ui collecticons one by one with USWDS equivalents provided by `@trussworks/react-uswds`.
I am adding a storybook page to to verify the rendered output from Icon components, as their actual names are hard to find in the trussworks docs.

### Notes & Questions About Changes
3 out of 18.
It is not straightforward to find those icons in the interface. The Icon.ArrowForward in [uhoh/fatal-error.js](https://github.com/NASA-IMPACT/veda-ui/commit/988e24baf2f56153add2a49d4c55cde7ff648e2b#diff-646a2e9648924a8dbb3ee2bb76762f3ff552b7ff8fb80c3c00808aa65eec8c38) is supposed to show up on the ErrorBoundary, but I did not get that page to ever show up, even when manually throwing an error in the Home page.

### Validation / Testing
You can help me by finding the icons in the UI and check their appearance matches roughly the old collecticon implementation.
