### PR TITLE
fix: Storybook preprocessor config

### DIFF
--- a/storybook/src/stories/components/exploration/components/datasets/colormap-options.stories.tsx
+++ b/storybook/src/stories/components/exploration/components/datasets/colormap-options.stories.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { ColormapOptions } from '$components/exploration/components/datasets/colormap-options';
+import { colorMapScale } from '$components/exploration/types.d.ts';
+
+const meta: Meta<typeof ColormapOptions> = {
+  title: 'Components/Exploration/ColormapOptions',
+  component: ColormapOptions,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: 'Simple colormap options component with range slider.'
+      }
+    }
+  },
+  tags: ['autodocs']
+};
+
+export default meta;
+type Story = StoryObj<typeof ColormapOptions>;
+
+const ColormapOptionsDemo = () => {
+  const [colorMap, setColorMap] = useState('viridis');
+  const [colorMapScale, setColorMapScale] = useState<colorMapScale>({
+    min: 0,
+    max: 100
+  });
+
+  return (
+    <div>
+      <h3>
+        Current Range: {colorMapScale.min} to {colorMapScale.max}
+      </h3>
+      <ColormapOptions
+        colorMap={colorMap}
+        setColorMap={setColorMap}
+        min={0}
+        max={100}
+        colorMapScale={colorMapScale}
+        setColorMapScale={setColorMapScale}
+      />
+    </div>
+  );
+};
+
+export const Simple: Story = {
+  render: () => <ColormapOptionsDemo />
+};

--- a/storybook/vite.config.ts
+++ b/storybook/vite.config.ts
@@ -10,6 +10,19 @@ export default defineConfig(({ mode }) => {
     envDir: rootEnvDir,
     publicDir: path.resolve(__dirname, '../static'),
     plugins: [react()],
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: 'legacy',
+          includePaths: [
+            // USWDS from node_modules
+            path.resolve(__dirname, 'node_modules/@uswds/uswds'),
+            path.resolve(__dirname, 'node_modules/@uswds/uswds/dist'),
+            path.resolve(__dirname, 'node_modules/@uswds/uswds/packages')
+          ]
+        }
+      }
+    },
     resolve: {
       alias: {
         // Application path aliases


### PR DESCRIPTION
Add SCSS preprocessor configuration to Storybook Vite config to properly handle USWDS styles.

## Changes
- Add SCSS preprocessor configuration with legacy API
- Include USWDS paths for proper SCSS compilation
- Add test story for ColormapOptions component

## Context
This is the same configuration as in #1843 but as a separate PR to avoid dependencies on other work.

## Testing Instructions
1. Run `yarn storybook` from storybook directory
2. Navigate to "Components/Exploration/ColormapOptions"
3. Verify USWDS styles and icons render correctly
4. **To test that the config is necessary:**
   - Remove the `css.preprocessorOptions` block from `storybook/vite.config.ts`
   - Restart Storybook
   - Observe that USWDS styles break (icons missing, unstyled components)
   - Restore the config to see it working again

This is ready for review.