### PR TITLE
fix: remove Collecticons from EmptyHub and TimelineZoomControls components

### DIFF
--- a/app/scripts/components/common/empty-hub.deprecated.tsx
+++ b/app/scripts/components/common/empty-hub.deprecated.tsx
@@ -1,24 +1,28 @@
 import React, { ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { Icon } from '@trussworks/react-uswds';
+import { CollecticonPage } from '@devseed-ui/collecticons';
 import { themeVal } from '@devseed-ui/theme-provider';
 
 import { variableGlsp } from '$styles/variable-utils';
 
-function EmptyHub(props: { children: ReactNode }) {
+/**
+ * @deprecated This component uses collecticons. Use the main EmptyHub component instead.
+ * This file is kept for migration comparison purposes.
+ */
+function EmptyHubDeprecated(props: { children: ReactNode }) {
   const theme = useTheme();
 
   const { children, ...rest } = props;
 
   return (
     <div {...rest}>
-      <Icon.ContactPage size={6} color={theme.color!['base-400']} />
+      <CollecticonPage size='xxlarge' color={theme.color!['base-400']} />
       {children}
     </div>
   );
 }
 
-export default styled(EmptyHub)`
+export default styled(EmptyHubDeprecated)`
   max-width: 100%;
   grid-column: 1/-1;
   display: flex;

--- a/app/scripts/components/common/empty-hub.tsx
+++ b/app/scripts/components/common/empty-hub.tsx
@@ -12,7 +12,7 @@ function EmptyHub(props: { children: ReactNode }) {
 
   return (
     <div {...rest}>
-      <Icon.ContactPage size={6} color={theme.color!['base-400']} />
+      <Icon.ContactPage size={7} color={theme.color?.['base-400']} />
       {children}
     </div>
   );

--- a/app/scripts/components/exploration/components/timeline/timeline-zoom-controls.deprecated.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-zoom-controls.deprecated.tsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 import { useAtomValue } from 'jotai';
 import { scaleLog } from 'd3';
 
-import { Icon } from '@trussworks/react-uswds';
-
 import { clamp } from './timeline-utils';
 
+import { CollecticonMagnifierMinus } from '$components/common/icons-legacy/magnifier-minus';
+import { CollecticonMagnifierPlus } from '$components/common/icons-legacy/magnifier-plus';
 import { TipButton } from '$components/common/tip-button';
 import { SliderInput } from '$styles/range-slider';
 import {
@@ -32,7 +32,13 @@ interface TimelineZoomControlsProps {
   onZoom: (zoom: number) => void;
 }
 
-export function TimelineZoomControls(props: TimelineZoomControlsProps) {
+/**
+ * @deprecated This component uses collecticons. Use the main TimelineZoomControls component instead.
+ * This file is kept for migration comparison purposes.
+ */
+export function TimelineZoomControlsDeprecated(
+  props: TimelineZoomControlsProps
+) {
   const { onZoom } = props;
   const { k } = useAtomValue(zoomTransformAtom);
   const { k0, k1 } = useScaleFactors();
@@ -78,7 +84,7 @@ export function TimelineZoomControls(props: TimelineZoomControlsProps) {
         onClick={handleZoomOut}
         visuallyDisabled={currentZoom <= 0}
       >
-        <Icon.ZoomOut size={3} />
+        <CollecticonMagnifierMinus meaningful title='Zoom out timeline' />
       </TipButton>
       <SliderInput
         min={0}
@@ -99,7 +105,7 @@ export function TimelineZoomControls(props: TimelineZoomControlsProps) {
         onClick={handleZoomIn}
         visuallyDisabled={currentZoom >= 100}
       >
-        <Icon.ZoomIn size={3} />
+        <CollecticonMagnifierPlus meaningful title='Zoom in timeline' />
       </TipButton>
     </TimelineControlsSelf>
   );

--- a/app/scripts/components/exploration/components/timeline/timeline-zoom-controls.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-zoom-controls.tsx
@@ -78,7 +78,7 @@ export function TimelineZoomControls(props: TimelineZoomControlsProps) {
         onClick={handleZoomOut}
         visuallyDisabled={currentZoom <= 0}
       >
-        <Icon.ZoomOut size={3} />
+        <Icon.ZoomOut size={3} role='img' aria-label='Zoom out timeline' />
       </TipButton>
       <SliderInput
         min={0}
@@ -99,7 +99,7 @@ export function TimelineZoomControls(props: TimelineZoomControlsProps) {
         onClick={handleZoomIn}
         visuallyDisabled={currentZoom >= 100}
       >
-        <Icon.ZoomIn size={3} />
+        <Icon.ZoomIn size={3} role='img' aria-label='Zoom in timeline' />
       </TipButton>
     </TimelineControlsSelf>
   );

--- a/storybook/src/stories/documentation/icon-guidelines.stories.tsx
+++ b/storybook/src/stories/documentation/icon-guidelines.stories.tsx
@@ -35,74 +35,12 @@ import {
   CalendarMinusIcon,
   DropIcon
 } from '$components/common/custom-icon';
-import { TipButton } from '$components/common/tip-button';
 
-// Example components for migration demo
-const LegacyZoomControls: React.FC = () => (
-  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-    <TipButton
-      tipContent='Zoom out'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom out */
-      }}
-    >
-      <CollecticonMagnifierMinus meaningful title='Zoom out' />
-    </TipButton>
-    <input
-      type='range'
-      min='0'
-      max='100'
-      defaultValue='50'
-      style={{ width: '100px' }}
-    />
-    <TipButton
-      tipContent='Zoom in'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom in */
-      }}
-    >
-      <CollecticonMagnifierPlus meaningful title='Zoom in' />
-    </TipButton>
-  </div>
-);
-
-const MigratedZoomControls: React.FC = () => (
-  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
-    <TipButton
-      tipContent='Zoom out'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom out */
-      }}
-    >
-      <Icon.ZoomOut size={3} />
-    </TipButton>
-    <input
-      type='range'
-      min='0'
-      max='100'
-      defaultValue='50'
-      style={{ width: '100px' }}
-    />
-    <TipButton
-      tipContent='Zoom in'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom in */
-      }}
-    >
-      <Icon.ZoomIn size={3} />
-    </TipButton>
-  </div>
-);
-
-// Component 1: Migration Guidance
-const MigrationGuidance: React.FC = () => {
+// Icon Guidelines Component
+const IconGuidelines: React.FC = () => {
   return (
     <div style={{ padding: '20px', maxWidth: '800px' }}>
-      <h1>Icons Guide</h1>
+      <h1>Icon Guidelines</h1>
 
       <div
         style={{
@@ -207,7 +145,7 @@ import { DropIcon } from '$components/common/custom-icon';
       <ul>
         <li>
           Create both legacy and migrated versions in the{' '}
-          <strong>Component Examples</strong>
+          <strong>Migration Examples</strong> story
         </li>
         <li>Compare side-by-side for visual consistency</li>
         <li>Create PR with comparison for team review</li>
@@ -297,7 +235,7 @@ import { DropIcon } from '$components/common/custom-icon';
             In the copy, replace collecticons with USWDS icons using the Icon
             Reference
           </li>
-          <li>Add both versions to the Component Examples for comparison</li>
+          <li>Add both versions to the Migration Examples for comparison</li>
           <li>Create PR with both versions side-by-side</li>
           <li>Get visual approval from team</li>
           <li>Replace original component and cleanup</li>
@@ -307,7 +245,7 @@ import { DropIcon } from '$components/common/custom-icon';
   );
 };
 
-// Component 2: Icon Mapping Table
+// Icon Mapping Table Component
 const IconMappingTable: React.FC = () => {
   return (
     <div style={{ padding: '20px' }}>
@@ -720,154 +658,14 @@ const IconMappingTable: React.FC = () => {
   );
 };
 
-// Component 3: Component Sandbox
-const MigrationSandbox: React.FC = () => {
-  return (
-    <div style={{ padding: '20px' }}>
-      <h1>Component Examples</h1>
-      <p>
-        Test components with migrated icons side-by-side before creating PRs.
-        This tool helps ensure visual consistency and proper functionality
-        during the migration process.
-      </p>
-
-      <div
-        style={{
-          border: '1px solid #ccc',
-          padding: '16px',
-          marginBottom: '24px',
-          backgroundColor: '#f9f9f9'
-        }}
-      >
-        <h3>🔧 How to Use This Section</h3>
-        <ol>
-          <li>Copy your existing component and create a migrated version</li>
-          <li>
-            Replace collecticons with USWDS icons using the Icon Reference table
-          </li>
-          <li>Add both versions to the comparison grid below</li>
-          <li>Test functionality and visual consistency</li>
-          <li>Create PR with both versions for team review</li>
-        </ol>
-      </div>
-
-      <h2>Example: Zoom Controls Migration</h2>
-      <p>
-        This example shows the migration of TimelineZoomControls component from
-        exploration/timeline, demonstrating the before/after comparison process.
-      </p>
-
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: '1fr 1fr',
-          gap: '24px',
-          margin: '24px 0'
-        }}
-      >
-        <div
-          style={{
-            padding: '20px',
-            border: '2px solid #ef4444',
-            borderRadius: '8px',
-            backgroundColor: '#fef2f2'
-          }}
-        >
-          <h3 style={{ margin: '0 0 16px 0', color: '#991b1b' }}>
-            Before (Legacy)
-          </h3>
-          <div
-            style={{
-              marginBottom: '16px',
-              padding: '16px',
-              backgroundColor: '#ffffff',
-              borderRadius: '4px'
-            }}
-          >
-            <LegacyZoomControls />
-          </div>
-          <div
-            style={{
-              fontSize: '12px',
-              color: '#991b1b',
-              fontFamily: 'monospace'
-            }}
-          >
-            Uses CollecticonMagnifierPlus/Minus
-          </div>
-        </div>
-
-        <div
-          style={{
-            padding: '20px',
-            border: '2px solid #22c55e',
-            borderRadius: '8px',
-            backgroundColor: '#f0fdf4'
-          }}
-        >
-          <h3 style={{ margin: '0 0 16px 0', color: '#166534' }}>
-            After (Migrated)
-          </h3>
-          <div
-            style={{
-              marginBottom: '16px',
-              padding: '16px',
-              backgroundColor: '#ffffff',
-              borderRadius: '4px'
-            }}
-          >
-            <MigratedZoomControls />
-          </div>
-          <div
-            style={{
-              fontSize: '12px',
-              color: '#166534',
-              fontFamily: 'monospace'
-            }}
-          >
-            Uses Icon.ZoomIn/ZoomOut
-          </div>
-        </div>
-      </div>
-
-      <h2>Add Your Component Comparison</h2>
-      <p>
-        Copy the grid structure above to compare your before/after components.
-        Replace the placeholder content with your actual components.
-      </p>
-
-      <div
-        style={{
-          border: '2px dashed #d1d5db',
-          padding: '32px',
-          margin: '24px 0',
-          textAlign: 'center',
-          borderRadius: '8px',
-          backgroundColor: '#f9fafb'
-        }}
-      >
-        <div
-          style={{ color: '#6b7280', fontSize: '16px', marginBottom: '8px' }}
-        >
-          📝 Your Component Comparison
-        </div>
-        <div style={{ color: '#9ca3af', fontSize: '14px' }}>
-          Copy the grid structure above and replace this placeholder with your
-          before/after components
-        </div>
-      </div>
-    </div>
-  );
-};
-
 const meta: Meta = {
-  title: 'Documentation/Icons',
+  title: 'Documentation/Icon Guidelines',
   parameters: {
     docs: {
       description: {
         component:
-          'Guide for using icons in VEDA UI. Currently migrating from @devseed-ui/collecticons to USWDS icons. ' +
-          'Includes migration strategy, comprehensive icon mapping reference, component examples, and best practices.'
+          'Guidelines and reference for using icons in VEDA UI. Includes migration strategy from @devseed-ui/collecticons to USWDS icons, ' +
+          'comprehensive icon mapping reference, and best practices for icon usage.'
       }
     }
   }
@@ -876,13 +674,9 @@ const meta: Meta = {
 export default meta;
 
 export const Guidelines: StoryObj = {
-  render: () => <MigrationGuidance />
+  render: () => <IconGuidelines />
 };
 
 export const IconReference: StoryObj = {
   render: () => <IconMappingTable />
-};
-
-export const ComponentExamples: StoryObj = {
-  render: () => <MigrationSandbox />
 };

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 import { ThemeProvider } from 'styled-components';
 import { TimelineZoomControls } from '$components/exploration/components/timeline/timeline-zoom-controls';
 import { TimelineZoomControlsDeprecated } from '$components/exploration/components/timeline/timeline-zoom-controls.deprecated';
+import EmptyHub from '$components/common/empty-hub';
+import EmptyHubDeprecated from '$components/common/empty-hub.deprecated';
 
 // Styled Components
 const Container = styled.div`
@@ -191,6 +193,8 @@ const ZoomControlsPair = createComponentPair(
   TimelineZoomControls
 );
 
+const EmptyHubPair = createComponentPair(EmptyHubDeprecated, EmptyHub);
+
 // Migration examples data
 interface MigrationExampleData {
   title: string;
@@ -212,6 +216,19 @@ const MIGRATION_EXAMPLES: MigrationExampleData[] = [
       'Icons: CollecticonMagnifierPlus, CollecticonMagnifierMinus (from timeline-zoom-controls.deprecated.tsx)',
     migratedIcons:
       'Icons: Icon.ZoomIn, Icon.ZoomOut (from timeline-zoom-controls.tsx)'
+  },
+  {
+    title: 'Empty Hub Migration',
+    description:
+      'Migration of empty state component with document icon. Demonstrates simple icon replacement and theme integration.',
+    legacyComponent: (
+      <EmptyHubPair.Legacy>No content available</EmptyHubPair.Legacy>
+    ),
+    migratedComponent: (
+      <EmptyHubPair.Migrated>No content available</EmptyHubPair.Migrated>
+    ),
+    legacyIcons: 'Icons: CollecticonPage (from empty-hub.deprecated.tsx)',
+    migratedIcons: 'Icons: Icon.ContactPage (from empty-hub.tsx)'
   }
   // Add more examples here as needed
 ];

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -1,12 +1,9 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Icon } from '@trussworks/react-uswds';
 import styled from 'styled-components';
-import {
-  CollecticonMagnifierMinus,
-  CollecticonMagnifierPlus
-} from '$components/common/icons-legacy';
-import { TipButton } from '$components/common/tip-button';
+import { ThemeProvider } from 'styled-components';
+import { TimelineZoomControls } from '$components/exploration/components/timeline/timeline-zoom-controls';
+import { TimelineZoomControlsDeprecated } from '$components/exploration/components/timeline/timeline-zoom-controls.deprecated';
 
 // Styled Components
 const Container = styled.div`
@@ -95,19 +92,48 @@ const PlaceholderCode = styled.div`
   display: inline-block;
 `;
 
-const ZoomControlsContainer = styled.div`
-  display: flex;
-  gap: 8px;
-  align-items: center;
-`;
-
-const RangeSlider = styled.input`
-  width: 100px;
-`;
-
 const SectionWrapper = styled.div`
   margin-bottom: 48px;
 `;
+
+// Mock providers for components
+const mockTheme = {
+  color: {
+    'base-400': '#6b7280',
+    'base-300': '#d1d5db'
+  }
+};
+
+/**
+ * Generic higher-order component that wraps components with mock providers
+ * needed for Storybook rendering (ThemeProvider, etc.)
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const withMockProviders = <T extends Record<string, any>>(
+  Component: React.ComponentType<T>
+) => {
+  const WrappedComponent = (props: T) => (
+    <ThemeProvider theme={mockTheme}>
+      <Component {...props} />
+    </ThemeProvider>
+  );
+  WrappedComponent.displayName = `withMockProviders(${
+    Component.displayName || Component.name
+  })`;
+  return WrappedComponent;
+};
+
+/**
+ * Helper function to create component comparison pairs for migration examples
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const createComponentPair = <T extends Record<string, any>>(
+  LegacyComponent: React.ComponentType<T>,
+  MigratedComponent: React.ComponentType<T>
+) => ({
+  Legacy: withMockProviders(LegacyComponent),
+  Migrated: withMockProviders(MigratedComponent)
+});
 
 // Reusable Components
 interface InfoSectionProps {
@@ -159,54 +185,59 @@ const ComparisonExample: React.FC<ComparisonExampleProps> = ({
   </SectionWrapper>
 );
 
-// Example components for migration demo
-const LegacyZoomControls: React.FC = () => (
-  <ZoomControlsContainer>
-    <TipButton
-      tipContent='Zoom out'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom out */
-      }}
-    >
-      <CollecticonMagnifierMinus meaningful title='Zoom out' />
-    </TipButton>
-    <RangeSlider type='range' min='0' max='100' defaultValue='50' />
-    <TipButton
-      tipContent='Zoom in'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom in */
-      }}
-    >
-      <CollecticonMagnifierPlus meaningful title='Zoom in' />
-    </TipButton>
-  </ZoomControlsContainer>
+// Component pairs for migration demo
+const ZoomControlsPair = createComponentPair(
+  TimelineZoomControlsDeprecated,
+  TimelineZoomControls
 );
 
