### PR TITLE
fix: escape regex backslashes in release-it config for scoped commits

### DIFF
--- a/.release-it.js
+++ b/.release-it.js
@@ -22,7 +22,7 @@ function groupCommitsByCategory(logs) {
   // Loop through each prefix to find conventional commit pattern ex. feat: , feat(card):, feat(card)! including some edge cases
   Object.entries(prefixes).forEach(([prefix, category]) => {
     const regex = new RegExp(
-      `^(${prefix}(\([\w\-]+\))?!?: [^\r\n]+((\s)((\s)[^\r\n]+)+)*)(\s?)$`
+      `^(${prefix}(\\([\\w\\-]+\\))?!?: [^\\r\\n]+((\\s)((\\s)[^\\r\\n]+)+)*)(\\s?)$`
     );
     const matches = logs.filter((l) => l.match(regex));
     grouped[category] = [...matches, ...grouped[category]];


### PR DESCRIPTION
**Closes:** https://github.com/NASA-IMPACT/veda-ui/issues/1963

### Description of Changes

Commits with scopes (e.g., `docs(adr):`, `fix(auth):`) were not appearing in [GitHub release changelogs](https://github.com/NASA-IMPACT/veda-ui/releases/tag/v6.20.3).

The issue seems to be caused by the regex in `.release-it.js` thats using single backslashes inside a template literal passed to `new RegExp()`. So things like `\(` was interpreted as `(` (a grouping operator) instead of a literal parenthesis.

Double-escaping the backslashes should fix the pattern so scoped conv commits are matched correctly.

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing

Tested locally by running this utility in my terminal:

```
node -e "
  const config = require('./.release-it.js');
  const releaseNotes = config.github.releaseNotes;
  const changelog = 'feat: add feature\nfix(auth): fix login bug\ndocs(adr): update ADR';
  console.log(releaseNotes({ changelog }));
"
```

Before fix: Only feat: add feature appears in output
After fix: All three commits appear, including scoped ones (fix(auth):, docs(adr):)