### PR TITLE
fix: remove unconditional debug console.log in raster-timeseries

### DIFF
--- a/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
@@ -97,9 +97,6 @@ export function useStacResponse({
             'color: red;',
             id
           );
-        // Temporarily turning on log for debugging
-        /* eslint-disable-next-line no-console */
-        console.log(error);
         return;
       }
     };

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
@@ -85,7 +85,7 @@ export function useStacResponse({
 
         setStacCollection(responseData.features);
         changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
-      } catch (error) {
+      } catch {
         if (!controller.signal.aborted) {
           setStacCollection([]);
           changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });


### PR DESCRIPTION
**Related Ticket:** _N/A_

### Description of Changes
Remove a `console.log(error)` left in production code with the comment "Temporarily turning on log for debugging". The conditional debug logging behind the `LOG` flag is preserved. Also switch to catch-without-binding since the error variable is no longer referenced.

### Notes & Questions About Changes
- The guarded `if (LOG) console.log(...)` statements are intentionally kept — only the unconditional one is removed

### Validation / Testing
- Full test suite passes (161/161)
- Lefthook pre-commit hooks pass (eslint, stylelint, ts-check)
- Zero new lint warnings introduced (removed 1 pre-existing `no-unused-vars` warning)