### PR TITLE
fix: Guided tour doesn't work in exported `ExplorationAndAnalysis` component

### DIFF
--- a/app/scripts/components/exploration/container.tsx
+++ b/app/scripts/components/exploration/container.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
-import { TourProvider } from '@reactour/tour';
 import { Link } from 'react-router-dom';
 import { DevTools } from 'jotai-devtools';
 import { useAtom, useSetAtom } from 'jotai';
-import { PopoverTourComponent, TourManager } from './tour-manager';
 
 import { DatasetSelectorModal } from './components/dataset-selector-modal';
 import useTimelineDatasetAtom from './hooks/use-timeline-dataset-atom';
@@ -24,14 +22,6 @@ import { DATASETS_PATH, EXPLORATION_PATH } from '$utils/routes';
  * veda2 instances can just use the direct component, 'ExplorationAndAnalysis', and manage data directly in their page views
  */
 
-const tourProviderStyles = {
-  popover: (base) => ({
-    ...base,
-    padding: '0',
-    background: 'none'
-  })
-};
-
 export default function ExplorationAndAnalysisContainer() {
   const setExternalDatasets = useSetAtom(externalDatasetsAtom);
   setExternalDatasets(allExploreDatasets);
@@ -50,18 +40,13 @@ export default function ExplorationAndAnalysisContainer() {
   const closeModal = () => setDatasetModalRevealed(false);
 
   return (
-    <TourProvider
-      steps={[]}
-      styles={tourProviderStyles}
-      ContentComponent={PopoverTourComponent}
-    >
+    <>
       <DevTools />
       <LayoutProps
         title='Exploration'
         description='Explore and analyze datasets'
         hideFooter
       />
-      <TourManager />
       <PageMainContent>
         <PageHero title='Exploration' isHidden />
         <ExplorationAndAnalysis
@@ -88,6 +73,6 @@ export default function ExplorationAndAnalysisContainer() {
           }
         />
       </PageMainContent>
-    </TourProvider>
+    </>
   );
 }

--- a/app/scripts/components/exploration/index.tsx
+++ b/app/scripts/components/exploration/index.tsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import styled from 'styled-components';
 import { themeVal } from '@devseed-ui/theme-provider';
+import { TourProvider } from '@reactour/tour';
 
 import { useAtom, useSetAtom } from 'jotai';
 import Timeline from './components/timeline/timeline';
 import { ExplorationMap } from './components/map';
 import { useAnalysisController } from './hooks/use-analysis-data-request';
+import { PopoverTourComponent, TourManager } from './tour-manager';
 import { TimelineDataset } from './types.d.ts';
 import { selectedCompareDateAtom, selectedDateAtom } from './atoms/dates';
 import { CLEAR_LOCATION, urlAtom } from '$utils/params-location-atom/url';
@@ -58,6 +60,14 @@ const Container = styled.div`
   }
 `;
 
+const tourProviderStyles = {
+  popover: (base) => ({
+    ...base,
+    padding: '0',
+    background: 'none'
+  })
+};
+
 interface ExplorationAndAnalysisProps {
   datasets: TimelineDataset[];
   setDatasets: (datasets: TimelineDataset[]) => void;
@@ -91,35 +101,42 @@ export default function ExplorationAndAnalysis(
   }, []);
 
   return (
-    <Container>
-      <PanelGroup direction='vertical' className='panel-wrapper'>
-        <Panel
-          maxSize={75}
-          className='panel'
-          onResize={(size: number) => {
-            setPanelHeight(size);
-          }}
-        >
-          <ExplorationMap
-            datasets={datasets}
-            setDatasets={setDatasets}
-            selectedDay={selectedDay}
-            selectedCompareDay={selectedCompareDay}
-          />
-        </Panel>
-        <PanelResizeHandle className='resize-handle' />
-        <Panel maxSize={75} className='panel panel-timeline'>
-          <Timeline
-            datasets={datasets}
-            selectedDay={selectedDay}
-            setSelectedDay={setSelectedDay}
-            selectedCompareDay={selectedCompareDay}
-            setSelectedCompareDay={setSelectedCompareDay}
-            onDatasetAddClick={openDatasetsSelectionModal}
-            panelHeight={panelHeight}
-          />
-        </Panel>
-      </PanelGroup>
-    </Container>
+    <TourProvider
+      steps={[]}
+      styles={tourProviderStyles}
+      ContentComponent={PopoverTourComponent}
+    >
+      <TourManager />
+      <Container>
+        <PanelGroup direction='vertical' className='panel-wrapper'>
+          <Panel
+            maxSize={75}
+            className='panel'
+            onResize={(size: number) => {
+              setPanelHeight(size);
+            }}
+          >
+            <ExplorationMap
+              datasets={datasets}
+              setDatasets={setDatasets}
+              selectedDay={selectedDay}
+              selectedCompareDay={selectedCompareDay}
+            />
+          </Panel>
+          <PanelResizeHandle className='resize-handle' />
+          <Panel maxSize={75} className='panel panel-timeline'>
+            <Timeline
+              datasets={datasets}
+              selectedDay={selectedDay}
+              setSelectedDay={setSelectedDay}
+              selectedCompareDay={selectedCompareDay}
+              setSelectedCompareDay={setSelectedCompareDay}
+              onDatasetAddClick={openDatasetsSelectionModal}
+              panelHeight={panelHeight}
+            />
+          </Panel>
+        </PanelGroup>
+      </Container>
+    </TourProvider>
   );
 }


### PR DESCRIPTION
**Related Ticket:** https://github.com/US-GHG-Center/ghgc-architecture/issues/744#issuecomment-3513309879
Example [here](https://veda-ui-next-test.netlify.app/exploration?datasets=%5B%7B%22id%22%3A%22blue-tarp-detection%22%2C%22settings%22%3A%7B%22isVisible%22%3Atrue%2C%22opacity%22%3A100%2C%22analysisMetrics%22%3A%5B%7B%22id%22%3A%22mean%22%2C%22label%22%3A%22Average%22%2C%22chartLabel%22%3A%22Average%22%2C%22themeColor%22%3A%22infographicB%22%7D%2C%7B%22id%22%3A%22std%22%2C%22label%22%3A%22St+Deviation%22%2C%22chartLabel%22%3A%22St+Deviation%22%2C%22themeColor%22%3A%22infographicD%22%7D%5D%7D%7D%5D&taxonomy=%7B%7D&search=)

### Description of Changes
Moved TourProvider and tour-related components to ExplorationAndAnalysis component (since it's the only place where it is used)

### Validation / Testing
Manually tested locally by using `yarn link`
