### PR TITLE
fix: move mediaQuery inside useEffect to fix missing dependency

### DIFF
--- a/packages/veda-ui/src/utils/use-prefers-reduced-motion.ts
+++ b/packages/veda-ui/src/utils/use-prefers-reduced-motion.ts
@@ -1,18 +1,13 @@
 import { useEffect, useState } from 'react';
 
 export default function useReducedMotion() {
-  const mediaQuery =
-    typeof window !== 'undefined'
-      ? window.matchMedia('(prefers-reduced-motion: reduce)')
-      : null;
-
-  const [reducedMotion, setReducedMotion] = useState(
-    mediaQuery?.matches || false
-  );
+  const [reducedMotion, setReducedMotion] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
 
   useEffect(() => {
-    if (!mediaQuery) return;
-
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
     const listener = () => setReducedMotion(mediaQuery.matches);
     mediaQuery.addEventListener('change', listener);
 


### PR DESCRIPTION
**Related Ticket:** _N/A_

### Description of Changes
In `useReducedMotion()`, the `mediaQuery` variable was created during render but used inside a `useEffect` with an empty dependency array, triggering the `react-hooks/exhaustive-deps` lint warning. This fix moves the `MediaQueryList` creation inside the effect and uses a lazy `useState` initializer for the initial value, keeping SSR compatibility.

### Notes & Questions About Changes
- `window.matchMedia()` returns the same `MediaQueryList` for the same query string, so the empty dependency array was functionally correct — but the code pattern violated React best practices and the lint rule

### Validation / Testing
- Full test suite passes (161/161)
- Zero eslint warnings on the modified file (was 1 `react-hooks/exhaustive-deps` warning before)