### PR TITLE
ci: Make sure npm version is 11.5.1 or later to support trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           node-version: ${{ env.NODE }}
           registry-url: https://registry.npmjs.org/
+      - name: Install npm 11.5.1+ for trusted publishing
+        run: npm install -g npm@^11.5.1
+
       - run: yarn
       # Clean up any stale version tags left from failed release runs.
       # Context:


### PR DESCRIPTION
Issue: https://github.com/NASA-IMPACT/veda-ui/actions/runs/21595621843/job/62227167955

tldr:
> npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access
> npm notice Access token expired or revoked. Please try logging in again.
> npm error code E404

Looks like it's still trying to use access token.

From https://docs.npmjs.com/trusted-publishers,
> Note: Trusted publishing requires npm CLI version 11.5.1 or later.

Adds a step to ensure that npm version 11.5.1 or later is installed in the running before publishing.