-const MigratedZoomControls: React.FC = () => (
-  <ZoomControlsContainer>
-    <TipButton
-      tipContent='Zoom out'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom out */
-      }}
-    >
-      <Icon.ZoomOut size={3} />
-    </TipButton>
-    <RangeSlider type='range' min='0' max='100' defaultValue='50' />
-    <TipButton
-      tipContent='Zoom in'
-      fitting='skinny'
-      onClick={() => {
-        /* zoom in */
-      }}
-    >
-      <Icon.ZoomIn size={3} />
-    </TipButton>
-  </ZoomControlsContainer>
-);
+// Migration examples data
+interface MigrationExampleData {
+  title: string;
+  description: string;
+  legacyComponent: React.ReactNode;
+  migratedComponent: React.ReactNode;
+  legacyIcons: string;
+  migratedIcons: string;
+}
+
+const MIGRATION_EXAMPLES: MigrationExampleData[] = [
+  {
+    title: 'Zoom Controls Migration',
+    description:
+      'Migration of interactive zoom controls with range slider and action buttons. Demonstrates proper icon sizing and button integration.',
+    legacyComponent: <ZoomControlsPair.Legacy onZoom={() => {}} />,
+    migratedComponent: <ZoomControlsPair.Migrated onZoom={() => {}} />,
+    legacyIcons:
+      'Icons: CollecticonMagnifierPlus, CollecticonMagnifierMinus (from timeline-zoom-controls.deprecated.tsx)',
+    migratedIcons:
+      'Icons: Icon.ZoomIn, Icon.ZoomOut (from timeline-zoom-controls.tsx)'
+  }
+  // Add more examples here as needed
+];
+
+// Constants
+const MIGRATION_STEPS = [
+  'Copy your existing component and create a migrated version',
+  'Replace collecticons with USWDS icons using the Icon Reference table',
+  'Add both versions to the comparison grid below',
+  'Test functionality and visual consistency',
+  'Create PR with both versions for team review'
+];
+
+const PLACEHOLDER_CONTENT = {
+  title: '📝 Your Component Comparison',
+  subtitle:
+    'Copy the grid structure above and replace this placeholder with your before/after components',
+  code: '<YourLegacyComponent /> → <YourMigratedComponent />'
+};
+
+// Example: To add a new component comparison, use:
+// const ButtonGroupPair = createComponentPair(
+//   ButtonGroupDeprecated,
+//   ButtonGroup
+// );
+// Then use <ButtonGroupPair.Legacy {...props} /> and <ButtonGroupPair.Migrated {...props} />
 
 // Migration Examples Component
 const MigrationExamplesComponent: React.FC = () => {
@@ -222,24 +253,23 @@ const MigrationExamplesComponent: React.FC = () => {
 
       <InfoSection title='🔧 How to Use This Section'>
         <ol>
-          <li>Copy your existing component and create a migrated version</li>
-          <li>
-            Replace collecticons with USWDS icons using the Icon Reference table
-          </li>
-          <li>Add both versions to the comparison grid below</li>
-          <li>Test functionality and visual consistency</li>
-          <li>Create PR with both versions for team review</li>
+          {MIGRATION_STEPS.map((step) => (
+            <li key={step}>{step}</li>
+          ))}
         </ol>
       </InfoSection>
 
-      <ComparisonExample
-        title='Zoom Controls Migration'
-        description='Migration of interactive zoom controls with range slider and action buttons. Demonstrates proper icon sizing and button integration.'
-        legacyComponent={<LegacyZoomControls />}
-        migratedComponent={<MigratedZoomControls />}
-        legacyIcons='Icons: CollecticonMagnifierPlus, CollecticonMagnifierMinus'
-        migratedIcons='Icons: Icon.ZoomIn, Icon.ZoomOut'
-      />
+      {MIGRATION_EXAMPLES.map((example) => (
+        <ComparisonExample
+          key={example.title}
+          title={example.title}
+          description={example.description}
+          legacyComponent={example.legacyComponent}
+          migratedComponent={example.migratedComponent}
+          legacyIcons={example.legacyIcons}
+          migratedIcons={example.migratedIcons}
+        />
+      ))}
 
       {/* Add Your Component Section */}
       <SectionWrapper>
@@ -250,14 +280,11 @@ const MigrationExamplesComponent: React.FC = () => {
         </p>
 
         <PlaceholderBox>
-          <PlaceholderTitle>📝 Your Component Comparison</PlaceholderTitle>
+          <PlaceholderTitle>{PLACEHOLDER_CONTENT.title}</PlaceholderTitle>
           <PlaceholderSubtitle>
-            Copy the grid structure above and replace this placeholder with your
-            before/after components
+            {PLACEHOLDER_CONTENT.subtitle}
           </PlaceholderSubtitle>
-          <PlaceholderCode>
-            &lt;YourLegacyComponent /&gt; → &lt;YourMigratedComponent /&gt;
-          </PlaceholderCode>
+          <PlaceholderCode>{PLACEHOLDER_CONTENT.code}</PlaceholderCode>
         </PlaceholderBox>
       </SectionWrapper>
     </Container>

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Icon } from '@trussworks/react-uswds';
+import {
+  CollecticonMagnifierMinus,
+  CollecticonMagnifierPlus
+} from '$components/common/icons-legacy';
+import { TipButton } from '$components/common/tip-button';
+
+// Example components for migration demo
+const LegacyZoomControls: React.FC = () => (
+  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+    <TipButton
+      tipContent='Zoom out'
+      fitting='skinny'
+      onClick={() => {
+        /* zoom out */
+      }}
+    >
+      <CollecticonMagnifierMinus meaningful title='Zoom out' />
+    </TipButton>
+    <input
+      type='range'
+      min='0'
+      max='100'
+      defaultValue='50'
+      style={{ width: '100px' }}
+    />
+    <TipButton
+      tipContent='Zoom in'
+      fitting='skinny'
+      onClick={() => {
+        /* zoom in */
+      }}
+    >
+      <CollecticonMagnifierPlus meaningful title='Zoom in' />
+    </TipButton>
+  </div>
+);
+
+const MigratedZoomControls: React.FC = () => (
+  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+    <TipButton
+      tipContent='Zoom out'
+      fitting='skinny'
+      onClick={() => {
+        /* zoom out */
+      }}
+    >
+      <Icon.ZoomOut size={3} />
+    </TipButton>
+    <input
+      type='range'
+      min='0'
+      max='100'
+      defaultValue='50'
+      style={{ width: '100px' }}
+    />
+    <TipButton
+      tipContent='Zoom in'
+      fitting='skinny'
+      onClick={() => {
+        /* zoom in */
+      }}
+    >
+      <Icon.ZoomIn size={3} />
+    </TipButton>
+  </div>
+);
+
+// Migration Examples Component
+const MigrationExamplesComponent: React.FC = () => {
+  return (
+    <div style={{ padding: '20px', maxWidth: '1200px' }}>
+      <h1>Collecticons Migration Examples</h1>
+      <p>
+        Interactive examples showing the migration from collecticons to USWDS
+        icons. Compare legacy and migrated components side-by-side to ensure
+        visual consistency and proper functionality during the migration
+        process.
+      </p>
+
+      <div
+        style={{
+          border: '1px solid #ccc',
+          padding: '16px',
+          marginBottom: '32px',
+          backgroundColor: '#f9f9f9'
+        }}
+      >
+        <h3>🔧 How to Use This Section</h3>
+        <ol>
+          <li>Copy your existing component and create a migrated version</li>
+          <li>
+            Replace collecticons with USWDS icons using the Icon Reference table
+          </li>
+          <li>Add both versions to the comparison grid below</li>
+          <li>Test functionality and visual consistency</li>
+          <li>Create PR with both versions for team review</li>
+        </ol>
+      </div>
+
+      {/* Zoom Controls Example */}
+      <div style={{ marginBottom: '48px' }}>
+        <h2>Zoom Controls Migration</h2>
+        <p>
+          Migration of interactive zoom controls with range slider and action
+          buttons. Demonstrates proper icon sizing and button integration.
+        </p>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr',
+            gap: '32px',
+            margin: '24px 0'
+          }}
+        >
+          <div
+            style={{
+              padding: '24px',
+              border: '2px solid #ef4444',
+              borderRadius: '12px',
+              backgroundColor: '#fef2f2',
+              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+            }}
+          >
+            <h3 style={{ margin: '0 0 16px 0', color: '#991b1b' }}>
+              Before (Legacy)
+            </h3>
+            <div
+              style={{
+                marginBottom: '16px',
+                padding: '20px',
+                backgroundColor: '#ffffff',
+                borderRadius: '8px',
+                border: '1px solid #fecaca'
+              }}
+            >
+              <LegacyZoomControls />
+            </div>
+            <div
+              style={{
+                fontSize: '12px',
+                color: '#991b1b',
+                fontFamily: 'monospace',
+                backgroundColor: '#fef2f2',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                border: '1px solid #fecaca'
+              }}
+            >
+              <strong>Icons:</strong> CollecticonMagnifierPlus,
+              CollecticonMagnifierMinus
+            </div>
+          </div>
+
+          <div
+            style={{
+              padding: '24px',
+              border: '2px solid #22c55e',
+              borderRadius: '12px',
+              backgroundColor: '#f0fdf4',
+              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
+            }}
+          >
+            <h3 style={{ margin: '0 0 16px 0', color: '#166534' }}>
+              After (Migrated)
+            </h3>
+            <div
+              style={{
+                marginBottom: '16px',
+                padding: '20px',
+                backgroundColor: '#ffffff',
+                borderRadius: '8px',
+                border: '1px solid #bbf7d0'
+              }}
+            >
+              <MigratedZoomControls />
+            </div>
+            <div
+              style={{
+                fontSize: '12px',
+                color: '#166534',
+                fontFamily: 'monospace',
+                backgroundColor: '#f0fdf4',
+                padding: '8px 12px',
+                borderRadius: '6px',
+                border: '1px solid #bbf7d0'
+              }}
+            >
+              <strong>Icons:</strong> Icon.ZoomIn, Icon.ZoomOut
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Add Your Component Section */}
+      <div style={{ marginBottom: '48px' }}>
+        <h2>Add Your Component Comparison</h2>
+        <p>
+          Copy the grid structure above to compare your before/after components.
+          Replace the placeholder content with your actual components.
+        </p>
+
+        <div
+          style={{
+            border: '2px dashed #d1d5db',
+            padding: '48px',
+            margin: '32px 0',
+            textAlign: 'center',
+            borderRadius: '12px',
+            backgroundColor: '#f9fafb'
+          }}
+        >
+          <div
+            style={{ color: '#6b7280', fontSize: '18px', marginBottom: '12px' }}
+          >
+            📝 Your Component Comparison
+          </div>
+          <div
+            style={{ color: '#9ca3af', fontSize: '16px', marginBottom: '16px' }}
+          >
+            Copy the grid structure above and replace this placeholder with your
+            before/after components
+          </div>
+          <div
+            style={{
+              fontSize: '14px',
+              color: '#6b7280',
+              fontFamily: 'monospace',
+              backgroundColor: '#f3f4f6',
+              padding: '8px 16px',
+              borderRadius: '6px',
+              display: 'inline-block'
+            }}
+          >
+            &lt;YourLegacyComponent /&gt; → &lt;YourMigratedComponent /&gt;
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const meta: Meta = {
+  title: 'Documentation/Migration Examples',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Interactive examples and comparisons for migrating from @devseed-ui/collecticons to USWDS icons. ' +
+          'Includes side-by-side comparisons, migration patterns, and component examples to ensure visual consistency.'
+      }
+    }
+  }
+};
+
+export default meta;
+
+export const MigrationExamples: StoryObj = {
+  render: () => <MigrationExamplesComponent />
+};

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -1,15 +1,167 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Icon } from '@trussworks/react-uswds';
+import styled from 'styled-components';
 import {
   CollecticonMagnifierMinus,
   CollecticonMagnifierPlus
 } from '$components/common/icons-legacy';
 import { TipButton } from '$components/common/tip-button';
 
