### PR TITLE
fix: update cmr query key to cache bust on start and end date

### DIFF
--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -167,7 +167,7 @@ export function formatCMRResponse(statResponse: CMRStatistics): TimeseriesData {
   return cmrResponse;
 }
 
-export async function requestCMRTimeseriesData({
+async function requestCMRTimeseriesData({
   start,
   end,
   aoi,


### PR DESCRIPTION
**Related Ticket:** 
Closes: #1897 

### Description of Changes
Updated the query key on the CMR time series stats endpoint to include start and end date for cache bust. This will refetch, even if the new date range stats was included in the prior fetch, so this isn't as optimized as it could be for caching. But this was the simplest approach without adding additional logic to check if the dates were exclusive of the previously set range. 

### Notes & Questions About Changes
Curious if there are other parameters missing in this query key that should be added?

### Validation / Testing
This would impact any CMR dataset available for timeseries analysis. I tested using the [original branch the bug was reported on](https://github.com/NASA-IMPACT/veda-ui/pull/1896) as this branch provided the CMR dataset for testing.  When going through every dataset available on veda-ui in my local env, I was unable to find a valid CMR dataset. I suggest pulling in the commit`46eb610bd5d0e3f6eef29b8cf62a74d05e1b7ad8` from the bug report branch into your local to test.