### PR TITLE
fix: migrate scrollytelling from CollecticonCircleXmark to USWDS

### DIFF
--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -12,11 +12,11 @@ import styled, { css } from 'styled-components';
 // Avoid error: node_modules/date-fns/esm/index.js does not export 'default'
 import scrollama from 'scrollama';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
-import { CollecticonCircleXmark } from '@devseed-ui/collecticons';
 
 import { MapRef } from 'react-map-gl';
 import { BlockErrorBoundary } from '..';
 import { ChapterProps, ScrollyChapter, validateChapter } from './chapter';
+import MapErrorMessage from './map-error-message';
 import { ProjectionOptions, VedaData } from '$types/veda';
 import { projectionDefault } from '$components/common/map/controls/map-options/projections';
 import { userTzDate2utcString, utcString2userTzDate } from '$utils/date';
@@ -358,9 +358,7 @@ function Scrollytelling(props) {
     activeChapterLayerData ?? {};
 
   return (
-
     <div>
-
       <ScrollyMapContainer topOffset={topOffset || 0}>
         {areLayersLoading && <MapLoading />}
 
@@ -368,14 +366,10 @@ function Scrollytelling(props) {
           Map overlay element
           Map message for loading error
         */}
-        <MapMessage
+        <MapErrorMessage
           id='scrolly-map-message'
           active={didFailLayerLoading}
-          isInvalid
-        >
-          <CollecticonCircleXmark /> There was a problem loading the map data.
-          Refresh the page and try again.
-        </MapMessage>
+        />
 
         {/*
           Map overlay element

--- a/app/scripts/components/common/blocks/scrollytelling/map-error-message.deprecated.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/map-error-message.deprecated.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { CollecticonCircleXmark } from '@devseed-ui/collecticons';
+import MapMessage from '$components/common/map/map-message';
+
+interface MapErrorMessageProps {
+  id: string;
+  active: boolean;
+}
+
+/**
+ * @deprecated This component uses Collecticons and is being migrated to USWDS icons.
+ * Use the main MapErrorMessage component instead.
+ */
+export default function MapErrorMessageDeprecated(props: MapErrorMessageProps) {
+  const { id, active } = props;
+
+  return (
+    <MapMessage id={id} active={active} isInvalid>
+      <CollecticonCircleXmark size='large' /> There was a problem loading the
+      map data. Refresh the page and try again.
+    </MapMessage>
+  );
+}

--- a/app/scripts/components/common/blocks/scrollytelling/map-error-message.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/map-error-message.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Icon } from '@trussworks/react-uswds';
+import MapMessage from '$components/common/map/map-message';
+
+interface MapErrorMessageProps {
+  /** Unique identifier for the error message */
+  id: string;
+  /** Whether the error message is currently active/visible */
+  active: boolean;
+}
+
+/**
+ * Map error message component with USWDS icon.
+ * Displays an error message when map data fails to load.
+ *
+ * @param props - Component props
+ * @returns JSX element
+ */
+export default function MapErrorMessage(props: MapErrorMessageProps) {
+  const { id, active } = props;
+
+  return (
+    <MapMessage id={id} active={active} isInvalid>
+      <Icon.HighlightOff size={4} /> There was a problem loading the map data.
+      Refresh the page and try again.
+    </MapMessage>
+  );
+}

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -52,6 +52,7 @@ const ComponentPreview = styled.div<{ variant: 'legacy' | 'migrated' }>`
   border: 1px solid
     ${(props) => (props.variant === 'legacy' ? '#fecaca' : '#bbf7d0')};
   position: relative;
+  min-height: 120px;
 `;
 
 const IconInfo = styled.div<{ variant: 'legacy' | 'migrated' }>`

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -6,6 +6,8 @@ import { TimelineZoomControls } from '$components/exploration/components/timelin
 import { TimelineZoomControlsDeprecated } from '$components/exploration/components/timeline/timeline-zoom-controls.deprecated';
 import EmptyHub from '$components/common/empty-hub';
 import EmptyHubDeprecated from '$components/common/empty-hub.deprecated';
+import MapErrorMessage from '$components/common/blocks/scrollytelling/map-error-message';
+import MapErrorMessageDeprecated from '$components/common/blocks/scrollytelling/map-error-message.deprecated';
 
 // Styled Components
 const Container = styled.div`
@@ -49,6 +51,7 @@ const ComponentPreview = styled.div<{ variant: 'legacy' | 'migrated' }>`
   border-radius: 8px;
   border: 1px solid
     ${(props) => (props.variant === 'legacy' ? '#fecaca' : '#bbf7d0')};
+  position: relative;
 `;
 
 const IconInfo = styled.div<{ variant: 'legacy' | 'migrated' }>`
@@ -194,6 +197,10 @@ const ZoomControlsPair = createComponentPair(
 );
 
 const EmptyHubPair = createComponentPair(EmptyHubDeprecated, EmptyHub);
+const MapErrorMessagePair = createComponentPair(
+  MapErrorMessageDeprecated,
+  MapErrorMessage
+);
 
 // Migration examples data
 interface MigrationExampleData {
@@ -229,6 +236,20 @@ const MIGRATION_EXAMPLES: MigrationExampleData[] = [
     ),
     legacyIcons: 'Icons: CollecticonPage (from empty-hub.deprecated.tsx)',
     migratedIcons: 'Icons: Icon.ContactPage (from empty-hub.tsx)'
+  },
+  {
+    title: 'Map Error Message Migration',
+    description:
+      'Migration of map error message component with error icon. Demonstrates icon replacement in error states.',
+    legacyComponent: (
+      <MapErrorMessagePair.Legacy id='test-error' active={true} />
+    ),
+    migratedComponent: (
+      <MapErrorMessagePair.Migrated id='test-error' active={true} />
+    ),
+    legacyIcons:
+      'Icons: CollecticonCircleXmark (from map-error-message.deprecated.tsx)',
+    migratedIcons: 'Icons: Icon.HighlightOff (from map-error-message.tsx)'
   }
   // Add more examples here as needed
 ];


### PR DESCRIPTION
Contributes to #1814.

### Changes

* Extract MapErrorMessage component from scrollytelling for better reusability
* Replace CollecticonCircleXmark with Icon.HighlightOff from USWDS
* Create deprecated version for migration comparison using .deprecated.tsx pattern
* Add JSDoc documentation to migrated component
* Update scrollytelling to use new MapErrorMessage component
* Add MapErrorMessage to migration examples in Storybook
* Add minimum height to component preview for consistent layout

### How to give feedback

* Run Storybook locally and visit Documentation/Migration Examples to compare legacy vs migrated components

### Notes

* Based on PR #1884 - follows the same migration pattern
* .deprecated.tsx files are temporary and will be removed after migration
* Migration stories are only for reference and will be cleaned up later

### Preview

Ready for review.