+// Styled Components
+const Container = styled.div`
+  padding: 20px;
+  max-width: 1200px;
+`;
+
+const InfoBox = styled.div`
+  border: 1px solid #ccc;
+  padding: 16px;
+  margin-bottom: 32px;
+  background-color: #f9f9f9;
+`;
+
+const ComparisonGrid = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  margin: 24px 0;
+`;
+
+const ComparisonCard = styled.div<{ variant: 'legacy' | 'migrated' }>`
+  padding: 24px;
+  border: 2px solid
+    ${(props) => (props.variant === 'legacy' ? '#ef4444' : '#22c55e')};
+  border-radius: 12px;
+  background-color: ${(props) =>
+    props.variant === 'legacy' ? '#fef2f2' : '#f0fdf4'};
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+`;
+
+const ComparisonTitle = styled.h3<{ variant: 'legacy' | 'migrated' }>`
+  margin: 0 0 16px 0;
+  color: ${(props) => (props.variant === 'legacy' ? '#991b1b' : '#166534')};
+`;
+
+const ComponentPreview = styled.div<{ variant: 'legacy' | 'migrated' }>`
+  margin-bottom: 16px;
+  padding: 20px;
+  background-color: #ffffff;
+  border-radius: 8px;
+  border: 1px solid
+    ${(props) => (props.variant === 'legacy' ? '#fecaca' : '#bbf7d0')};
+`;
+
+const IconInfo = styled.div<{ variant: 'legacy' | 'migrated' }>`
+  font-size: 12px;
+  color: ${(props) => (props.variant === 'legacy' ? '#991b1b' : '#166534')};
+  font-family: monospace;
+  background-color: ${(props) =>
+    props.variant === 'legacy' ? '#fef2f2' : '#f0fdf4'};
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid
+    ${(props) => (props.variant === 'legacy' ? '#fecaca' : '#bbf7d0')};
+`;
+
+const PlaceholderBox = styled.div`
+  border: 2px dashed #d1d5db;
+  padding: 48px;
+  margin: 32px 0;
+  text-align: center;
+  border-radius: 12px;
+  background-color: #f9fafb;
+`;
+
+const PlaceholderTitle = styled.div`
+  color: #6b7280;
+  font-size: 18px;
+  margin-bottom: 12px;
+`;
+
+const PlaceholderSubtitle = styled.div`
+  color: #9ca3af;
+  font-size: 16px;
+  margin-bottom: 16px;
+`;
+
+const PlaceholderCode = styled.div`
+  font-size: 14px;
+  color: #6b7280;
+  font-family: monospace;
+  background-color: #f3f4f6;
+  padding: 8px 16px;
+  border-radius: 6px;
+  display: inline-block;
+`;
+
+const ZoomControlsContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+const RangeSlider = styled.input`
+  width: 100px;
+`;
+
+const SectionWrapper = styled.div`
+  margin-bottom: 48px;
+`;
+
+// Reusable Components
+interface InfoSectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+const InfoSection: React.FC<InfoSectionProps> = ({ title, children }) => (
+  <InfoBox>
+    <h3>{title}</h3>
+    {children}
+  </InfoBox>
+);
+
+interface ComparisonExampleProps {
+  title: string;
+  description: string;
+  legacyComponent: React.ReactNode;
+  migratedComponent: React.ReactNode;
+  legacyIcons: string;
+  migratedIcons: string;
+}
+
+const ComparisonExample: React.FC<ComparisonExampleProps> = ({
+  title,
+  description,
+  legacyComponent,
+  migratedComponent,
+  legacyIcons,
+  migratedIcons
+}) => (
+  <SectionWrapper>
+    <h2>{title}</h2>
+    <p>{description}</p>
+    <ComparisonGrid>
+      <ComparisonCard variant='legacy'>
+        <ComparisonTitle variant='legacy'>Before (Legacy)</ComparisonTitle>
+        <ComponentPreview variant='legacy'>{legacyComponent}</ComponentPreview>
+        <IconInfo variant='legacy'>{legacyIcons}</IconInfo>
+      </ComparisonCard>
+      <ComparisonCard variant='migrated'>
+        <ComparisonTitle variant='migrated'>After (Migrated)</ComparisonTitle>
+        <ComponentPreview variant='migrated'>
+          {migratedComponent}
+        </ComponentPreview>
+        <IconInfo variant='migrated'>{migratedIcons}</IconInfo>
+      </ComparisonCard>
+    </ComparisonGrid>
+  </SectionWrapper>
+);
+
 // Example components for migration demo
 const LegacyZoomControls: React.FC = () => (
-  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+  <ZoomControlsContainer>
     <TipButton
       tipContent='Zoom out'
       fitting='skinny'
@@ -19,13 +171,7 @@ const LegacyZoomControls: React.FC = () => (
     >
       <CollecticonMagnifierMinus meaningful title='Zoom out' />
     </TipButton>
-    <input
-      type='range'
-      min='0'
-      max='100'
-      defaultValue='50'
-      style={{ width: '100px' }}
-    />
+    <RangeSlider type='range' min='0' max='100' defaultValue='50' />
     <TipButton
       tipContent='Zoom in'
       fitting='skinny'
@@ -35,11 +181,11 @@ const LegacyZoomControls: React.FC = () => (
     >
       <CollecticonMagnifierPlus meaningful title='Zoom in' />
     </TipButton>
-  </div>
+  </ZoomControlsContainer>
 );
 
 const MigratedZoomControls: React.FC = () => (
-  <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+  <ZoomControlsContainer>
     <TipButton
       tipContent='Zoom out'
       fitting='skinny'
@@ -49,13 +195,7 @@ const MigratedZoomControls: React.FC = () => (
     >
       <Icon.ZoomOut size={3} />
     </TipButton>
-    <input
-      type='range'
-      min='0'
-      max='100'
-      defaultValue='50'
-      style={{ width: '100px' }}
-    />
+    <RangeSlider type='range' min='0' max='100' defaultValue='50' />
     <TipButton
       tipContent='Zoom in'
       fitting='skinny'
@@ -65,13 +205,13 @@ const MigratedZoomControls: React.FC = () => (
     >
       <Icon.ZoomIn size={3} />
     </TipButton>
-  </div>
+  </ZoomControlsContainer>
 );
 
 // Migration Examples Component
 const MigrationExamplesComponent: React.FC = () => {
   return (
-    <div style={{ padding: '20px', maxWidth: '1200px' }}>
+    <Container>
       <h1>Collecticons Migration Examples</h1>
       <p>
         Interactive examples showing the migration from collecticons to USWDS
@@ -80,15 +220,7 @@ const MigrationExamplesComponent: React.FC = () => {
         process.
       </p>
 
-      <div
-        style={{
-          border: '1px solid #ccc',
-          padding: '16px',
-          marginBottom: '32px',
-          backgroundColor: '#f9f9f9'
-        }}
-      >
-        <h3>🔧 How to Use This Section</h3>
+      <InfoSection title='🔧 How to Use This Section'>
         <ol>
           <li>Copy your existing component and create a migrated version</li>
           <li>
@@ -98,148 +230,37 @@ const MigrationExamplesComponent: React.FC = () => {
           <li>Test functionality and visual consistency</li>
           <li>Create PR with both versions for team review</li>
         </ol>
-      </div>
+      </InfoSection>
 
-      {/* Zoom Controls Example */}
-      <div style={{ marginBottom: '48px' }}>
-        <h2>Zoom Controls Migration</h2>
-        <p>
-          Migration of interactive zoom controls with range slider and action
-          buttons. Demonstrates proper icon sizing and button integration.
-        </p>
-
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr 1fr',
-            gap: '32px',
-            margin: '24px 0'
-          }}
-        >
-          <div
-            style={{
-              padding: '24px',
-              border: '2px solid #ef4444',
-              borderRadius: '12px',
-              backgroundColor: '#fef2f2',
-              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
-            }}
-          >
-            <h3 style={{ margin: '0 0 16px 0', color: '#991b1b' }}>
-              Before (Legacy)
-            </h3>
-            <div
-              style={{
-                marginBottom: '16px',
-                padding: '20px',
-                backgroundColor: '#ffffff',
-                borderRadius: '8px',
-                border: '1px solid #fecaca'
-              }}
-            >
-              <LegacyZoomControls />
-            </div>
-            <div
-              style={{
-                fontSize: '12px',
-                color: '#991b1b',
-                fontFamily: 'monospace',
-                backgroundColor: '#fef2f2',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid #fecaca'
-              }}
-            >
-              <strong>Icons:</strong> CollecticonMagnifierPlus,
-              CollecticonMagnifierMinus
-            </div>
-          </div>
-
-          <div
-            style={{
-              padding: '24px',
-              border: '2px solid #22c55e',
-              borderRadius: '12px',
-              backgroundColor: '#f0fdf4',
-              boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.1)'
-            }}
-          >
-            <h3 style={{ margin: '0 0 16px 0', color: '#166534' }}>
-              After (Migrated)
-            </h3>
-            <div
-              style={{
-                marginBottom: '16px',
-                padding: '20px',
-                backgroundColor: '#ffffff',
-                borderRadius: '8px',
-                border: '1px solid #bbf7d0'
-              }}
-            >
-              <MigratedZoomControls />
-            </div>
-            <div
-              style={{
-                fontSize: '12px',
-                color: '#166534',
-                fontFamily: 'monospace',
-                backgroundColor: '#f0fdf4',
-                padding: '8px 12px',
-                borderRadius: '6px',
-                border: '1px solid #bbf7d0'
-              }}
-            >
-              <strong>Icons:</strong> Icon.ZoomIn, Icon.ZoomOut
-            </div>
-          </div>
-        </div>
-      </div>
+      <ComparisonExample
+        title='Zoom Controls Migration'
+        description='Migration of interactive zoom controls with range slider and action buttons. Demonstrates proper icon sizing and button integration.'
+        legacyComponent={<LegacyZoomControls />}
+        migratedComponent={<MigratedZoomControls />}
+        legacyIcons='Icons: CollecticonMagnifierPlus, CollecticonMagnifierMinus'
+        migratedIcons='Icons: Icon.ZoomIn, Icon.ZoomOut'
+      />
 
       {/* Add Your Component Section */}
-      <div style={{ marginBottom: '48px' }}>
+      <SectionWrapper>
         <h2>Add Your Component Comparison</h2>
         <p>
           Copy the grid structure above to compare your before/after components.
           Replace the placeholder content with your actual components.
         </p>
 
-        <div
-          style={{
-            border: '2px dashed #d1d5db',
-            padding: '48px',
-            margin: '32px 0',
-            textAlign: 'center',
-            borderRadius: '12px',
-            backgroundColor: '#f9fafb'
-          }}
-        >
-          <div
-            style={{ color: '#6b7280', fontSize: '18px', marginBottom: '12px' }}
-          >
-            📝 Your Component Comparison
-          </div>
-          <div
-            style={{ color: '#9ca3af', fontSize: '16px', marginBottom: '16px' }}
-          >
+        <PlaceholderBox>
+          <PlaceholderTitle>📝 Your Component Comparison</PlaceholderTitle>
+          <PlaceholderSubtitle>
             Copy the grid structure above and replace this placeholder with your
             before/after components
-          </div>
-          <div
-            style={{
-              fontSize: '14px',
-              color: '#6b7280',
-              fontFamily: 'monospace',
-              backgroundColor: '#f3f4f6',
-              padding: '8px 16px',
-              borderRadius: '6px',
-              display: 'inline-block'
-            }}
-          >
+          </PlaceholderSubtitle>
+          <PlaceholderCode>
             &lt;YourLegacyComponent /&gt; → &lt;YourMigratedComponent /&gt;
-          </div>
-        </div>
-      </div>
-    </div>
+          </PlaceholderCode>
+        </PlaceholderBox>
+      </SectionWrapper>
+    </Container>
   );
 };
 


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-ui/issues/1814.

### Changes
- Refactored migration examples stories with styled-components and reusable components
- Added `withMockProviders` HOC and `createComponentPair` helper
- Introduced `.deprecated.tsx` pattern for side-by-side comparison in Storybook
- Migrated EmptyHub and TimelineZoomControls to USWDS icons with accessibility (role="img", aria-label)

### How to give feedback
- Run Storybook locally and visit Documentation/Migration Examples to compare legacy vs migrated components

### Notes
- `.deprecated.tsx` files are temporary and will be removed after migration
- Migration stories are only for reference and will be cleaned up later

### Preview

![preview](https://github.com/user-attachments/assets/b15aaab4-2a2c-4c0d-b2d5-c30278c30103)


Ready for review.
