### PR TITLE
ci: disable the slack notifications until we stabilize the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,11 @@ jobs:
           client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": ${{ env.VERSION }}}'
   notify:
     # If any of job fails
-    if: failure()
+    # Temporarily disable Slack notifications to avoid noise while stabilizing the release workflow.
+    # This prevents both failure and no-commit alerts from posting to Slack,
+    # but preserves the structure of the job so it can be easily re-enabled later.
+    # To re-enable, change "if: false" back to "if: failure()".
+    if: false
     runs-on: ubuntu-latest
     needs:
       - release


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
Disabling the slack failure notifications until we stabilize the release workflow, to avoid noise

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
