### PR TITLE
feat: migrate ExternalLinkFlag to USWDS

### DIFF
--- a/app/scripts/components/common/card/index.tsx
+++ b/app/scripts/components/common/card/index.tsx
@@ -1,18 +1,13 @@
 import React, { MouseEventHandler } from 'react';
-import {
-  listReset,
-  media,
-  multiply,
-  themeVal
-} from '@devseed-ui/theme-provider';
+import { listReset, media } from '@devseed-ui/theme-provider';
 import styled from 'styled-components';
-import { CollecticonExpandTopRight } from '@devseed-ui/collecticons';
 import ClassicCard, { ClassicCardItem } from './classic';
 import CoverCard, { CoverCardItem } from './cover';
 import FeaturedCard, { FeaturedCardItem } from './featured';
 import HorizontalInfoCard, { HorizontalInfoCardItem } from './horizontal-info';
 import FlagCard from './uswds-cards/flag-card';
 import { LabelType } from './uswds-cards/types';
+import ExternalLinkFlagNew from '$components/common/external-link-flag';
 import { LinkProperties } from '$types/veda';
 import * as utils from '$utils/utils';
 import { ElementInteractive } from '$components/common/element-interactive';
@@ -253,38 +248,29 @@ export const Card = styled(CardComponent)`
   /* Convert to styled-component: https://styled-components.com/docs/advanced#caveat */
 `;
 
