### PR TITLE
fix: guard WMS date domain lookup in scrollytelling

### DIFF
--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -33,18 +33,21 @@ export function Layer(props: LayerProps) {
   const { isVisible, opacity, colorMap, scale } = dataset.settings;
 
   // The date needs to match the dataset's time density.
-  const relevantDate = useMemo(
-    () =>
-      dataset.data.type === 'wms'
-        ? getRelevantDate(selectedDay, dataset.data.domain)
-        : getTimeDensityStartDate(selectedDay, dataset.data.timeDensity),
-    [
-      selectedDay,
-      dataset.data.timeDensity,
-      dataset.data.domain,
-      dataset.data.type
-    ]
-  );
+  const relevantDate = useMemo(() => {
+    if (dataset.data.type === 'wms') {
+      // Guard: if domain is not loaded yet, use selectedDay directly.
+      if (!dataset.data.domain || dataset.data.domain.length === 0) {
+        return selectedDay;
+      }
+      return getRelevantDate(selectedDay, dataset.data.domain);
+    }
+    return getTimeDensityStartDate(selectedDay, dataset.data.timeDensity);
+  }, [
+    selectedDay,
+    dataset.data.timeDensity,
+    dataset.data.domain,
+    dataset.data.type
+  ]);
 
   // Resolve config functions.
   const params = useMemo(() => {

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -357,6 +357,11 @@ export function getTimeDensityStartDate(date: Date, timeDensity: TimeDensity) {
 }
 
 export function getRelevantDate(date: Date, domain: Date[]) {
+  // Guard: if domain is not loaded yet, use the requested date directly.
+  if (!domain || domain.length === 0) {
+    return date;
+  }
+
   // Return the date that falls into the same year? Or closest one?
   // Returning the close one now, but then it is weird when timeDensity is set up as year and
   // selected date is ~ March 2020, it will send a request for 2019-12-31 (since it is the closest date)


### PR DESCRIPTION
Contributes to #1925

Prevents 'No closest date found' error when WMS layer domain is not yet loaded in scrollytelling blocks. Returns requested date directly when domain is empty, allowing layers to render before STAC metadata loads.

**Changes:**
- Added guard in `layer.tsx` before calling `getRelevantDate()` for WMS layers
- Added guard in `getRelevantDate()` to handle empty domain arrays