### PR TITLE
ci: prevent cleanup from deleting latest valid release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,12 +67,17 @@ jobs:
       # and deletes it locally and remotely so release-it can safely recreate it during this run.
       - name: Clean stale tags from failed releases
         run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 || echo "")
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Checking for existing tag v$CURRENT_VERSION..."
-          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-            echo "Removing stale tag v$CURRENT_VERSION"
-            git tag -d "v$CURRENT_VERSION" || true
-            git push origin ":refs/tags/v$CURRENT_VERSION" || true
+          if [ "$LAST_TAG" = "v$CURRENT_VERSION" ]; then
+            echo "Skipping cleanup: tag v$CURRENT_VERSION already valid."
+          else
+            STALE_TAG="v$CURRENT_VERSION"
+            if git rev-parse "$STALE_TAG" >/dev/null 2>&1; then
+              echo "Removing stale tag $STALE_TAG"
+              git tag -d "$STALE_TAG" || true
+              git push origin ":refs/tags/$STALE_TAG" || true
+            fi
           fi
       - name: Release through Git
         id: git-release


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
Modified the cleanup step in the release workflow to skip deletion when the latest Git tag matches the current package.json version. This is to prevent valid tags from being removed before release-it runs (and resolving the “6.16.0…6.16.0” same-version issue during automated releases).

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
Tested locally with a `test-cleanup.sh`:

```
#!/usr/bin/env bash
set -euo pipefail

LAST_TAG=$(git describe --tags --abbrev=0 || echo "")
CURRENT_VERSION=$(node -p "require('./package.json').version")

echo "Last tag: $LAST_TAG"
echo "Current version: $CURRENT_VERSION"

if [ "$LAST_TAG" = "v$CURRENT_VERSION" ]; then
  echo "Skipping cleanup: tag v$CURRENT_VERSION already valid."
else
  STALE_TAG="v$CURRENT_VERSION"
  if git rev-parse "$STALE_TAG" >/dev/null 2>&1; then
    echo "Removing stale tag $STALE_TAG"
    git tag -d "$STALE_TAG" || true
    git push origin ":refs/tags/$STALE_TAG" || true
  else
    echo "No stale tag $STALE_TAG found."
  fi
fi
```

Running `./test-cleanup.sh` shows:

```
Last tag: v6.16.0
Current version: 6.16.0
Skipping cleanup: tag v6.16.0 already valid.
```


