### PR TITLE
fix: type.d.ts.ts filename typo

### DIFF
--- a/app/scripts/components/common/blocks/block-map.tsx
+++ b/app/scripts/components/common/blocks/block-map.tsx
@@ -26,7 +26,7 @@ import {
   ScaleControl
 } from '$components/common/map/controls';
 import { Layer } from '$components/exploration/components/map/layer';
-import { VizDatasetSuccess } from '$components/exploration/types.d.ts';
+import { VizDatasetSuccess } from '$components/exploration/types';
 import { ProjectionOptions } from '$types/veda';
 
 export const mapHeight = '32rem';

--- a/app/scripts/components/common/blocks/lazy-components.jsx
+++ b/app/scripts/components/common/blocks/lazy-components.jsx
@@ -21,7 +21,7 @@ import { veda_faux_module_datasets } from '$data-layer/datasets';
 import { reconcileDatasets } from '$components/exploration/data-utils';
 import { getDatasetLayers } from '$utils/data-utils';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
-import { DatasetStatus } from '$components/exploration/types.d.ts';
+import { DatasetStatus } from '$components/exploration/types';
 import { useVedaUI } from '$context/veda-ui-provider';
 
 const getDataLayer = (layerIndex, layers) => {

--- a/app/scripts/components/common/blocks/multilayer-block-map.tsx
+++ b/app/scripts/components/common/blocks/multilayer-block-map.tsx
@@ -13,7 +13,7 @@ import {
   USWDSInputGroup as InputGroup
 } from '$uswds';
 import type { ProjectionOptions } from '$types/veda';
-import type { VizDatasetSuccess } from '$components/exploration/types.d.ts';
+import type { VizDatasetSuccess } from '$components/exploration/types';
 import type { DatasetLayer } from '$types/veda';
 
 import 'react-calendar/dist/Calendar.css';

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -40,7 +40,7 @@ import {
   DatasetStatus,
   VizDataset,
   VizDatasetSuccess
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import { DatasetData } from '$types/veda';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
 import {

--- a/app/scripts/components/common/dataset-layer-card/color-range-slider/index.tsx
+++ b/app/scripts/components/common/dataset-layer-card/color-range-slider/index.tsx
@@ -11,7 +11,7 @@ import {
   tooltiptextClasses
 } from './utils';
 
-import { colorMapScale } from '$components/exploration/types.d.ts';
+import { colorMapScale } from '$components/exploration/types';
 import { USWDSTextInput } from '$uswds';
 
 interface ColorrangeRangeSlideProps {

--- a/app/scripts/components/common/dataset-layer-card/colormap-options.tsx
+++ b/app/scripts/components/common/dataset-layer-card/colormap-options.tsx
@@ -9,7 +9,7 @@ import {
 } from './color-maps';
 import { DropIcon } from '$components/common/custom-icon';
 
-import { colorMapScale } from '$components/exploration/types.d.ts';
+import { colorMapScale } from '$components/exploration/types';
 
 export const DEFAULT_COLORMAP = 'viridis';
 

--- a/app/scripts/components/common/dataset-layer-card/colormap-section.tsx
+++ b/app/scripts/components/common/dataset-layer-card/colormap-section.tsx
@@ -4,10 +4,7 @@ import { Icon } from '@trussworks/react-uswds';
 import Tippy from '@tippyjs/react';
 import { ColormapOptions } from './colormap-options';
 import { LayerGradientColormapGraphic } from '$components/common/map/layer-legend';
-import {
-  TimelineDataset,
-  colorMapScale
-} from '$components/exploration/types.d.ts';
+import { TimelineDataset, colorMapScale } from '$components/exploration/types';
 import { LoadingSkeleton } from '$components/common/loading-skeleton';
 import {
   LayerCategoricalGraphic,

--- a/app/scripts/components/common/dataset-layer-card/index.tsx
+++ b/app/scripts/components/common/dataset-layer-card/index.tsx
@@ -12,10 +12,7 @@ import { LayerInfoLiner } from '$components/exploration/components/layer-info-mo
 import LayerMenuOptions from '$components/common/dataset-layer-card/layer-options-menu';
 import { TipButton } from '$components/common/tip-button';
 
-import {
-  TimelineDataset,
-  colorMapScale
-} from '$components/exploration/types.d.ts';
+import { TimelineDataset, colorMapScale } from '$components/exploration/types';
 import { DatasetData } from '$types/veda';
 import { DatasetLayersIcon } from '$components/common/custom-icon/dataset-layers';
 import { ParentDatasetTitle } from '$components/common/catalog/catalog-legacy/catalog-content';

--- a/app/scripts/components/common/dataset-layer-card/layer-options-menu.tsx
+++ b/app/scripts/components/common/dataset-layer-card/layer-options-menu.tsx
@@ -6,7 +6,7 @@ import { Icon } from '@trussworks/react-uswds';
 import { TileUrlModal } from '../../exploration/components/datasets/tile-link-modal';
 import { TipButton } from '$components/common/tip-button';
 import { NativeSliderInput, SliderInputProps } from '$styles/range-slider';
-import { VizDataset } from '$components/exploration/types.d.ts';
+import { VizDataset } from '$components/exploration/types';
 import { DropIcon } from '$components/common/custom-icon';
 
 interface LayerMenuOptionsProps {

--- a/app/scripts/components/common/map/utils.ts
+++ b/app/scripts/components/common/map/utils.ts
@@ -19,7 +19,7 @@ import {
   DatasetStatus,
   EADatasetDataLayer,
   VizDataset
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import { fixAntimeridian } from '$utils/antimeridian';
 
 export const FIT_BOUNDS_PADDING = 32;

--- a/app/scripts/components/exploration/analysis-data.ts
+++ b/app/scripts/components/exploration/analysis-data.ts
@@ -9,7 +9,7 @@ import {
   DatasetStatus,
   AnalysisTimeseriesEntry,
   TimeseriesData
-} from './types.d.ts';
+} from './types';
 
 import { MAX_QUERY_NUM } from './constants';
 import {

--- a/app/scripts/components/exploration/atoms/datasets.ts
+++ b/app/scripts/components/exploration/atoms/datasets.ts
@@ -1,4 +1,4 @@
-import { TimelineDataset, TimelineDatasetForUrl } from '../types.d.ts';
+import { TimelineDataset, TimelineDatasetForUrl } from '../types';
 import { datasetLayersAtom } from './datasetLayers';
 import { reconcileDatasets } from '$components/exploration/data-utils';
 import { atomWithUrlValueStability } from '$utils/params-location-atom/atom-with-url-value-stability';

--- a/app/scripts/components/exploration/atoms/dates.ts
+++ b/app/scripts/components/exploration/atoms/dates.ts
@@ -1,4 +1,4 @@
-import { DateRange } from '../types.d.ts';
+import { DateRange } from '../types';
 import { atomWithUrlValueStability } from '$utils/params-location-atom/atom-with-url-value-stability';
 
 // We cannot start a date with null.

--- a/app/scripts/components/exploration/atoms/hooks.ts
+++ b/app/scripts/components/exploration/atoms/hooks.ts
@@ -12,7 +12,7 @@ import {
   TimelineDataset,
   DatasetStatus,
   TimelineDatasetSuccess
-} from '../types.d.ts';
+} from '../types';
 import { timelineSizesAtom } from './timeline';
 import { timelineDatasetsAtom } from './datasets';
 

--- a/app/scripts/components/exploration/atoms/timeline.ts
+++ b/app/scripts/components/exploration/atoms/timeline.ts
@@ -1,7 +1,7 @@
 import { atom } from 'jotai';
 
 import { HEADER_COLUMN_WIDTH, RIGHT_AXIS_SPACE } from '../constants';
-import { ZoomTransformPlain } from '../types.d.ts';
+import { ZoomTransformPlain } from '../types';
 
 // Zoom transform for the timeline. Values as object instead of d3.ZoomTransform
 export const zoomTransformAtom = atom<ZoomTransformPlain>({

--- a/app/scripts/components/exploration/atoms/viewMode.ts
+++ b/app/scripts/components/exploration/atoms/viewMode.ts
@@ -1,4 +1,4 @@
-import { ViewMode } from '$components/exploration/types.d.ts';
+import { ViewMode } from '$components/exploration/types';
 import { atomWithUrlValueStability } from '$utils/params-location-atom/atom-with-url-value-stability';
 
 const initialParams = new URLSearchParams(window.location.search);

--- a/app/scripts/components/exploration/components/chart-popover.tsx
+++ b/app/scripts/components/exploration/components/chart-popover.tsx
@@ -22,7 +22,7 @@ import {
   AnalysisTimeseriesEntry,
   TimeDensity,
   TimelineDatasetSuccess
-} from '../types.d.ts';
+} from '../types';
 import {
   FADED_TEXT_COLOR,
   TEXT_TITLE_BG_COLOR,

--- a/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
+++ b/app/scripts/components/exploration/components/dataset-selector-modal/index.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { Modal, ModalBody, ModalFooter, ModalHeader } from '@devseed-ui/modal';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
-import { TimelineDataset } from '../../types.d.ts';
+import { TimelineDataset } from '../../types';
 
 import RenderModalHeader from './header';
 import ModalFooterRender from './footer';

--- a/app/scripts/components/exploration/components/datasets/block-utils.ts
+++ b/app/scripts/components/exploration/components/datasets/block-utils.ts
@@ -4,7 +4,7 @@ import endOfYear from 'date-fns/endOfYear';
 import startOfDay from 'date-fns/startOfDay';
 import startOfMonth from 'date-fns/startOfMonth';
 import startOfYear from 'date-fns/startOfYear';
-import { TimeDensity } from '$components/exploration/types.d.ts';
+import { TimeDensity } from '$components/exploration/types';
 
 /**
  * Calculate the start and end of a block of time, given a date and a time

--- a/app/scripts/components/exploration/components/datasets/data-layer-card-container.tsx
+++ b/app/scripts/components/exploration/components/datasets/data-layer-card-container.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useAtom } from 'jotai';
 import DataLayerCardPresentational from '$components/common/dataset-layer-card';
 import useParentDataset from '$components/exploration/hooks/use-parent-data';
-import { TimelineDataset } from '$components/exploration/types.d.ts';
+import { TimelineDataset } from '$components/exploration/types';
 import { timelineDatasetsAtom } from '$components/exploration/atoms/datasets';
 import {
   useTimelineDatasetSettings,

--- a/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-chart.tsx
@@ -17,7 +17,7 @@ import { getNumForChart } from '$components/common/chart/utils';
 import {
   TimelineDatasetAnalysisSuccess,
   TimelineDatasetSuccess
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 
 const CHART_MARGIN = 8;
 

--- a/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
+++ b/app/scripts/components/exploration/components/datasets/dataset-list-item.tsx
@@ -24,7 +24,7 @@ import DataLayerCard from './data-layer-card-container';
 import {
   DatasetStatus,
   TimelineDatasetSuccess
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import {
   DATASET_TRACK_BLOCK_HEIGHT,
   HEADER_COLUMN_WIDTH

--- a/app/scripts/components/exploration/components/map/index.tsx
+++ b/app/scripts/components/exploration/components/map/index.tsx
@@ -5,7 +5,7 @@ import {
   TimelineDataset,
   DatasetStatus,
   TimelineDatasetSuccess
-} from '../../types.d.ts';
+} from '../../types';
 import { Layer } from './layer';
 import { AnalysisMessageControl } from './analysis-message-control';
 import { ShowTourControl } from './tour-control';

--- a/app/scripts/components/exploration/components/map/layer.tsx
+++ b/app/scripts/components/exploration/components/map/layer.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 // Avoid error: node_modules/date-fns/esm/index.js does not export 'default'
 import * as dateFns from 'date-fns';
 
-import { TimelineDatasetSuccess, VizDatasetSuccess } from '../../types.d.ts';
+import { TimelineDatasetSuccess, VizDatasetSuccess } from '../../types';
 import {
   getRelevantDate,
   getTimeDensityStartDate

--- a/app/scripts/components/exploration/components/timeline-single/dataset-item.tsx
+++ b/app/scripts/components/exploration/components/timeline-single/dataset-item.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { ScaleTime } from 'd3';
 import { themeVal } from '@devseed-ui/theme-provider';
 import { DatasetChart } from '../datasets/dataset-chart';
-import { TimelineDatasetSuccess } from '$components/exploration/types.d.ts';
+import { TimelineDatasetSuccess } from '$components/exploration/types';
 
 const DatasetItem = styled.article`
   width: 100%;

--- a/app/scripts/components/exploration/components/timeline-single/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline-single/timeline.tsx
@@ -31,7 +31,7 @@ import {
   zoomTransformAtom
 } from '$components/exploration/atoms/timeline';
 import { usePreviousValue } from '$utils/use-effect-previous';
-import { TimelineDatasetSuccess } from '$components/exploration/types.d.ts';
+import { TimelineDatasetSuccess } from '$components/exploration/types';
 import { getLowestCommonTimeDensity } from '$components/exploration/data-utils';
 
 const TimelineWrapper = styled.div`

--- a/app/scripts/components/exploration/components/timeline/date-axis.tsx
+++ b/app/scripts/components/exploration/components/timeline/date-axis.tsx
@@ -7,7 +7,7 @@ import startOfYear from 'date-fns/startOfYear';
 import { themeVal } from '@devseed-ui/theme-provider';
 
 import { RIGHT_AXIS_SPACE } from '$components/exploration/constants';
-import { TimeDensity } from '$components/exploration/types.d.ts';
+import { TimeDensity } from '$components/exploration/types';
 
 const GridLine = styled.line`
   stroke: ${themeVal('color.base-200')};
@@ -76,7 +76,11 @@ function getTicks(scale: ScaleTime<number, number>) {
  * @param {TimeDensity} timeDensity - The density of the timeline aka the level of detail (e.g., year, month, day).
  * @returns {Date[]} - An array of minor tick dates.
  */
-function getMinorTicks(scale: ScaleTime<number, number>, majorTicks: Date[], timeDensity: TimeDensity): Date[] {
+function getMinorTicks(
+  scale: ScaleTime<number, number>,
+  majorTicks: Date[],
+  timeDensity: TimeDensity
+): Date[] {
   if (timeDensity === TimeDensity.DAY || majorTicks.length < 2) {
     return [];
   }
@@ -90,7 +94,8 @@ function getMinorTicks(scale: ScaleTime<number, number>, majorTicks: Date[], tim
   const segments = 10;
 
   // Calculate the interval between minor ticks based on the first two major ticks
-  const minorTickInterval = (majorTicks[1].getTime() - majorTicks[0].getTime()) / segments;
+  const minorTickInterval =
+    (majorTicks[1].getTime() - majorTicks[0].getTime()) / segments;
 
   // Initialize minorTicks as an array of Date objects
   let minorTicks: Date[] = [];
@@ -137,7 +142,10 @@ export function DateAxis(props: DateAxisProps) {
 
   const majorTicks = useMemo(() => getTicks(xScaled), [xScaled]);
   const axisDensity = useMemo(() => getTimeDensity(majorTicks), [majorTicks]);
-  const minorTicks = useMemo(() => getMinorTicks(xScaled, majorTicks, axisDensity), [xScaled, majorTicks, axisDensity]);
+  const minorTicks = useMemo(
+    () => getMinorTicks(xScaled, majorTicks, axisDensity),
+    [xScaled, majorTicks, axisDensity]
+  );
 
   return (
     <DateAxisSVG className='date-axis' width={width} height={32}>

--- a/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-controls.tsx
@@ -11,7 +11,7 @@ import { Toolbar, ToolbarGroup, VerticalDivider } from '@devseed-ui/toolbar';
 
 import { isEqual } from 'lodash';
 import { View } from 'react-calendar/dist/cjs/shared/types';
-import { TimeDensity } from './../../types.d.ts';
+import { TimeDensity } from './../../types';
 import { DateAxis } from './date-axis';
 import { TimelineZoomControls } from './timeline-zoom-controls';
 import { TimelineDatePicker } from './timeline-datepicker';
@@ -30,7 +30,10 @@ import {
   selectedIntervalAtom
 } from '$components/exploration/atoms/dates';
 import { DAY_SIZE_MAX } from '$components/exploration/constants';
-import { CalendarMinusIcon, CalendarPlusIcon } from '$components/common/custom-icon';
+import {
+  CalendarMinusIcon,
+  CalendarPlusIcon
+} from '$components/common/custom-icon';
 import { TipToolbarIconButton } from '$components/common/tip-button';
 import useAois from '$components/common/map/controls/hooks/use-aois';
 import { useOnTOIZoom } from '$components/exploration/hooks/use-toi-zoom';

--- a/app/scripts/components/exploration/components/timeline/timeline-head.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline-head.tsx
@@ -6,9 +6,14 @@ import format from 'date-fns/format';
 import startOfDay from 'date-fns/startOfDay';
 import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
-import { TIMELINE_PLAYHEAD_COLOR_LABEL, TIMELINE_PLAYHEAD_COLOR_PRIMARY, TIMELINE_PLAYHEAD_COLOR_SECONDARY, TIMELINE_PLAYHEAD_COLOR_TEXT } from './timeline-controls';
+import {
+  TIMELINE_PLAYHEAD_COLOR_LABEL,
+  TIMELINE_PLAYHEAD_COLOR_PRIMARY,
+  TIMELINE_PLAYHEAD_COLOR_SECONDARY,
+  TIMELINE_PLAYHEAD_COLOR_TEXT
+} from './timeline-controls';
 import { RIGHT_AXIS_SPACE } from '$components/exploration/constants';
-import { DateRange } from '$components/exploration/types.d.ts';
+import { DateRange } from '$components/exploration/types';
 
 // Needs padding so that the timeline head is fully visible.
 // This value gets added to the width.
@@ -55,7 +60,7 @@ const TimelinePlayheadWrapper = styled.div`
 const TimelinePlayheadBase = styled.div`
   background-color: ${TIMELINE_PLAYHEAD_COLOR_SECONDARY};
   color: ${TIMELINE_PLAYHEAD_COLOR_TEXT};
-  padding: ${glsp(0.15)} ${glsp(0.30)};
+  padding: ${glsp(0.15)} ${glsp(0.3)};
   border-radius: ${themeVal('shape.rounded')};
   font-size: 0.75rem;
   position: relative;
@@ -70,21 +75,23 @@ const TimelinePlayheadExtended = styled(TimelinePlayheadBase)`
   text-align: center;
 `;
 
-const TimelinePlayhead = styled(TimelinePlayheadExtended)<{ direction: 'left' | 'right' }>`
-  ${({ direction }) => direction === 'left'
-    ? css`
-      border-bottom-left-radius: ${themeVal('shape.rounded')};
-      border-bottom-right-radius: 0;
-      position: absolute;
-      transform: translateX(-100%);
-      left: ${glsp(1.05)};
-    `
-    : css`
-      border-bottom-right-radius: ${themeVal('shape.rounded')};
-      border-bottom-left-radius: 0;
-      right: 0;
-    `
-  }
+const TimelinePlayhead = styled(TimelinePlayheadExtended)<{
+  direction: 'left' | 'right';
+}>`
+  ${({ direction }) =>
+    direction === 'left'
+      ? css`
+          border-bottom-left-radius: ${themeVal('shape.rounded')};
+          border-bottom-right-radius: 0;
+          position: absolute;
+          transform: translateX(-100%);
+          left: ${glsp(1.05)};
+        `
+      : css`
+          border-bottom-right-radius: ${themeVal('shape.rounded')};
+          border-bottom-left-radius: 0;
+          right: 0;
+        `}
 `;
 
 const TimelinePlayheadWithAfter = styled(TimelinePlayheadBase)`
@@ -142,7 +149,17 @@ type TimelineHeadProps = Omit<TimelineHeadBaseProps, 'children'> & {
 };
 
 export function TimelineHeadBase(props: TimelineHeadBaseProps) {
-  const { domain, xScaled, selectedDay, width, onDayChange, xPosOffset = 0, zIndex = themeVal('zIndices.overlay'), isStrokeDashed, children } = props;
+  const {
+    domain,
+    xScaled,
+    selectedDay,
+    width,
+    onDayChange,
+    xPosOffset = 0,
+    zIndex = themeVal('zIndices.overlay'),
+    isStrokeDashed,
+    children
+  } = props;
 
   const theme = useTheme();
   const rectRef = useRef<HTMLDivElement>(null);
@@ -188,11 +205,17 @@ export function TimelineHeadBase(props: TimelineHeadBaseProps) {
   if (xPos < 0 || xPos > width) return null;
 
   return (
-    <TimelineHeadWrapper style={{width: width + SVG_PADDING * 2, zIndex: zIndex as number}}>
-      <TimelinePlayheadWrapper data-tour={props['data-tour']} ref={rectRef} style={{ transform: `translate(${xPos - xPosOffset}px, -12px)`}}>
+    <TimelineHeadWrapper
+      style={{ width: width + SVG_PADDING * 2, zIndex: zIndex as number }}
+    >
+      <TimelinePlayheadWrapper
+        data-tour={props['data-tour']}
+        ref={rectRef}
+        style={{ transform: `translate(${xPos - xPosOffset}px, -12px)` }}
+      >
         {children}
       </TimelinePlayheadWrapper>
-      <svg style={{width: width + SVG_PADDING * 2, height: '100%'}}>
+      <svg style={{ width: width + SVG_PADDING * 2, height: '100%' }}>
         <g
           transform={`translate(${SVG_PADDING}, 0)`}
           data-tour={props['data-tour']}
@@ -211,54 +234,70 @@ export function TimelineHeadBase(props: TimelineHeadBaseProps) {
   );
 }
 
-export const TimelineHeadPoint = forwardRef<HTMLDivElement, TimelineHeadProps>((props, ref) => {
-  const { label, selectedDay, labelFormat, ...rest } = props;
+export const TimelineHeadPoint = forwardRef<HTMLDivElement, TimelineHeadProps>(
+  (props, ref) => {
+    const { label, selectedDay, labelFormat, ...rest } = props;
 
-  return (
-    <TimelineHeadBase selectedDay={selectedDay} xPosOffset={40} zIndex={1301} {...rest}>
-      <TimelinePlayheadWithAfter ref={ref}>
-        <TimelinePlayheadContent>
-          <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
-          {format(selectedDay, labelFormat)}
-        </TimelinePlayheadContent>
-      </TimelinePlayheadWithAfter>
-    </TimelineHeadBase>
-  );
-});
+    return (
+      <TimelineHeadBase
+        selectedDay={selectedDay}
+        xPosOffset={40}
+        zIndex={1301}
+        {...rest}
+      >
+        <TimelinePlayheadWithAfter ref={ref}>
+          <TimelinePlayheadContent>
+            <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
+            {format(selectedDay, labelFormat)}
+          </TimelinePlayheadContent>
+        </TimelinePlayheadWithAfter>
+      </TimelineHeadBase>
+    );
+  }
+);
 
 TimelineHeadPoint.displayName = 'TimelineHeadPoint';
 
-export const TimelineHeadIn = forwardRef<HTMLDivElement, TimelineHeadProps>((props, ref) => {
-  const { label, selectedDay, labelFormat, ...rest } = props;
+export const TimelineHeadIn = forwardRef<HTMLDivElement, TimelineHeadProps>(
+  (props, ref) => {
+    const { label, selectedDay, labelFormat, ...rest } = props;
 
-  return (
-    <TimelineHeadBase isStrokeDashed selectedDay={selectedDay} {...rest}>
-      <TimelinePlayhead direction='left' ref={ref}>
-        <TimelinePlayheadContent>
-          <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
-          {format(selectedDay, labelFormat)}
-        </TimelinePlayheadContent>
-      </TimelinePlayhead>
-    </TimelineHeadBase>
-  );
-});
+    return (
+      <TimelineHeadBase isStrokeDashed selectedDay={selectedDay} {...rest}>
+        <TimelinePlayhead direction='left' ref={ref}>
+          <TimelinePlayheadContent>
+            <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
+            {format(selectedDay, labelFormat)}
+          </TimelinePlayheadContent>
+        </TimelinePlayhead>
+      </TimelineHeadBase>
+    );
+  }
+);
 
 TimelineHeadIn.displayName = 'TimelineHeadIn';
 
-export const TimelineHeadOut = forwardRef<HTMLDivElement, TimelineHeadProps>((props, ref) => {
-  const { label, selectedDay, labelFormat, ...rest } = props;
+export const TimelineHeadOut = forwardRef<HTMLDivElement, TimelineHeadProps>(
+  (props, ref) => {
+    const { label, selectedDay, labelFormat, ...rest } = props;
 
-  return (
-    <TimelineHeadBase isStrokeDashed selectedDay={selectedDay} xPosOffset={-15} {...rest}>
-      <TimelinePlayhead direction='right' ref={ref}>
-        <TimelinePlayheadContent>
-          <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
-          {format(selectedDay, labelFormat)}
-        </TimelinePlayheadContent>
-      </TimelinePlayhead>
-    </TimelineHeadBase>
-  );
-});
+    return (
+      <TimelineHeadBase
+        isStrokeDashed
+        selectedDay={selectedDay}
+        xPosOffset={-15}
+        {...rest}
+      >
+        <TimelinePlayhead direction='right' ref={ref}>
+          <TimelinePlayheadContent>
+            <TimelinePlayheadLabel>{label}</TimelinePlayheadLabel>
+            {format(selectedDay, labelFormat)}
+          </TimelinePlayheadContent>
+        </TimelinePlayhead>
+      </TimelineHeadBase>
+    );
+  }
+);
 
 TimelineHeadOut.displayName = 'TimelineHeadOut';
 

--- a/app/scripts/components/exploration/components/timeline/timeline-utils.ts
+++ b/app/scripts/components/exploration/components/timeline/timeline-utils.ts
@@ -1,5 +1,5 @@
 import { ScaleTime, Selection, ZoomBehavior, ZoomTransform } from 'd3';
-import { TimelineDatasetSuccess } from '$components/exploration/types.d.ts';
+import { TimelineDatasetSuccess } from '$components/exploration/types';
 
 /**
  * Clamps the given value to the given range.

--- a/app/scripts/components/exploration/components/timeline/timeline.tsx
+++ b/app/scripts/components/exploration/components/timeline/timeline.tsx
@@ -67,7 +67,7 @@ import {
   DatasetStatus,
   TimelineDatasetSuccess,
   ZoomTransformPlain
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import { useInteractionRectHover } from '$components/exploration/hooks/use-dataset-hover';
 import { useAnalysisController } from '$components/exploration/hooks/use-analysis-data-request';
 import useAois from '$components/common/map/controls/hooks/use-aois';

--- a/app/scripts/components/exploration/data-utils.spec.ts
+++ b/app/scripts/components/exploration/data-utils.spec.ts
@@ -7,7 +7,7 @@ import {
   SourceParametersWithLayerId
 } from './data-utils';
 import { RENDER_KEY } from '$components/exploration/constants';
-import { TimeDensity } from '$components/exploration/types.d.ts';
+import { TimeDensity } from '$components/exploration/types';
 
 const LAYER_KEY = 'layer-1';
 const renderExtensionData = {

--- a/app/scripts/components/exploration/data-utils.ts
+++ b/app/scripts/components/exploration/data-utils.ts
@@ -18,7 +18,7 @@ import {
   TimeDensity,
   TimelineDatasetSuccess,
   colorMapScale
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import { utcString2userTzDate } from '$utils/date';
 import { DatasetLayer, DatasetLayerType, SourceParameters } from '$types/veda';
 

--- a/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
+++ b/app/scripts/components/exploration/hooks/use-analysis-data-request.ts
@@ -16,7 +16,7 @@ import {
   TimelineDataset,
   TimelineDatasetAnalysis,
   DatasetStatus
-} from '../types.d.ts';
+} from '../types';
 import { MAX_QUERY_NUM } from '../constants';
 import useAois from '$components/common/map/controls/hooks/use-aois';
 import { useVedaUI } from '$context/veda-ui-provider';

--- a/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/app/scripts/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -9,7 +9,7 @@ import {
   TimelineDataset,
   DatasetStatus,
   VizDataset
-} from '../types.d.ts';
+} from '../types';
 import {
   getTimeDensityFromInterval,
   resolveLayerTemporalExtent,

--- a/app/scripts/components/exploration/hooks/use-timeline-dataset-atom.tsx
+++ b/app/scripts/components/exploration/hooks/use-timeline-dataset-atom.tsx
@@ -1,6 +1,6 @@
 import { useAtom } from 'jotai';
 import { timelineDatasetsAtom } from '../atoms/datasets';
-import { TimelineDataset } from '../types.d.ts';
+import { TimelineDataset } from '../types';
 
 export default function useTimelineDatasetAtom(): [
   TimelineDataset[],

--- a/app/scripts/components/exploration/types.d.ts
+++ b/app/scripts/components/exploration/types.d.ts
@@ -198,7 +198,7 @@ export interface ZoomTransformPlain {
 /**
  * Exploration view mode.
  *
- * - 'simple': Minimal view for embedding
+ * - 'simple': Minimal view used primarily for embedding in viewport constrained external apps
  * - 'default': Full exploration interface
  */
 export type ViewMode = 'simple' | 'default';

--- a/app/scripts/components/exploration/views/default/index.tsx
+++ b/app/scripts/components/exploration/views/default/index.tsx
@@ -12,7 +12,7 @@ import {
   PopoverTourComponent,
   TourManager
 } from '$components/exploration/tour-manager';
-import { TimelineDataset } from '$components/exploration/types.d.ts';
+import { TimelineDataset } from '$components/exploration/types';
 import {
   selectedCompareDateAtom,
   selectedDateAtom

--- a/app/scripts/components/exploration/views/simple/index.tsx
+++ b/app/scripts/components/exploration/views/simple/index.tsx
@@ -19,7 +19,7 @@ import {
   VizDatasetSuccess,
   DatasetStatus,
   TimelineDataset
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 import { useReconcileWithStacMetadata } from '$components/exploration/hooks/use-stac-metadata-datasets';
 import { ProjectionOptions, TimeDensity } from '$types/veda';
 import { useVedaUI } from '$context/veda-ui-provider';

--- a/app/scripts/components/exploration/views/simple/timeline-simple-view.tsx
+++ b/app/scripts/components/exploration/views/simple/timeline-simple-view.tsx
@@ -13,7 +13,7 @@ import {
   TimelineDataset,
   DatasetStatus,
   TimelineDatasetSuccess
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 
 const TimelineWrapper = styled.div`
   width: 100%;

--- a/app/scripts/libs/types.ts
+++ b/app/scripts/libs/types.ts
@@ -42,7 +42,7 @@ import type {
   TimelineDatasetForUrl,
   DateRange,
   ZoomTransformPlain
-} from '$components/exploration/types.d.ts';
+} from '$components/exploration/types';
 
 export type {
   // Common/UI

--- a/storybook/src/stories/components/exploration/components/datasets/colormap-options.stories.tsx
+++ b/storybook/src/stories/components/exploration/components/datasets/colormap-options.stories.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { ColormapOptions } from '$components/common/dataset-layer-card/colormap-options';
-import { colorMapScale } from '$components/exploration/types.d.ts';
+import { colorMapScale } from '$components/exploration/types';
 
 const meta: Meta<typeof ColormapOptions> = {
   title: 'Library Components/Data Layers/Colormap Options',

--- a/storybook/src/stories/data-layer-card-hooked.tsx
+++ b/storybook/src/stories/data-layer-card-hooked.tsx
@@ -11,7 +11,7 @@ import { mockDatasets } from './mock-data.js';
 import { ExplorationMap } from '$components/exploration/components/map';
 
 import DataLayerCardPresentational from '$components/common/dataset-layer-card';
-import { TimelineDataset } from '$components/exploration/types.d.ts';
+import { TimelineDataset } from '$components/exploration/types';
 export interface colorMapScale {
   min: number;
   max: number;


### PR DESCRIPTION
### Description of Changes
This fixes a filename typo from `types.d.ts.ts` to `types.d.ts` and all the resulting imports.

Note this builds on a prior PR (not main) as files were moved around, to prevent conflicts.

### Validation / Testing
App builds, and loads 