### PR TITLE
ci: Connect to NPM using OIDC instead of a token for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 # Sets the GITHUB_TOKEN permissions to allow release
 permissions:
   contents: write
+  id-token: write # Required for OIDC connection with NPM
 
 # This action requires a GitHub app with content write access installed
 # to bypass the main branch  protection rule and dispatch the event to a different repo
@@ -91,8 +92,6 @@ jobs:
         run: |
           yarn buildlib
           npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
**Closes:** https://github.com/NASA-IMPACT/veda-ui/issues/1961

### Description of Changes
- Replace npm token authentication with OIDC-based authentication

Prerequisite done:
- Added this repo as a trusted publisher for @teamimpact/veda-ui npm package
<img width="796" height="405" alt="image" src="https://github.com/user-attachments/assets/e9581f8c-a8ea-47c5-a870-76d6fd03a100" />

### Validation / Testing
Not sure how to test this..?

### Post merge
- [ ] Disallow token based publishing access for @teamimpact/veda-ui npm package
(switch to the second one in the image)
<img width="680" height="127" alt="image" src="https://github.com/user-attachments/assets/9fe13bb5-205c-40cc-b783-a8f904e367cc" />

- [ ] Remove `NPM_TOKEN` from GitHub env vars