-const ExternalLinkMark = styled.div`
-  display: flex;
-  align-items: center;
-  position: absolute;
-  top: ${variableGlsp(0.25)};
-  right: ${variableGlsp(0.25)};
-  padding: ${variableGlsp(0.125)} ${variableGlsp(0.25)};
-  background-color: ${themeVal('color.primary')};
-  color: ${themeVal('color.surface')};
-  text-transform: none;
-  border-radius: calc(
-    ${multiply(themeVal('shape.rounded'), 2)} - ${variableGlsp(0.125)}
-  );
-  z-index: 1;
-`;
-
-const FlagText = styled.div`
-  display: inline;
-  font-weight: bold;
-  font-size: 0.825rem;
-  margin-right: ${variableGlsp(0.25)};
-`;
-
-// @NOTE: ExternalLinkFlag should be broken out but currently GHG instance directly imports this from here
-
+/**
+ * @deprecated This re-export from card/ will be removed in v7.
+ * Import `ExternalLinkFlag` from `@teamimpact/veda-ui` or from
+ * `$components/common/external-link-flag` instead.
+ *
+ * @example
+ * ```tsx
+ * // New (preferred)
+ * import { ExternalLinkFlag } from '@teamimpact/veda-ui';
+ * // Or
+ * import { ExternalLinkFlag } from '$components/common/external-link-flag';
+ * ```
+ */
+let hasWarnedExternalLinkFlag = false;
 export function ExternalLinkFlag() {
-  return (
-    <ExternalLinkMark>
-      <FlagText>External Link</FlagText>
-      <CollecticonExpandTopRight size='small' meaningful={false} />
-    </ExternalLinkMark>
-  );
+  if (process.env.NODE_ENV !== 'production' && !hasWarnedExternalLinkFlag) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[veda-ui] ExternalLinkFlag import from card/ is deprecated and will be removed in v7. Import from @teamimpact/veda-ui or $components/common/external-link-flag. Migrated to USWDS Icon.Launch; expect a slightly larger icon.'
+    );
+    hasWarnedExternalLinkFlag = true;
+  }
+  return <ExternalLinkFlagNew />;
 }
 
 function CardLinkWrapper({

--- a/app/scripts/components/common/external-link-flag.deprecated.tsx
+++ b/app/scripts/components/common/external-link-flag.deprecated.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import styled from 'styled-components';
+import { CollecticonExpandTopRight } from '@devseed-ui/collecticons';
+import { multiply, themeVal } from '@devseed-ui/theme-provider';
+import { variableGlsp } from '$styles/variable-utils';
+
+const ExternalLinkMark = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: ${variableGlsp(0.25)};
+  right: ${variableGlsp(0.25)};
+  padding: ${variableGlsp(0.125)} ${variableGlsp(0.25)};
+  background-color: ${themeVal('color.primary')};
+  color: ${themeVal('color.surface')};
+  text-transform: none;
+  border-radius: calc(
+    ${multiply(themeVal('shape.rounded'), 2)} - ${variableGlsp(0.125)}
+  );
+  z-index: 1;
+`;
+
+const FlagText = styled.div`
+  display: inline;
+  font-weight: bold;
+  font-size: 0.825rem;
+  margin-right: ${variableGlsp(0.25)};
+`;
+
+/**
+ * @deprecated This is the legacy version using CollecticonExpandTopRight.
+ * Use the new version from '@teamimpact/veda-ui' instead.
+ *
+ * @returns {JSX.Element} The external link flag badge with legacy icon
+ */
+export function ExternalLinkFlagDeprecated(): JSX.Element {
+  return (
+    <ExternalLinkMark>
+      <FlagText>External Link</FlagText>
+      <CollecticonExpandTopRight size='small' meaningful={false} />
+    </ExternalLinkMark>
+  );
+}
+
+export default ExternalLinkFlagDeprecated;

--- a/app/scripts/components/common/external-link-flag.deprecation.test.tsx
+++ b/app/scripts/components/common/external-link-flag.deprecation.test.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ExternalLinkFlag } from '$components/common/card/';
+
+// Mock console.warn to capture warnings
+const mockConsoleWarn = jest.fn();
+const originalConsoleWarn = console.warn;
+
+describe('ExternalLinkFlag Deprecation Warning', () => {
+  beforeEach(() => {
+    // Reset the mock and restore original console.warn
+    mockConsoleWarn.mockClear();
+    console.warn = mockConsoleWarn;
+
+    // Reset the module to clear the hasWarnedExternalLinkFlag flag
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    // Restore original console.warn
+    console.warn = originalConsoleWarn;
+  });
+
+  it('should log deprecation warning once in development', () => {
+    // Set NODE_ENV to development
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
+    try {
+      // First render should trigger warning
+      render(<ExternalLinkFlag />);
+      expect(mockConsoleWarn).toHaveBeenCalledTimes(1);
+      expect(mockConsoleWarn).toHaveBeenCalledWith(
+        '[veda-ui] ExternalLinkFlag import from card/ is deprecated and will be removed in v7. Import from @teamimpact/veda-ui or $components/common/external-link-flag. Migrated to USWDS Icon.Launch; expect a slightly larger icon.'
+      );
+
+      // Second render should not trigger warning again
+      render(<ExternalLinkFlag />);
+      expect(mockConsoleWarn).toHaveBeenCalledTimes(1);
+    } finally {
+      // Restore original NODE_ENV
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('should not log warning in production', () => {
+    // Set NODE_ENV to production
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      render(<ExternalLinkFlag />);
+      expect(mockConsoleWarn).not.toHaveBeenCalled();
+    } finally {
+      // Restore original NODE_ENV
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('should render the component correctly', () => {
+    const { container } = render(<ExternalLinkFlag />);
+
+    // Check that the component renders
+    expect(container.firstChild).toBeTruthy();
+
+    // Check for the "External Link" text
+    expect(container.textContent).toContain('External Link');
+  });
+});

--- a/app/scripts/components/common/external-link-flag.tsx
+++ b/app/scripts/components/common/external-link-flag.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Icon } from '@trussworks/react-uswds';
+import { multiply, themeVal } from '@devseed-ui/theme-provider';
+import { variableGlsp } from '$styles/variable-utils';
+
+const ExternalLinkMark = styled.div`
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: ${variableGlsp(0.25)};
+  right: ${variableGlsp(0.25)};
+  padding: ${variableGlsp(0.125)} ${variableGlsp(0.25)};
+  background-color: ${themeVal('color.primary')};
+  color: ${themeVal('color.surface')};
+  text-transform: none;
+  border-radius: calc(
+    ${multiply(themeVal('shape.rounded'), 2)} - ${variableGlsp(0.125)}
+  );
+  z-index: 1;
+`;
+
+const FlagText = styled.div`
+  display: inline;
+  font-weight: bold;
+  font-size: 0.825rem;
+  margin-right: ${variableGlsp(0.25)};
+`;
+
+/**
+ * ExternalLinkFlag
+ *
+ * Small badge component used to mark external links in card-like UIs.
+ * Displays "External Link" text with a launch icon in the top-right corner.
+ *
+ * @example
+ * ```tsx
+ * <ExternalLinkFlag />
+ * ```
+ *
+ * @returns {JSX.Element} The external link flag badge
+ */
+export function ExternalLinkFlag(): JSX.Element {
+  return (
+    <ExternalLinkMark>
+      <FlagText>External Link</FlagText>
+      <Icon.Launch size={3} aria-hidden='true' />
+    </ExternalLinkMark>
+  );
+}
+
+export default ExternalLinkFlag;

--- a/app/scripts/libs/index.ts
+++ b/app/scripts/libs/index.ts
@@ -1,4 +1,5 @@
 import { PageHero } from '$components/common/page-hero';
+import { ExternalLinkFlag } from '$components/common/external-link-flag';
 import { GlobalStyles } from '$styles/legacy-global-styles';
 
 const LegacyGlobalStyles = GlobalStyles;
@@ -81,4 +82,4 @@ export {
   VEDAPresetSelectorAoi
 } from './components';
 
-export { PageHero, LegacyGlobalStyles };
+export { PageHero, LegacyGlobalStyles, ExternalLinkFlag };

--- a/storybook/src/stories/documentation/migration-examples.stories.tsx
+++ b/storybook/src/stories/documentation/migration-examples.stories.tsx
@@ -8,6 +8,8 @@ import EmptyHub from '$components/common/empty-hub';
 import EmptyHubDeprecated from '$components/common/empty-hub.deprecated';
 import MapErrorMessage from '$components/common/blocks/scrollytelling/map-error-message';
 import MapErrorMessageDeprecated from '$components/common/blocks/scrollytelling/map-error-message.deprecated';
+import { ExternalLinkFlag } from '$components/common/external-link-flag';
+import ExternalLinkFlagDeprecated from '$components/common/external-link-flag.deprecated';
 
 // Styled Components
 const Container = styled.div`
@@ -203,6 +205,11 @@ const MapErrorMessagePair = createComponentPair(
   MapErrorMessage
 );
 
+const ExternalLinkFlagPair = createComponentPair(
+  ExternalLinkFlagDeprecated,
+  ExternalLinkFlag
+);
+
 // Migration examples data
 interface MigrationExampleData {
   title: string;
@@ -251,6 +258,16 @@ const MIGRATION_EXAMPLES: MigrationExampleData[] = [
     legacyIcons:
       'Icons: CollecticonCircleXmark (from map-error-message.deprecated.tsx)',
     migratedIcons: 'Icons: Icon.HighlightOff (from map-error-message.tsx)'
+  },
+  {
+    title: 'External Link Flag Migration',
+    description:
+      'The USWDS launch icon does not have a smaller size option, so the migrated version is expected to appear slightly larger.',
+    legacyComponent: <ExternalLinkFlagPair.Legacy />,
+    migratedComponent: <ExternalLinkFlagPair.Migrated />,
+    legacyIcons:
+      'Icons: CollecticonExpandTopRight size="small" (from external-link-flag.deprecated.tsx)',
+    migratedIcons: 'Icons: Icon.Launch size={3} (from external-link-flag.tsx)'
   }
   // Add more examples here as needed
 ];


### PR DESCRIPTION
Contributes to https://github.com/NASA-IMPACT/veda-ui/issues/1814.

## Summary
- Migrates `ExternalLinkFlag` from Collecticons to `USWDS Icon.Launch`
- Extracts component to `$components/common/external-link-flag`; keeps deprecated re-export under `card/` with one-time dev warning
- Clarifies deprecation scope: only `card/` import will be removed in v7
- Adds Storybook migration example (before/after)
- Adds unit test verifying one-time warning

## Notes
- `USWDS Launch` has no smaller size; migrated icon appears slightly larger
- Downstream apps continue working via deprecated path until v7

This is ready for review.
