### PR TITLE
fix: skip `sel=time=...` when passing parameters to titiler-cmr's /timeseries/statistics endpoint

### DIFF
--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -224,11 +224,16 @@ export async function requestCMRTimeseriesData({
     }
   });
   try {
+    // for the time series endpoint we let titiler-cmr handle any sel=time logic
+    const sourceParams = datasetData.sourceParams ?? {};
+    const { time, ...selWithoutTime } = sourceParams.sel ?? {};
+
     const paramsRaw = {
       datetime: `${userTzDate2utcString(start)}/${userTzDate2utcString(end)}`,
       step: datasetData.timeInterval,
       // temporal_mode: 'interval',
-      ...datasetData.sourceParams
+      ...sourceParams,
+      sel: selWithoutTime
     };
     const formattedParamString = formatTitilerParameter(paramsRaw);
 


### PR DESCRIPTION
**Related Ticket:** #1880

### Description of Changes
If a dataset has `sel: - time: {start_datetime}` in its parameters, do not pass that to the /timeseries endpoint. 

### Notes & Questions About Changes
- Corresponding API change in titiler-cmr: https://github.com/developmentseed/titiler-cmr/pull/76 to add a new `use_sel_for_datetime` parameter.

### Validation / Testing
We can test this on any of the TROPESS datasets (which they are adding to the AQ Portal here https://github.com/Air-Quality-Portal/veda-config-aq/pull/14)
