### PR TITLE
fix: next-veda-ui is unsupported / removed from monday release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,13 +100,6 @@ jobs:
           repository: nasa-impact/veda-config
           event-type: update-version
           client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": "${{ steps.git-release.outputs.VERSION_NUMBER }}"}'
-      - name: Trigger version update in Template Instance
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{steps.generate-token.outputs.token}}
-          repository: nasa-impact/next-veda-ui
-          event-type: update-version
-          client-payload: '{"ref": "${{ github.ref }}", "VERSION_NUMBER": ${{ env.VERSION }}}'
   notify:
     # If any of job fails
     if: failure()


### PR DESCRIPTION
Closes: #1955 

### Description of Changes
Because of the current unsupported state of next-veda-ui, this PR removes `next-veda-ui` from the `veda-ui` release workflow. This is to prevent auto-generation of [ignored PRs](https://github.com/NASA-IMPACT/next-veda-ui/pulls). 
<img width="1285" height="731" alt="Screenshot 2025-12-16 at 12 45 48 PM" src="https://github.com/user-attachments/assets/ddb72c2d-a055-4b92-943a-35d373a6f5f2" />

### Notes & Questions About Changes
Note, there is a [companion PR](https://github.com/NASA-IMPACT/next-veda-ui/pull/120) in `next-veda-ui` to mark that repo as unsupported / beta.


