### PR TITLE
feat: export exploration types for downstream consumers

### DIFF
--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -114,7 +114,7 @@ export interface DatasetSettings {
 
 // Any sort of meta information the dataset like:
 // Tile endpoints for the layer given the current map view.
-type DatasetMeta = Record<string, any>;
+export type DatasetMeta = Record<string, any>;
 
 // Holds only dataset needed for visualization (Subset of timeline dataset)
 // @ TODO: Rename Timeline specific variable names

--- a/app/scripts/components/exploration/types.d.ts.ts
+++ b/app/scripts/components/exploration/types.d.ts.ts
@@ -50,7 +50,7 @@ export interface AnalysisTimeseriesEntry {
   percentile_98: number;
 }
 
-interface AnalysisMeta {
+export interface AnalysisMeta {
   loaded: number;
   total: number;
 }

--- a/app/scripts/libs/types.ts
+++ b/app/scripts/libs/types.ts
@@ -7,14 +7,41 @@ import type { DatasetData, StoryData, VedaData } from '$types/veda';
 
 // Exploration feature types
 import type {
-  VizDatasetSuccess,
+  // Enums
+  TimeDensity,
   DatasetStatus,
-  VizDataset,
+  // Core data types
+  StacDatasetData,
   EADatasetDataLayer,
+  AnalysisTimeseriesEntry,
+  AnalysisMeta,
+  // TimelineDatasetAnalysis types
+  TimelineDatasetAnalysisIdle,
+  TimelineDatasetAnalysisLoading,
+  TimelineDatasetAnalysisError,
+  TimelineDatasetAnalysisSuccess,
+  TimelineDatasetAnalysis,
+  TimeseriesData,
+  // Settings and configuration
+  colorMapScale,
   DatasetSettings,
   DatasetMeta,
+  // VizDataset types
+  VizDatasetIdle,
+  VizDatasetLoading,
+  VizDatasetError,
+  VizDatasetSuccess,
+  VizDataset,
+  // TimelineDataset types
+  TimelineDatasetIdle,
+  TimelineDatasetLoading,
+  TimelineDatasetError,
+  TimelineDatasetSuccess,
   TimelineDataset,
-  TimelineDatasetAnalysis
+  // Additional types
+  TimelineDatasetForUrl,
+  DateRange,
+  ZoomTransformPlain
 } from '$components/exploration/types.d.ts';
 
 export type {
@@ -26,12 +53,32 @@ export type {
   StoryData,
   VedaData,
   // Exploration
-  VizDatasetSuccess,
+  TimeDensity,
   DatasetStatus,
-  VizDataset,
+  StacDatasetData,
   EADatasetDataLayer,
+  AnalysisTimeseriesEntry,
+  AnalysisMeta,
+  TimelineDatasetAnalysisIdle,
+  TimelineDatasetAnalysisLoading,
+  TimelineDatasetAnalysisError,
+  TimelineDatasetAnalysisSuccess,
+  TimelineDatasetAnalysis,
+  TimeseriesData,
+  colorMapScale,
   DatasetSettings,
   DatasetMeta,
+  VizDatasetIdle,
+  VizDatasetLoading,
+  VizDatasetError,
+  VizDatasetSuccess,
+  VizDataset,
+  TimelineDatasetIdle,
+  TimelineDatasetLoading,
+  TimelineDatasetError,
+  TimelineDatasetSuccess,
   TimelineDataset,
-  TimelineDatasetAnalysis
+  TimelineDatasetForUrl,
+  DateRange,
+  ZoomTransformPlain
 };

--- a/app/scripts/libs/types.ts
+++ b/app/scripts/libs/types.ts
@@ -1,5 +1,37 @@
+// Common/UI types
 import type { InternalNavLink } from '$components/common/types';
-import type { DatasetData, StoryData, VedaData } from '$types/veda';
 import type { NavItem } from '$components/common/page-header/types';
 
-export type { InternalNavLink, DatasetData, StoryData, VedaData, NavItem };
+// VEDA data types
+import type { DatasetData, StoryData, VedaData } from '$types/veda';
+
+// Exploration feature types
+import type {
+  VizDatasetSuccess,
+  DatasetStatus,
+  VizDataset,
+  EADatasetDataLayer,
+  DatasetSettings,
+  DatasetMeta,
+  TimelineDataset,
+  TimelineDatasetAnalysis
+} from '$components/exploration/types.d.ts';
+
+export type {
+  // Common/UI
+  InternalNavLink,
+  NavItem,
+  // VEDA
+  DatasetData,
+  StoryData,
+  VedaData,
+  // Exploration
+  VizDatasetSuccess,
+  DatasetStatus,
+  VizDataset,
+  EADatasetDataLayer,
+  DatasetSettings,
+  DatasetMeta,
+  TimelineDataset,
+  TimelineDatasetAnalysis
+};


### PR DESCRIPTION
Contributes to #1845

Forwards all exploration-related types from veda-ui library to enable downstream consumers like next-veda-ui to import them instead of copying locally.