### PR TITLE
fix: preserve all dates for non-periodic datasets with summaries.datetime

### DIFF
--- a/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-data.spec.ts
+++ b/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-data.spec.ts
@@ -171,4 +171,84 @@ describe('fetchStacDatasetById', () => {
     ]);
     expect(result.renders).toEqual([{ id: 'r2' }]);
   });
+
+  it('preserves all dates for non-periodic data with summaries.datetime', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        summaries: {
+          datetime: [
+            '2000-01-01T00:00:00Z',
+            '2005-01-01T00:00:00Z',
+            '2010-01-01T00:00:00Z',
+            '2015-01-01T00:00:00Z',
+            '2020-01-01T00:00:00Z'
+          ]
+        },
+        extent: {
+          temporal: {
+            interval: [['2000-01-01T00:00:00Z', '2020-01-01T00:00:00Z']]
+          }
+        },
+        'dashboard:is_periodic': false,
+        'dashboard:time_density': 'year'
+      }
+    });
+
+    const dataset = {
+      data: { id: 'd6', type: 'raster', stacCol: 'col6' }
+    } as any;
+
+    const { fetchStacDatasetById } = await import(
+      './use-stac-metadata-datasets'
+    );
+    const result = await fetchStacDatasetById(dataset, 'http://fake');
+
+    // Should preserve all 5 dates, not just the first 2
+    expect(result.domain).toEqual([
+      '2000-01-01T00:00:00Z',
+      '2005-01-01T00:00:00Z',
+      '2010-01-01T00:00:00Z',
+      '2015-01-01T00:00:00Z',
+      '2020-01-01T00:00:00Z'
+    ]);
+    expect(result.isPeriodic).toBe(false);
+  });
+
+  it('preserves all dates for non-periodic wmts with summaries.datetime', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: {
+        summaries: {
+          datetime: [
+            '2000-01-01T00:00:00Z',
+            '2005-01-01T00:00:00Z',
+            '2010-01-01T00:00:00Z'
+          ]
+        },
+        extent: {
+          temporal: {
+            interval: [['2000-01-01T00:00:00Z', '2010-01-01T00:00:00Z']]
+          }
+        },
+        'dashboard:is_periodic': false,
+        'dashboard:time_density': 'year'
+      }
+    });
+
+    const dataset = {
+      data: { id: 'd7', type: 'wmts', stacCol: 'col7' }
+    } as any;
+
+    const { fetchStacDatasetById } = await import(
+      './use-stac-metadata-datasets'
+    );
+    const result = await fetchStacDatasetById(dataset, 'http://fake');
+
+    // Should preserve all 3 dates, not just the first 2
+    expect(result.domain).toEqual([
+      '2000-01-01T00:00:00Z',
+      '2005-01-01T00:00:00Z',
+      '2010-01-01T00:00:00Z'
+    ]);
+    expect(result.isPeriodic).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes: https://github.com/NASA-IMPACT/veda-ui/issues/1966

### Description of Changes
- Fix regression where non-periodic datasets with discrete dates in summaries.datetime only show the first 2 dates in the timeline instead of all dates
- Skip normalizeDomain() for non-periodic data when domain has >2 discrete dates from summaries.datetime  

### Notes & Questions About Changes
_{Add additonal notes and outstanding questions here related to changes in this pull request}_

### Validation / Testing
- Using the deploy [preview in this PR](https://github.com/US-GHG-Center/veda-config-ghg/pull/845), test the dataset mentioned in https://github.com/NASA-IMPACT/veda-ui/issues/1966
- Smoke test other datasets to make sure there are no regressions
                                                                                                                      
