### PR TITLE
fix: [veda-ui-1864] Do not override rescale defined from source parameters in map layer

### DIFF
--- a/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-paint-layer.tsx
@@ -17,7 +17,6 @@ interface RasterPaintLayerProps extends BaseGeneratorParams {
   colorMap?: string | undefined;
   tileParams: Record<string, any>;
   generatorPrefix?: string;
-  reScale?: { min: number; max: number };
   metadataFormatter?: (
     tileJsonData: TileJSON | null,
     tileParamsAsString: string
@@ -38,7 +37,6 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
     hidden,
     opacity,
     colorMap,
-    reScale,
     generatorPrefix = 'raster',
     metadataFormatter,
     sourceParamFormatter = (tileUrl) => ({ url: tileUrl }),
@@ -51,10 +49,9 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
   const updatedTileParams = useMemo(() => {
     return {
       ...tileParams,
-      ...(colorMap && { colormap_name: colorMap }),
-      ...(reScale && { rescale: Object.values(reScale) })
+      ...(colorMap && { colormap_name: colorMap })
     };
-  }, [tileParams, colorMap, reScale]);
+  }, [tileParams, colorMap]);
 
   //
   // Generate Mapbox GL layers and sources for raster timeseries
@@ -156,8 +153,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       tileApiEndpoint,
       haveTileParamsChanged,
       generatorParams,
-      colorMap,
-      reScale
+      colorMap
       // generatorParams includes hidden and opacity
       // hidden,
       // opacity,

--- a/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
+++ b/app/scripts/components/common/map/style-generators/raster-timeseries.tsx
@@ -255,7 +255,6 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     stacApiEndpoint,
     tileApiEndpoint,
     colorMap,
-    reScale,
     envApiStacEndpoint,
     envApiRasterEndpoint
   } = props;
@@ -328,7 +327,6 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
           opacity={opacity}
           colorMap={colorMap}
           generatorOrder={generatorOrder}
-          reScale={reScale}
           generatorPrefix='raster-timeseries'
           onStatusChange={changeStatus}
           metadataFormatter={(tilejsonData, tileParamsAsString) => {

--- a/app/scripts/components/common/map/types.d.ts
+++ b/app/scripts/components/common/map/types.d.ts
@@ -55,7 +55,6 @@ export interface BaseTimeseriesProps extends BaseGeneratorParams {
   zoomExtent?: number[];
   onStatusChange?: (result: { status: ActionStatus; id: string }) => void;
   colorMap?: string;
-  reScale?: { min: number; max: number };
   envApiStacEndpoint: string;
   envApiRasterEndpoint: string;
 }

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -30,7 +30,7 @@ export function Layer(props: LayerProps) {
   const { envApiStacEndpoint, envApiRasterEndpoint } = useVedaUI();
 
   const { id: layerId, dataset, order, selectedDay, onStatusChange } = props;
-  const { isVisible, opacity, colorMap, scale } = dataset.settings;
+  const { isVisible, opacity, colorMap } = dataset.settings;
 
   // The date needs to match the dataset's time density.
   const relevantDate = useMemo(
@@ -89,7 +89,6 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />
@@ -108,7 +107,6 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />
@@ -158,7 +156,6 @@ export function Layer(props: LayerProps) {
           opacity={opacity}
           onStatusChange={onStatusChange}
           colorMap={colorMap}
-          reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
         />


### PR DESCRIPTION
**Related Ticket:**
https://github.com/NASA-IMPACT/veda-ui/issues/1864

### Description of Changes
The reScale override is removed as sourceParams.rescale is the target value that should be used to generate tileParams in RasterPaintLayer. Adjusting the gradient sliders should no longer update the TiTiler rescale request params. I think this what was said to be the desired behavior? (see screenshots)

mdx file: 
<img width="967" height="304" alt="Image" src="https://github.com/user-attachments/assets/7bb0e696-4c3a-491c-bf61-48d1a350c7ed" />

local view:
<img width="1239" height="942" alt="Image" src="https://github.com/user-attachments/assets/3b6ea408-bf67-4471-adb9-e5ab17781bbc" />

PR: https://github.com/NASA-IMPACT/veda-ui/pull/1915

### Validation / Testing
I need some assistance here as I'm unsure the full impact of this change.

cc @dzole0311 @vgeorge 