### PR TITLE
ci: use npx for npm version instead of global installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,8 +53,6 @@ jobs:
         with:
           node-version: ${{ env.NODE }}
           registry-url: https://registry.npmjs.org/
-      - name: Install npm 11.5.1+ for trusted publishing
-        run: npm install -g npm@^11.5.1
 
       - run: yarn
       # Clean up any stale version tags left from failed release runs.
@@ -94,7 +92,7 @@ jobs:
       - name: Publish package to NPM
         run: |
           yarn buildlib
-          npm publish
+          npx npm@^11.5.1 publish
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
### Description of Changes
Uses npx for npm version for publishing instead of installing globally which we apparently don't have permission for. See [this test workflow run](https://github.com/NASA-IMPACT/veda-ui/actions/runs/21605162352/job/62361132757)

I've already tested this via the [test-trusted-publishing branch](https://github.com/NASA-IMPACT/veda-ui/compare/test-trusted-publishing?expand=1) - [this](https://github.com/NASA-IMPACT/veda-ui/actions/runs/21636292958/job/62362594306) is the workflow run using `npm publish --dry-run`. It only failed because of the following error:
> npm error You cannot publish over the previously published versions: 6.20.3.

But the other steps in the workflow should create a new version.
