### PR TITLE
fix: make release workflow idempotent and reset version to last successful release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,13 @@ on:
 permissions:
   contents: write
 
-# This action requires a GitHub app with content write access installed 
+# This action requires a GitHub app with content write access installed
 # to bypass the main branch  protection rule and dispatch the event to a different repo
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs: 
+    outputs:
       no_commit: ${{ steps.git-release.outputs.NO_COMMIT }}
     steps:
       - name: Generate a token
@@ -53,6 +53,27 @@ jobs:
           node-version: ${{ env.NODE }}
           registry-url: https://registry.npmjs.org/
       - run: yarn
+      # Clean up any stale version tags left from failed release runs.
+      # Context:
+      # - Each release run uses release-it to bump package.json, create a new Git tag (e.g., v7.0.0),
+      #   and then publish to NPM. If the run fails after the tag is created but before publish,
+      #   that tag remains both locally in the local repo (inside the GitHub Actions runner) and remotely on GitHub.
+      # - "Locally" refers to the temporary clone created by actions/checkout@v4 inside the workflow runner.
+      # - "Remotely" refers to the GitHub repository itself ("origin" on GitHub.com).
+      #   The command `git push origin :refs/tags/v7.0.0` deletes the remote tag.
+      # - On the next run, if that stale tag still exists, release-it detects no version change
+      #   and fails with “Version not changed”.
+      # This step checks whether the tag for the current package.json version already exists,
+      # and deletes it locally and remotely so release-it can safely recreate it during this run.
+      - name: Clean stale tags from failed releases
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          echo "Checking for existing tag v$CURRENT_VERSION..."
+          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
+            echo "Removing stale tag v$CURRENT_VERSION"
+            git tag -d "v$CURRENT_VERSION" || true
+            git push origin ":refs/tags/v$CURRENT_VERSION" || true
+          fi
       - name: Release through Git
         id: git-release
         run: yarn release  --ci --verbose
@@ -83,7 +104,7 @@ jobs:
           client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": ${{ env.VERSION }}}'
   notify:
     # If any of job fails
-    if: failure() 
+    if: failure()
     runs-on: ubuntu-latest
     needs:
       - release

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@teamimpact/veda-ui",
   "description": "Dashboard",
-  "version": "6.19.1",
+  "version": "6.16.0",
   "author": {
     "name": "Development Seed",
     "url": "https://developmentseed.org/"


### PR DESCRIPTION
**Related Ticket:** https://github.com/NASA-IMPACT/veda-ui/issues/1907

### Description of Changes
Opening a draft PR to attempt to fix the broken release workflow:

- Reset package.json version to 6.16.0, the last successful published version to realign with npm and GitHub release history
- Added cleanup step to the release workflow to automatically remove stale Git tags left by failed runs. Can't easily test this until we merge / publish

### Notes & Questions About Changes
- This resolves the npm error Version not changed issue caused by leftover tags (v6.17.0+)
- After merge, the next workflow run should bump to v6.17.0 and publish cleanly
- Manually ran `git tag -d v6.17.0 v6.18.0 v6.19.0 v6.19.1` and git push origin :refs/tags/...` to delete stale tags locally and on GitHub
- [Old draft releases](https://github.com/NASA-IMPACT/veda-ui/releases) in the veda-ui github repository (v6.17.0–v6.19.1) should be deleted manually. I think we can already do that, before the next publish attempt? cc @vgeorge @snmln 

### Validation / Testing
- Verified locally that stale tags were deleted (git fetch --tags --prune shows latest as v6.16.0)
- After merging, manually trigger "Release Every Monday" workflow and confirm it completes the release and creates new tag v6.17.0.
