### PR TITLE
ci: re-enable slack notifications for failed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,11 +109,7 @@ jobs:
           client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": ${{ env.VERSION }}}'
   notify:
     # If any of job fails
-    # Temporarily disable Slack notifications to avoid noise while stabilizing the release workflow.
-    # This prevents both failure and no-commit alerts from posting to Slack,
-    # but preserves the structure of the job so it can be easily re-enabled later.
-    # To re-enable, change "if: false" back to "if: failure()".
-    if: false
+    if: failure()
     runs-on: ubuntu-latest
     needs:
       - release


### PR DESCRIPTION
**Related Ticket:** _{link related ticket here}_

### Description of Changes
Re-enable the Slack notifications that we disabled while debugging the release workflow issues.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
_{Update with info on what can be manually validated in the Deploy Preview link for example "Validate style updates to selection modal do NOT affect cards"}_
