### PR TITLE
fix: include CSS/SCSS files in lefthook stylelint glob

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,5 +8,5 @@ pre-commit:
       glob: '*.{js,ts,jsx,tsx}'
       run: yarn eslint {staged_files}
     stylelint:
-      glob: '*.{js,ts,jsx,tsx}'
+      glob: '*.{js,ts,jsx,tsx,scss,css}'
       run: yarn lint:css {staged_files}


### PR DESCRIPTION
**Related Ticket:** _N/A_

### Description of Changes
The stylelint pre-commit hook glob only matched `*.{js,ts,jsx,tsx}`, so staging `.scss` or `.css` files would skip the stylelint check entirely. Added `scss` and `css` extensions to the glob pattern.

### Notes & Questions About Changes
- The `yarn lint:css` script already covers `.scss` files via its own glob patterns — this fix ensures the pre-commit hook actually triggers for stylesheet changes

### Validation / Testing
- Lefthook config reloaded automatically on commit (`sync hooks: ✔️`)