### PR TITLE
feat: support `tilingMode: cog` for `raster` data type to allow visualization from external stac

### DIFF
--- a/mock/datasets/hls-external.data.mdx
+++ b/mock/datasets/hls-external.data.mdx
@@ -20,7 +20,8 @@ layers:
     stacApiEndpoint: https://cmr.earthdata.nasa.gov/cloudstac/LPCLOUD
     tileApiEndpoint: https://openveda.cloud/api/raster
     name: HLS Landsat 30m
-    type: external-stac
+    type: raster
+    tilingMode: cog
     time_density: day
     description: Harmonized Landsat Sentinel-2 (HLS) Landsat Operational Land Imager Surface Reflectance and TOA Brightness Daily Global 30m v2.0.
     zoomExtent:
@@ -44,6 +45,6 @@ layers:
         - "#fde725"
 ---
 
-Test dataset for the `external-stac` data type using NASA CMR STAC (LPCLOUD).
+Test dataset for the `raster` type with `tilingMode: cog` using NASA CMR STAC (LPCLOUD).
 
 HLS provides consistent surface reflectance data from a virtual constellation of Landsat and Sentinel-2 sensors.

--- a/mock/datasets/hls-external.data.mdx
+++ b/mock/datasets/hls-external.data.mdx
@@ -1,0 +1,49 @@
+---
+id: hls-l30-external
+name: 'HLS Landsat 30m (External STAC)'
+featured: true
+sourceExclusive: Mock
+description: "Harmonized Landsat Sentinel-2 (HLS) Landsat 30m Surface Reflectance from NASA CMR STAC."
+media:
+  src: ::file ./img-placeholder-3.jpg
+  alt: HLS Landsat imagery placeholder
+taxonomy:
+  - name: Source
+    values:
+      - Mock
+  - name: Topics
+    values:
+      - Agriculture
+layers:
+  - id: hls-l30-external
+    stacCol: HLSL30_2.0
+    stacApiEndpoint: https://cmr.earthdata.nasa.gov/cloudstac/LPCLOUD
+    tileApiEndpoint: https://openveda.cloud/api/raster
+    name: HLS Landsat 30m
+    type: external-stac
+    time_density: day
+    description: Harmonized Landsat Sentinel-2 (HLS) Landsat Operational Land Imager Surface Reflectance and TOA Brightness Daily Global 30m v2.0.
+    zoomExtent:
+      - 7
+      - 20
+    sourceParams:
+      assets: s3_B04
+      colormap_name: viridis
+      rescale:
+        - 0
+        - 3000
+    legend:
+      type: gradient
+      min: "0"
+      max: "3000"
+      stops:
+        - "#440154"
+        - "#3b528b"
+        - "#21918c"
+        - "#5ec962"
+        - "#fde725"
+---
+
+Test dataset for the `external-stac` data type using NASA CMR STAC (LPCLOUD).
+
+HLS provides consistent surface reflectance data from a virtual constellation of Landsat and Sentinel-2 sensors.

--- a/mock/datasets/landsat-element84.data.mdx
+++ b/mock/datasets/landsat-element84.data.mdx
@@ -20,7 +20,8 @@ layers:
     stacApiEndpoint: https://earth-search.aws.element84.com/v1
     tileApiEndpoint: https://openveda.cloud/api/raster
     name: Landsat Collection 2 Level-2
-    type: external-stac
+    type: raster
+    tilingMode: cog
     time_density: day
     description: Atmospherically corrected global Landsat Collection 2 Level-2 data from Element84 Earth Search.
     zoomExtent:
@@ -45,6 +46,6 @@ layers:
         - "#fde725"
 ---
 
-Test dataset for the `external-stac` data type using Element84 Earth Search STAC API.
+Test dataset for the `raster` type with `tilingMode: cog` using Element84 Earth Search STAC API.
 
 Landsat Collection 2 Level-2 includes atmospherically corrected surface reflectance data from Landsat 4-9 satellites.

--- a/mock/datasets/landsat-element84.data.mdx
+++ b/mock/datasets/landsat-element84.data.mdx
@@ -1,0 +1,49 @@
+---
+id: landsat-element84
+name: 'Landsat C2 L2 (Element84 Earth Search)'
+featured: true
+sourceExclusive: Mock
+description: "Atmospherically corrected global Landsat Collection 2 Level-2 data from Element84 Earth Search."
+media:
+  src: ::file ./img-placeholder-3.jpg
+  alt: Landsat satellite imagery placeholder
+taxonomy:
+  - name: Source
+    values:
+      - Mock
+  - name: Topics
+    values:
+      - Agriculture
+layers:
+  - id: landsat-c2-l2-element84
+    stacCol: landsat-c2-l2
+    stacApiEndpoint: https://earth-search.aws.element84.com/v1
+    tileApiEndpoint: https://openveda.cloud/api/raster
+    name: Landsat Collection 2 Level-2
+    type: external-stac
+    time_density: day
+    description: Atmospherically corrected global Landsat Collection 2 Level-2 data from Element84 Earth Search.
+    zoomExtent:
+      - 7
+      - 20
+    sourceParams:
+      assets: red
+      colormap_name: viridis
+      rescale:
+        - 0
+        - 20000
+    legend:
+      type: gradient
+      min: "0"
+      max: "20000"
+      stops:
+        - "#440154"
+        - "#3b528b"
+        - "#21918c"
+        - "#5ec962"
+        - "#fde725"
+---
+
+Test dataset for the `external-stac` data type using Element84 Earth Search STAC API.
+
+Landsat Collection 2 Level-2 includes atmospherically corrected surface reflectance data from Landsat 4-9 satellites.

--- a/mock/datasets/landsat-element84.data.mdx
+++ b/mock/datasets/landsat-element84.data.mdx
@@ -26,6 +26,7 @@ layers:
     zoomExtent:
       - 7
       - 20
+    searchLimit: 100
     sourceParams:
       assets: red
       colormap_name: viridis

--- a/mock/datasets/sentinel2-element84.data.mdx
+++ b/mock/datasets/sentinel2-element84.data.mdx
@@ -20,7 +20,8 @@ layers:
     stacApiEndpoint: https://earth-search.aws.element84.com/v1
     tileApiEndpoint: https://openveda.cloud/api/raster
     name: Sentinel-2 Level-2A
-    type: external-stac
+    type: raster
+    tilingMode: cog
     time_density: day
     description: Global Sentinel-2 Level-2A surface reflectance data from Element84 Earth Search.
     zoomExtent:
@@ -45,6 +46,6 @@ layers:
         - "#fde725"
 ---
 
-Test dataset for the `external-stac` data type using Element84 Earth Search STAC API.
+Test dataset for the `raster` type with `tilingMode: cog` using Element84 Earth Search STAC API.
 
 Sentinel-2 Level-2A provides atmospherically corrected surface reflectance data from the Sentinel-2 constellation.

--- a/mock/datasets/sentinel2-element84.data.mdx
+++ b/mock/datasets/sentinel2-element84.data.mdx
@@ -1,0 +1,49 @@
+---
+id: sentinel2-element84
+name: 'Sentinel-2 L2A (Element84 Earth Search)'
+featured: true
+sourceExclusive: Mock
+description: "Global Sentinel-2 Level-2A data from the Multispectral Instrument (MSI) via Element84 Earth Search."
+media:
+  src: ::file ./img-placeholder-3.jpg
+  alt: Sentinel-2 satellite imagery placeholder
+taxonomy:
+  - name: Source
+    values:
+      - Mock
+  - name: Topics
+    values:
+      - Agriculture
+layers:
+  - id: sentinel-2-l2a-element84
+    stacCol: sentinel-2-l2a
+    stacApiEndpoint: https://earth-search.aws.element84.com/v1
+    tileApiEndpoint: https://openveda.cloud/api/raster
+    name: Sentinel-2 Level-2A
+    type: external-stac
+    time_density: day
+    description: Global Sentinel-2 Level-2A surface reflectance data from Element84 Earth Search.
+    zoomExtent:
+      - 7
+      - 20
+    sourceParams:
+      assets: red
+      colormap_name: viridis
+      rescale:
+        - 0
+        - 10000
+    legend:
+      type: gradient
+      min: "0"
+      max: "10000"
+      stops:
+        - "#440154"
+        - "#3b528b"
+        - "#21918c"
+        - "#5ec962"
+        - "#fde725"
+---
+
+Test dataset for the `external-stac` data type using Element84 Earth Search STAC API.
+
+Sentinel-2 Level-2A provides atmospherically corrected surface reflectance data from the Sentinel-2 constellation.

--- a/mock/datasets/sentinel2-element84.data.mdx
+++ b/mock/datasets/sentinel2-element84.data.mdx
@@ -26,6 +26,7 @@ layers:
     zoomExtent:
       - 7
       - 20
+    searchLimit: 100
     sourceParams:
       assets: red
       colormap_name: viridis

--- a/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
@@ -48,13 +48,15 @@ function useExternalStacSearch({
   changeStatus,
   stacCol,
   date,
-  stacApiEndpointToUse
+  stacApiEndpointToUse,
+  searchLimit
 }: {
   id: string;
   changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
   stacCol: string;
   date: Date;
   stacApiEndpointToUse: string;
+  searchLimit: number;
 }): [
   ExternalStacItem[],
   Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null
@@ -80,7 +82,7 @@ function useExternalStacSearch({
           datetime: `${userTzDate2utcString(
             startOfDay(date)
           )}/${userTzDate2utcString(endOfDay(date))}`,
-          limit: 1000
+          limit: searchLimit
         };
 
         if (LOG) {
@@ -143,7 +145,7 @@ function useExternalStacSearch({
       changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, stacCol, date, stacApiEndpointToUse]);
+  }, [id, stacCol, date, stacApiEndpointToUse, searchLimit]);
 
   // Markers to show where the data is when zoom is low
   const points = useMemo(() => {
@@ -251,6 +253,9 @@ function useExternalStacTileSources({
   return tileSources;
 }
 
+// Default search limit for STAC search
+const DEFAULT_SEARCH_LIMIT = 500;
+
 export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
   const {
     id,
@@ -269,7 +274,8 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     colorMap,
     reScale,
     envApiStacEndpoint,
-    envApiRasterEndpoint
+    envApiRasterEndpoint,
+    searchLimit = DEFAULT_SEARCH_LIMIT
   } = props;
 
   const { current: mapInstance } = useMaps();
@@ -288,7 +294,8 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     changeStatus,
     stacCol,
     date,
-    stacApiEndpointToUse
+    stacApiEndpointToUse,
+    searchLimit
   });
 
   // Get asset key from sourceParams for tile params

--- a/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { LngLatBoundsLike } from 'mapbox-gl';
+import styled from 'styled-components';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
+import { Button } from '@devseed-ui/button';
+import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
 import { ExternalStacTimeseriesProps, ExternalStacItem } from '../types';
 import { FIT_BOUNDS_PADDING, getMergedBBox, requestQuickCache } from '../utils';
@@ -22,6 +25,48 @@ interface TileSource {
   bbox: [number, number, number, number];
 }
 
+interface StacLink {
+  rel: string;
+  href: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+interface StacSearchResponse {
+  features: ExternalStacItem[];
+  context?: {
+    matched?: number;
+    returned?: number;
+  };
+  numberMatched?: number;
+  numberReturned?: number;
+  links?: StacLink[];
+}
+
+interface PaginationState {
+  hasMore: boolean;
+  totalMatched: number;
+  loadedCount: number;
+  isLoadingMore: boolean;
+  nextLink: StacLink | null;
+}
+
+const PaginationOverlay = styled.div`
+  position: absolute;
+  bottom: ${glsp(1)};
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  background: ${themeVal('color.surface')};
+  padding: ${glsp(0.5, 1)};
+  border-radius: ${themeVal('shape.rounded')};
+  box-shadow: ${themeVal('boxShadow.elevationA')};
+  display: flex;
+  align-items: center;
+  gap: ${glsp(0.5)};
+  font-size: 0.875rem;
+`;
+
 /**
  * Extracts the asset href from a STAC item, preferring S3 alternate if available.
  */
@@ -40,8 +85,7 @@ function getAssetHref(item: ExternalStacItem, assetKey: string): string | null {
 }
 
 /**
- * Hook to fetch STAC items from an external STAC server.
- * Similar to useStacResponse but fetches full item data including assets.
+ * Hook to fetch STAC items from an external STAC server with pagination support.
  */
 function useExternalStacSearch({
   id,
@@ -57,11 +101,32 @@ function useExternalStacSearch({
   date: Date;
   stacApiEndpointToUse: string;
   searchLimit: number;
-}): [
-  ExternalStacItem[],
-  Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null
-] {
+}): {
+  stacItems: ExternalStacItem[];
+  points: Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null;
+  pagination: PaginationState;
+  loadMore: () => void;
+} {
   const [stacItems, setStacItems] = useState<ExternalStacItem[]>([]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    hasMore: false,
+    totalMatched: 0,
+    loadedCount: 0,
+    isLoadingMore: false,
+    nextLink: null
+  });
+
+  // Reset when date or collection changes
+  useEffect(() => {
+    setStacItems([]);
+    setPagination({
+      hasMore: false,
+      totalMatched: 0,
+      loadedCount: 0,
+      isLoadingMore: false,
+      nextLink: null
+    });
+  }, [stacCol, date, stacApiEndpointToUse]);
 
   useEffect(() => {
     if (!id || !stacCol) return;
@@ -75,8 +140,6 @@ function useExternalStacSearch({
         const searchUrl = `${stacApiEndpointToUse}/search`;
 
         // Build search payload using standard STAC parameters
-        // Use 'collections' array (universally supported) instead of CQL2 filter for collection
-        // This ensures compatibility with external STAC servers that may use different CQL2 operators
         const payload = {
           collections: [stacCol],
           datetime: `${userTzDate2utcString(
@@ -98,9 +161,7 @@ function useExternalStacSearch({
           /* eslint-enable no-console */
         }
 
-        const responseData = await requestQuickCache<{
-          features: ExternalStacItem[];
-        }>({
+        const responseData = await requestQuickCache<StacSearchResponse>({
           url: searchUrl,
           payload,
           controller
@@ -118,11 +179,32 @@ function useExternalStacSearch({
           /* eslint-enable no-console */
         }
 
-        setStacItems(responseData.features);
+        const features = responseData.features || [];
+        const totalMatched =
+          responseData.context?.matched ||
+          responseData.numberMatched ||
+          features.length;
+        const nextLink = responseData.links?.find((l) => l.rel === 'next');
+
+        setStacItems(features);
+        setPagination({
+          hasMore: !!nextLink,
+          totalMatched,
+          loadedCount: features.length,
+          isLoadingMore: false,
+          nextLink: nextLink || null
+        });
         changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
       } catch (error) {
         if (!controller.signal.aborted) {
           setStacItems([]);
+          setPagination({
+            hasMore: false,
+            totalMatched: 0,
+            loadedCount: 0,
+            isLoadingMore: false,
+            nextLink: null
+          });
           changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
         }
         if (LOG)
@@ -147,10 +229,52 @@ function useExternalStacSearch({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, stacCol, date, stacApiEndpointToUse, searchLimit]);
 
+  const loadMore = useCallback(async () => {
+    if (!pagination.nextLink || pagination.isLoadingMore) return;
+
+    setPagination((prev) => ({ ...prev, isLoadingMore: true }));
+
+    try {
+      const controller = new AbortController();
+      let responseData: StacSearchResponse;
+
+      // Handle both GET and POST next links
+      if (pagination.nextLink.method === 'POST' && pagination.nextLink.body) {
+        responseData = await requestQuickCache<StacSearchResponse>({
+          url: pagination.nextLink.href,
+          payload: pagination.nextLink.body,
+          controller
+        });
+      } else {
+        responseData = await requestQuickCache<StacSearchResponse>({
+          url: pagination.nextLink.href,
+          payload: null,
+          controller
+        });
+      }
+
+      const newFeatures = responseData.features || [];
+      const nextLink = responseData.links?.find((l) => l.rel === 'next');
+
+      setStacItems((prev) => [...prev, ...newFeatures]);
+      setPagination((prev) => ({
+        ...prev,
+        hasMore: !!nextLink,
+        loadedCount: prev.loadedCount + newFeatures.length,
+        isLoadingMore: false,
+        nextLink: nextLink || null
+      }));
+    } catch (error) {
+      /* eslint-disable-next-line no-console */
+      console.error('Error loading more items:', error);
+      setPagination((prev) => ({ ...prev, isLoadingMore: false }));
+    }
+  }, [pagination.nextLink, pagination.isLoadingMore]);
+
   // Markers to show where the data is when zoom is low
   const points = useMemo(() => {
     if (!stacItems.length) return null;
-    const pts = stacItems.map((f) => {
+    const points = stacItems.map((f) => {
       const [w, s, e, n] = f.bbox;
       return {
         bounds: [
@@ -161,10 +285,10 @@ function useExternalStacSearch({
       };
     });
 
-    return pts;
+    return points;
   }, [stacItems]);
 
-  return [stacItems, points];
+  return { stacItems, points, pagination, loadMore };
 }
 
 /**
@@ -289,7 +413,7 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const [stacItems, points] = useExternalStacSearch({
+  const { stacItems, points, pagination, loadMore } = useExternalStacSearch({
     id,
     changeStatus,
     stacCol,
@@ -311,9 +435,9 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
 
   // Listen to mouse events on the markers layer
   const onPointsClick = useCallback(
-    (features) => {
-      const b = JSON.parse(features[0].properties.bounds);
-      mapInstance?.fitBounds(b, { padding: FIT_BOUNDS_PADDING });
+    (features: { properties: { bounds: string } }[]) => {
+      const bounds = JSON.parse(features[0].properties.bounds);
+      mapInstance?.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
     },
     [mapInstance]
   );
@@ -374,6 +498,20 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
           />
         );
       })}
+      {pagination.hasMore && !hidden && (
+        <PaginationOverlay>
+          <span>
+            Showing {pagination.loadedCount} of {pagination.totalMatched} items
+          </span>
+          <Button
+            size='small'
+            onClick={loadMore}
+            disabled={pagination.isLoadingMore}
+          >
+            {pagination.isLoadingMore ? 'Loading...' : 'Load More'}
+          </Button>
+        </PaginationOverlay>
+      )}
     </>
   );
 }

--- a/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { LngLatBoundsLike } from 'mapbox-gl';
 import styled from 'styled-components';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
@@ -10,7 +9,7 @@ import { ExternalStacTimeseriesProps, ExternalStacItem } from '../types';
 import { FIT_BOUNDS_PADDING, getMergedBBox, requestQuickCache } from '../utils';
 import useFitBbox from '../hooks/use-fit-bbox';
 import useMaps from '../hooks/use-maps';
-import PointsLayer from './points-layer';
+import FootprintsLayer from './footprints-layer';
 import { useRequestStatus, STATUS_KEY } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
 import { userTzDate2utcString } from '$utils/date';
@@ -103,7 +102,10 @@ function useExternalStacSearch({
   searchLimit: number;
 }): {
   stacItems: ExternalStacItem[];
-  points: Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null;
+  footprints: Array<{
+    bounds: [[number, number], [number, number]];
+    geometry?: ExternalStacItem['geometry'];
+  }> | null;
   pagination: PaginationState;
   loadMore: () => void;
 } {
@@ -271,24 +273,22 @@ function useExternalStacSearch({
     }
   }, [pagination.nextLink, pagination.isLoadingMore]);
 
-  // Markers to show where the data is when zoom is low
-  const points = useMemo(() => {
+  // Footprints to show where the data is when zoom is low
+  const footprints = useMemo(() => {
     if (!stacItems.length) return null;
-    const points = stacItems.map((f) => {
+    return stacItems.map((f) => {
       const [w, s, e, n] = f.bbox;
       return {
         bounds: [
           [w, s],
           [e, n]
-        ] as LngLatBoundsLike,
-        center: [(w + e) / 2, (s + n) / 2] as [number, number]
+        ] as [[number, number], [number, number]],
+        geometry: f.geometry
       };
     });
-
-    return points;
   }, [stacItems]);
 
-  return { stacItems, points, pagination, loadMore };
+  return { stacItems, footprints, pagination, loadMore };
 }
 
 /**
@@ -413,14 +413,16 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const { stacItems, points, pagination, loadMore } = useExternalStacSearch({
-    id,
-    changeStatus,
-    stacCol,
-    date,
-    stacApiEndpointToUse,
-    searchLimit
-  });
+  const { stacItems, footprints, pagination, loadMore } = useExternalStacSearch(
+    {
+      id,
+      changeStatus,
+      stacCol,
+      date,
+      stacApiEndpointToUse,
+      searchLimit
+    }
+  );
 
   // Get asset key from sourceParams for tile params
   const assetKey = sourceParams?.assets || 'cog_default';
@@ -433,9 +435,9 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     changeStatus
   });
 
-  // Listen to mouse events on the markers layer
-  const onPointsClick = useCallback(
-    (features: { properties: { bounds: string } }[]) => {
+  // Listen to mouse events on the footprints layer
+  const onFootprintsClick = useCallback(
+    (features) => {
       const bounds = JSON.parse(features[0].properties.bounds);
       mapInstance?.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
     },
@@ -458,12 +460,15 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
 
   return (
     <>
-      {points && (
-        <PointsLayer
+      {footprints && (
+        <FootprintsLayer
           id={id}
-          points={points}
+          footprints={footprints}
           zoomExtent={zoomExtent}
-          onPointsClick={onPointsClick}
+          hidden={hidden}
+          opacity={opacity}
+          generatorOrder={generatorOrder}
+          onFootprintsClick={onFootprintsClick}
         />
       )}
       {tileSources.map((source, index) => {

--- a/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/external-stac-timeseries.tsx
@@ -1,0 +1,372 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { LngLatBoundsLike } from 'mapbox-gl';
+import startOfDay from 'date-fns/startOfDay';
+import endOfDay from 'date-fns/endOfDay';
+
+import { ExternalStacTimeseriesProps, ExternalStacItem } from '../types';
+import { FIT_BOUNDS_PADDING, getMergedBBox, requestQuickCache } from '../utils';
+import useFitBbox from '../hooks/use-fit-bbox';
+import useMaps from '../hooks/use-maps';
+import PointsLayer from './points-layer';
+import { useRequestStatus, STATUS_KEY } from './hooks';
+import { RasterPaintLayer } from './raster-paint-layer';
+import { userTzDate2utcString } from '$utils/date';
+import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
+
+// Whether or not to print the request logs.
+const LOG = process.env.NODE_ENV !== 'production' ? true : false;
+
+interface TileSource {
+  id: string;
+  tileUrl: string;
+  bbox: [number, number, number, number];
+}
+
+/**
+ * Extracts the asset href from a STAC item, preferring S3 alternate if available.
+ */
+function getAssetHref(item: ExternalStacItem, assetKey: string): string | null {
+  const asset = item.assets[assetKey];
+  if (!asset) {
+    return null;
+  }
+
+  // Prefer S3 alternate if available (usually faster for titiler)
+  if (asset.alternate?.s3?.href) {
+    return asset.alternate.s3.href;
+  }
+
+  return asset.href;
+}
+
+/**
+ * Hook to fetch STAC items from an external STAC server.
+ * Similar to useStacResponse but fetches full item data including assets.
+ */
+function useExternalStacSearch({
+  id,
+  changeStatus,
+  stacCol,
+  date,
+  stacApiEndpointToUse
+}: {
+  id: string;
+  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
+  stacCol: string;
+  date: Date;
+  stacApiEndpointToUse: string;
+}): [
+  ExternalStacItem[],
+  Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null
+] {
+  const [stacItems, setStacItems] = useState<ExternalStacItem[]>([]);
+
+  useEffect(() => {
+    if (!id || !stacCol) return;
+
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        changeStatus({ status: S_LOADING, context: STATUS_KEY.StacSearch });
+
+        const searchUrl = `${stacApiEndpointToUse}/search`;
+
+        // Build search payload using standard STAC parameters
+        // Use 'collections' array (universally supported) instead of CQL2 filter for collection
+        // This ensures compatibility with external STAC servers that may use different CQL2 operators
+        const payload = {
+          collections: [stacCol],
+          datetime: `${userTzDate2utcString(
+            startOfDay(date)
+          )}/${userTzDate2utcString(endOfDay(date))}`,
+          limit: 1000
+        };
+
+        if (LOG) {
+          /* eslint-disable no-console */
+          console.groupCollapsed(
+            'ExternalStacTimeseries %cLoading STAC items',
+            'color: orange;',
+            id
+          );
+          console.log('Search URL', searchUrl);
+          console.log('Payload', payload);
+          console.groupEnd();
+          /* eslint-enable no-console */
+        }
+
+        const responseData = await requestQuickCache<{
+          features: ExternalStacItem[];
+        }>({
+          url: searchUrl,
+          payload,
+          controller
+        });
+
+        if (LOG) {
+          /* eslint-disable no-console */
+          console.groupCollapsed(
+            'ExternalStacTimeseries %cReceived STAC items',
+            'color: green;',
+            id
+          );
+          console.log('STAC response', responseData);
+          console.groupEnd();
+          /* eslint-enable no-console */
+        }
+
+        setStacItems(responseData.features);
+        changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setStacItems([]);
+          changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
+        }
+        if (LOG)
+          /* eslint-disable-next-line no-console */
+          console.log(
+            'ExternalStacTimeseries %cAborted STAC search',
+            'color: red;',
+            id
+          );
+        /* eslint-disable-next-line no-console */
+        console.log(error);
+        return;
+      }
+    };
+
+    load();
+
+    return () => {
+      controller.abort();
+      changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, stacCol, date, stacApiEndpointToUse]);
+
+  // Markers to show where the data is when zoom is low
+  const points = useMemo(() => {
+    if (!stacItems.length) return null;
+    const pts = stacItems.map((f) => {
+      const [w, s, e, n] = f.bbox;
+      return {
+        bounds: [
+          [w, s],
+          [e, n]
+        ] as LngLatBoundsLike,
+        center: [(w + e) / 2, (s + n) / 2] as [number, number]
+      };
+    });
+
+    return pts;
+  }, [stacItems]);
+
+  return [stacItems, points];
+}
+
+/**
+ * Hook to build COG tile sources from STAC items.
+ */
+function useExternalStacTileSources({
+  id,
+  stacItems,
+  tileApiEndpointToUse,
+  assetKey,
+  changeStatus
+}: {
+  id: string;
+  stacItems: ExternalStacItem[];
+  tileApiEndpointToUse: string;
+  assetKey: string;
+  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
+}): TileSource[] {
+  const [tileSources, setTileSources] = useState<TileSource[]>([]);
+
+  useEffect(() => {
+    if (!stacItems.length) {
+      setTileSources([]);
+      return;
+    }
+
+    changeStatus({ status: S_LOADING, context: STATUS_KEY.Layer });
+
+    try {
+      const sources: TileSource[] = stacItems.reduce<TileSource[]>(
+        (acc, item, i) => {
+          const assetHref = getAssetHref(item, assetKey);
+
+          if (!assetHref) {
+            if (LOG) {
+              /* eslint-disable-next-line no-console */
+              console.warn(
+                `ExternalStacTimeseries: Asset '${assetKey}' not found in item ${item.id}`
+              );
+            }
+            return acc;
+          }
+
+          // Build the COG tile URL
+          // titiler COG endpoint: /cog/tiles/{tileMatrixSetId}/{z}/{x}/{y}.png
+          const tileUrl = `${tileApiEndpointToUse}/cog/WebMercatorQuad/tilejson.json`;
+
+          return [
+            ...acc,
+            {
+              id: `${id}-item-${i}`,
+              tileUrl,
+              bbox: item.bbox
+            }
+          ];
+        },
+        []
+      );
+
+      if (LOG) {
+        /* eslint-disable no-console */
+        console.groupCollapsed(
+          'ExternalStacTimeseries %cBuilt tile sources',
+          'color: green;',
+          id
+        );
+        console.log('Sources', sources);
+        console.groupEnd();
+        /* eslint-enable no-console */
+      }
+
+      setTileSources(sources);
+      changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.Layer });
+    } catch (error) {
+      /* eslint-disable-next-line no-console */
+      console.error(
+        'ExternalStacTimeseries: Error building tile sources',
+        error
+      );
+      setTileSources([]);
+      changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, stacItems, tileApiEndpointToUse, assetKey]);
+
+  return tileSources;
+}
+
+export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
+  const {
+    id,
+    stacCol,
+    date,
+    sourceParams,
+    zoomExtent,
+    bounds,
+    onStatusChange,
+    isPositionSet,
+    hidden,
+    opacity,
+    generatorOrder,
+    stacApiEndpoint,
+    tileApiEndpoint,
+    colorMap,
+    reScale,
+    envApiStacEndpoint,
+    envApiRasterEndpoint
+  } = props;
+
+  const { current: mapInstance } = useMaps();
+
+  const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint ?? '';
+  const tileApiEndpointToUse = tileApiEndpoint ?? envApiRasterEndpoint ?? '';
+
+  const { changeStatus } = useRequestStatus({
+    id,
+    onStatusChange,
+    requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
+  });
+
+  const [stacItems, points] = useExternalStacSearch({
+    id,
+    changeStatus,
+    stacCol,
+    date,
+    stacApiEndpointToUse
+  });
+
+  // Get asset key from sourceParams for tile params
+  const assetKey = sourceParams?.assets || 'cog_default';
+
+  const tileSources = useExternalStacTileSources({
+    id,
+    stacItems,
+    tileApiEndpointToUse,
+    assetKey,
+    changeStatus
+  });
+
+  // Listen to mouse events on the markers layer
+  const onPointsClick = useCallback(
+    (features) => {
+      const b = JSON.parse(features[0].properties.bounds);
+      mapInstance?.fitBounds(b, { padding: FIT_BOUNDS_PADDING });
+    },
+    [mapInstance]
+  );
+
+  // FitBounds when needed
+  const layerBounds = useMemo(
+    () => (stacItems?.length ? getMergedBBox(stacItems) : undefined),
+    [stacItems]
+  );
+  useFitBbox(!!isPositionSet, bounds, layerBounds);
+
+  // Build tile params without the 'assets' key (it's used for asset selection, not tile rendering)
+  const tileParams = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { assets: _, ...rest } = sourceParams || {};
+    return rest;
+  }, [sourceParams]);
+
+  return (
+    <>
+      {points && (
+        <PointsLayer
+          id={id}
+          points={points}
+          zoomExtent={zoomExtent}
+          onPointsClick={onPointsClick}
+        />
+      )}
+      {tileSources.map((source, index) => {
+        // Get the asset href for this item to pass to the COG endpoint
+        const item = stacItems[index];
+        const assetHref = item ? getAssetHref(item, assetKey) : null;
+
+        if (!assetHref) return null;
+
+        return (
+          <RasterPaintLayer
+            key={source.id}
+            id={source.id}
+            tileApiEndpoint={source.tileUrl}
+            tileParams={{
+              url: assetHref,
+              ...tileParams
+            }}
+            zoomExtent={zoomExtent}
+            hidden={hidden}
+            opacity={opacity}
+            colorMap={colorMap}
+            generatorOrder={generatorOrder}
+            reScale={reScale}
+            generatorPrefix='external-stac-timeseries'
+            onStatusChange={changeStatus}
+            metadataFormatter={(tilejsonData) => {
+              return {
+                xyzTileUrl: tilejsonData?.tiles[0]
+              };
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/packages/veda-ui/src/components/common/map/style-generators/footprints-layer.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/footprints-layer.tsx
@@ -1,0 +1,145 @@
+import { useEffect } from 'react';
+import {
+  LayerSpecification,
+  SourceSpecification,
+  GeoJSONSourceSpecification,
+  FillLayerSpecification,
+  LineLayerSpecification
+} from 'mapbox-gl';
+import { useTheme } from 'styled-components';
+import { featureCollection, polygon, Feature, Polygon } from '@turf/helpers';
+import bboxPolygon from '@turf/bbox-polygon';
+import useMapStyle from '../hooks/use-map-style';
+
+import useLayerInteraction from '../hooks/use-layer-interaction';
+import useGeneratorParams from '../hooks/use-generator-params';
+
+interface Footprint {
+  bounds: [[number, number], [number, number]];
+  geometry?: Polygon;
+}
+
+interface FootprintsLayerProps {
+  id: string;
+  footprints: Footprint[] | null;
+  zoomExtent?: number[];
+  hidden?: boolean;
+  opacity?: number;
+  generatorOrder?: number;
+  onFootprintsClick?: (features: Feature[]) => void;
+}
+
+export default function FootprintsLayer(props: FootprintsLayerProps) {
+  const {
+    id,
+    footprints,
+    zoomExtent,
+    hidden,
+    opacity,
+    generatorOrder,
+    onFootprintsClick
+  } = props;
+
+  const generatorParams = useGeneratorParams({
+    generatorOrder: generatorOrder ?? 1000000, // on top of any layers
+    hidden: !!hidden,
+    opacity: opacity ?? 1
+  });
+
+  const { updateStyle } = useMapStyle();
+  const minZoom = zoomExtent?.[0] ?? 0;
+  const generatorId = `footprints-${id}`;
+
+  const theme = useTheme();
+
+  useEffect(() => {
+    let layers: LayerSpecification[] = [];
+    let sources: Record<string, SourceSpecification> = {};
+
+    const footprintsSourceId = `${id}-footprints`;
+    if (footprints && minZoom > 0) {
+      const features: Feature<Polygon>[] = footprints.map((f) => {
+        const props = { bounds: f.bounds };
+        if (f.geometry) {
+          return polygon(f.geometry.coordinates, props);
+        }
+        const [[w, s], [e, n]] = f.bounds;
+        return bboxPolygon([w, s, e, n], {
+          properties: props
+        }) as Feature<Polygon>;
+      });
+
+      const footprintsSource: GeoJSONSourceSpecification = {
+        type: 'geojson',
+        data: featureCollection(features)
+      };
+
+      const fillLayer: FillLayerSpecification = {
+        type: 'fill',
+        id: footprintsSourceId,
+        source: footprintsSourceId,
+        paint: {
+          'fill-color': theme.color?.primary,
+          'fill-opacity': 0.4,
+          'fill-outline-color': theme.color?.primary
+        },
+        maxzoom: minZoom,
+        metadata: {
+          layerOrderPosition: 'markers'
+        }
+      };
+
+      const lineLayer: LineLayerSpecification = {
+        type: 'line',
+        id: `${footprintsSourceId}-outline`,
+        source: footprintsSourceId,
+        paint: {
+          'line-color': theme.color?.primary,
+          'line-width': 3,
+          'line-opacity': 1
+        },
+        layout: {
+          'line-join': 'round',
+          'line-cap': 'round'
+        },
+        maxzoom: minZoom,
+        metadata: {
+          layerOrderPosition: 'markers'
+        }
+      };
+
+      sources = {
+        [footprintsSourceId]: footprintsSource as SourceSpecification
+      };
+      layers = [fillLayer, lineLayer];
+    }
+
+    updateStyle({
+      generatorId,
+      sources,
+      layers,
+      params: generatorParams
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, footprints, minZoom, generatorParams]);
+
+  //
+  // Cleanup layers on unmount.
+  //
+  useEffect(() => {
+    return () => {
+      updateStyle({
+        generatorId,
+        sources: {},
+        layers: []
+      });
+    };
+  }, [updateStyle, generatorId]);
+
+  useLayerInteraction({
+    layerId: `${id}-footprints`,
+    onClick: onFootprintsClick
+  });
+
+  return null;
+}

--- a/packages/veda-ui/src/components/common/map/style-generators/pagination-overlay.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/pagination-overlay.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Button } from '@devseed-ui/button';
+import { glsp, themeVal } from '@devseed-ui/theme-provider';
+
+const Overlay = styled.div`
+  position: absolute;
+  bottom: ${glsp(1)};
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  background: ${themeVal('color.surface')};
+  padding: ${glsp(0.5, 1)};
+  border-radius: ${themeVal('shape.rounded')};
+  box-shadow: ${themeVal('boxShadow.elevationA')};
+  display: flex;
+  align-items: center;
+  gap: ${glsp(0.5)};
+  font-size: 0.875rem;
+`;
+
+interface PaginationOverlayProps {
+  loadedCount: number;
+  totalMatched: number;
+  isLoadingMore: boolean;
+  onLoadMore: () => void;
+}
+
+export default function PaginationOverlay(props: PaginationOverlayProps) {
+  const { loadedCount, totalMatched, isLoadingMore, onLoadMore } = props;
+
+  return (
+    <Overlay>
+      <span>
+        Showing {loadedCount} of {totalMatched} items
+      </span>
+      <Button size='small' onClick={onLoadMore} disabled={isLoadingMore}>
+        {isLoadingMore ? 'Loading...' : 'Load More'}
+      </Button>
+    </Overlay>
+  );
+}

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
@@ -1,17 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import styled from 'styled-components';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
-import { Button } from '@devseed-ui/button';
-import { glsp, themeVal } from '@devseed-ui/theme-provider';
 
-import { ExternalStacTimeseriesProps, ExternalStacItem } from '../types';
+import { RasterCogTimeseriesProps, StacItemWithAssets } from '../types';
 import { FIT_BOUNDS_PADDING, getMergedBBox, requestQuickCache } from '../utils';
 import useFitBbox from '../hooks/use-fit-bbox';
 import useMaps from '../hooks/use-maps';
 import FootprintsLayer from './footprints-layer';
 import { useRequestStatus, STATUS_KEY } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
+import PaginationOverlay from './pagination-overlay';
 import { userTzDate2utcString } from '$utils/date';
 import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 
@@ -32,7 +30,7 @@ interface StacLink {
 }
 
 interface StacSearchResponse {
-  features: ExternalStacItem[];
+  features: StacItemWithAssets[];
   context?: {
     matched?: number;
     returned?: number;
@@ -50,26 +48,13 @@ interface PaginationState {
   nextLink: StacLink | null;
 }
 
-const PaginationOverlay = styled.div`
-  position: absolute;
-  bottom: ${glsp(1)};
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 10;
-  background: ${themeVal('color.surface')};
-  padding: ${glsp(0.5, 1)};
-  border-radius: ${themeVal('shape.rounded')};
-  box-shadow: ${themeVal('boxShadow.elevationA')};
-  display: flex;
-  align-items: center;
-  gap: ${glsp(0.5)};
-  font-size: 0.875rem;
-`;
-
 /**
  * Extracts the asset href from a STAC item, preferring S3 alternate if available.
  */
-function getAssetHref(item: ExternalStacItem, assetKey: string): string | null {
+function getAssetHref(
+  item: StacItemWithAssets,
+  assetKey: string
+): string | null {
   const asset = item.assets[assetKey];
   if (!asset) {
     return null;
@@ -84,9 +69,9 @@ function getAssetHref(item: ExternalStacItem, assetKey: string): string | null {
 }
 
 /**
- * Hook to fetch STAC items from an external STAC server with pagination support.
+ * Hook to fetch STAC items from a STAC server with pagination support.
  */
-function useExternalStacSearch({
+function useStacItemsSearch({
   id,
   changeStatus,
   stacCol,
@@ -101,15 +86,15 @@ function useExternalStacSearch({
   stacApiEndpointToUse: string;
   searchLimit: number;
 }): {
-  stacItems: ExternalStacItem[];
+  stacItems: StacItemWithAssets[];
   footprints: Array<{
     bounds: [[number, number], [number, number]];
-    geometry?: ExternalStacItem['geometry'];
+    geometry?: StacItemWithAssets['geometry'];
   }> | null;
   pagination: PaginationState;
   loadMore: () => void;
 } {
-  const [stacItems, setStacItems] = useState<ExternalStacItem[]>([]);
+  const [stacItems, setStacItems] = useState<StacItemWithAssets[]>([]);
   const [pagination, setPagination] = useState<PaginationState>({
     hasMore: false,
     totalMatched: 0,
@@ -153,7 +138,7 @@ function useExternalStacSearch({
         if (LOG) {
           /* eslint-disable no-console */
           console.groupCollapsed(
-            'ExternalStacTimeseries %cLoading STAC items',
+            'RasterCogTimeseries %cLoading STAC items',
             'color: orange;',
             id
           );
@@ -172,7 +157,7 @@ function useExternalStacSearch({
         if (LOG) {
           /* eslint-disable no-console */
           console.groupCollapsed(
-            'ExternalStacTimeseries %cReceived STAC items',
+            'RasterCogTimeseries %cReceived STAC items',
             'color: green;',
             id
           );
@@ -212,7 +197,7 @@ function useExternalStacSearch({
         if (LOG)
           /* eslint-disable-next-line no-console */
           console.log(
-            'ExternalStacTimeseries %cAborted STAC search',
+            'RasterCogTimeseries %cAborted STAC search',
             'color: red;',
             id
           );
@@ -294,7 +279,7 @@ function useExternalStacSearch({
 /**
  * Hook to build COG tile sources from STAC items.
  */
-function useExternalStacTileSources({
+function useCogTileSources({
   id,
   stacItems,
   tileApiEndpointToUse,
@@ -302,7 +287,7 @@ function useExternalStacTileSources({
   changeStatus
 }: {
   id: string;
-  stacItems: ExternalStacItem[];
+  stacItems: StacItemWithAssets[];
   tileApiEndpointToUse: string;
   assetKey: string;
   changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
@@ -326,7 +311,7 @@ function useExternalStacTileSources({
             if (LOG) {
               /* eslint-disable-next-line no-console */
               console.warn(
-                `ExternalStacTimeseries: Asset '${assetKey}' not found in item ${item.id}`
+                `RasterCogTimeseries: Asset '${assetKey}' not found in item ${item.id}`
               );
             }
             return acc;
@@ -351,7 +336,7 @@ function useExternalStacTileSources({
       if (LOG) {
         /* eslint-disable no-console */
         console.groupCollapsed(
-          'ExternalStacTimeseries %cBuilt tile sources',
+          'RasterCogTimeseries %cBuilt tile sources',
           'color: green;',
           id
         );
@@ -365,7 +350,7 @@ function useExternalStacTileSources({
     } catch (error) {
       /* eslint-disable-next-line no-console */
       console.error(
-        'ExternalStacTimeseries: Error building tile sources',
+        'RasterCogTimeseries: Error building tile sources',
         error
       );
       setTileSources([]);
@@ -380,7 +365,7 @@ function useExternalStacTileSources({
 // Default search limit for STAC search
 const DEFAULT_SEARCH_LIMIT = 500;
 
-export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
+export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
   const {
     id,
     stacCol,
@@ -413,21 +398,19 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const { stacItems, footprints, pagination, loadMore } = useExternalStacSearch(
-    {
-      id,
-      changeStatus,
-      stacCol,
-      date,
-      stacApiEndpointToUse,
-      searchLimit
-    }
-  );
+  const { stacItems, footprints, pagination, loadMore } = useStacItemsSearch({
+    id,
+    changeStatus,
+    stacCol,
+    date,
+    stacApiEndpointToUse,
+    searchLimit
+  });
 
   // Get asset key from sourceParams for tile params
   const assetKey = sourceParams?.assets || 'cog_default';
 
-  const tileSources = useExternalStacTileSources({
+  const tileSources = useCogTileSources({
     id,
     stacItems,
     tileApiEndpointToUse,
@@ -493,7 +476,7 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
             colorMap={colorMap}
             generatorOrder={generatorOrder}
             reScale={reScale}
-            generatorPrefix='external-stac-timeseries'
+            generatorPrefix='raster-cog-timeseries'
             onStatusChange={changeStatus}
             metadataFormatter={(tilejsonData) => {
               return {
@@ -504,18 +487,12 @@ export function ExternalStacTimeseries(props: ExternalStacTimeseriesProps) {
         );
       })}
       {pagination.hasMore && !hidden && (
-        <PaginationOverlay>
-          <span>
-            Showing {pagination.loadedCount} of {pagination.totalMatched} items
-          </span>
-          <Button
-            size='small'
-            onClick={loadMore}
-            disabled={pagination.isLoadingMore}
-          >
-            {pagination.isLoadingMore ? 'Loading...' : 'Load More'}
-          </Button>
-        </PaginationOverlay>
+        <PaginationOverlay
+          loadedCount={pagination.loadedCount}
+          totalMatched={pagination.totalMatched}
+          isLoadingMore={pagination.isLoadingMore}
+          onLoadMore={loadMore}
+        />
       )}
     </>
   );

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 
@@ -20,6 +26,7 @@ interface TileSource {
   id: string;
   tileUrl: string;
   bbox: [number, number, number, number];
+  assetHref: string;
 }
 
 interface StacLink {
@@ -102,9 +109,13 @@ function useStacItemsSearch({
     isLoadingMore: false,
     nextLink: null
   });
+  const loadMoreControllerRef = useRef<AbortController | null>(null);
 
-  // Reset when date or collection changes
+  // Reset when date or collection changes. Also abort any in-flight loadMore
+  // request so its setState calls don't land after the dataset has changed.
   useEffect(() => {
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = null;
     setStacItems([]);
     setPagination({
       hasMore: false,
@@ -194,15 +205,16 @@ function useStacItemsSearch({
           });
           changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
         }
-        if (LOG)
-          /* eslint-disable-next-line no-console */
+        if (LOG) {
+          /* eslint-disable no-console */
           console.log(
             'RasterCogTimeseries %cAborted STAC search',
             'color: red;',
             id
           );
-        /* eslint-disable-next-line no-console */
-        console.log(error);
+          console.log(error);
+          /* eslint-enable no-console */
+        }
         return;
       }
     };
@@ -219,26 +231,23 @@ function useStacItemsSearch({
   const loadMore = useCallback(async () => {
     if (!pagination.nextLink || pagination.isLoadingMore) return;
 
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = controller;
+
     setPagination((prev) => ({ ...prev, isLoadingMore: true }));
 
     try {
-      const controller = new AbortController();
-      let responseData: StacSearchResponse;
+      const isPost =
+        pagination.nextLink.method === 'POST' && !!pagination.nextLink.body;
+      const responseData = await requestQuickCache<StacSearchResponse>({
+        url: pagination.nextLink.href,
+        method: isPost ? 'post' : 'get',
+        payload: isPost ? pagination.nextLink.body : null,
+        controller
+      });
 
-      // Handle both GET and POST next links
-      if (pagination.nextLink.method === 'POST' && pagination.nextLink.body) {
-        responseData = await requestQuickCache<StacSearchResponse>({
-          url: pagination.nextLink.href,
-          payload: pagination.nextLink.body,
-          controller
-        });
-      } else {
-        responseData = await requestQuickCache<StacSearchResponse>({
-          url: pagination.nextLink.href,
-          payload: null,
-          controller
-        });
-      }
+      if (controller.signal.aborted) return;
 
       const newFeatures = responseData.features || [];
       const nextLink = responseData.links?.find((l) => l.rel === 'next');
@@ -252,9 +261,14 @@ function useStacItemsSearch({
         nextLink: nextLink || null
       }));
     } catch (error) {
+      if (controller.signal.aborted) return;
       /* eslint-disable-next-line no-console */
       console.error('Error loading more items:', error);
       setPagination((prev) => ({ ...prev, isLoadingMore: false }));
+    } finally {
+      if (loadMoreControllerRef.current === controller) {
+        loadMoreControllerRef.current = null;
+      }
     }
   }, [pagination.nextLink, pagination.isLoadingMore]);
 
@@ -326,7 +340,8 @@ function useCogTileSources({
             {
               id: `${id}-item-${i}`,
               tileUrl,
-              bbox: item.bbox
+              bbox: item.bbox,
+              assetHref
             }
           ];
         },
@@ -349,10 +364,7 @@ function useCogTileSources({
       changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.Layer });
     } catch (error) {
       /* eslint-disable-next-line no-console */
-      console.error(
-        'RasterCogTimeseries: Error building tile sources',
-        error
-      );
+      console.error('RasterCogTimeseries: Error building tile sources', error);
       setTileSources([]);
       changeStatus({ status: S_FAILED, context: STATUS_KEY.Layer });
     }
@@ -454,20 +466,14 @@ export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
           onFootprintsClick={onFootprintsClick}
         />
       )}
-      {tileSources.map((source, index) => {
-        // Get the asset href for this item to pass to the COG endpoint
-        const item = stacItems[index];
-        const assetHref = item ? getAssetHref(item, assetKey) : null;
-
-        if (!assetHref) return null;
-
+      {tileSources.map((source) => {
         return (
           <RasterPaintLayer
             key={source.id}
             id={source.id}
             tileApiEndpoint={source.tileUrl}
             tileParams={{
-              url: assetHref,
+              url: source.assetHref,
               ...tileParams
             }}
             zoomExtent={zoomExtent}

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
@@ -24,7 +24,7 @@ const LOG = process.env.NODE_ENV !== 'production' ? true : false;
 
 interface TileSource {
   id: string;
-  tileUrl: string;
+  tilesTemplate: string;
   bbox: [number, number, number, number];
   assetHref: string;
 }
@@ -331,15 +331,15 @@ function useCogTileSources({
             return acc;
           }
 
-          // Build the COG tile URL
-          // titiler COG endpoint: /cog/tiles/{tileMatrixSetId}/{z}/{x}/{y}.png
-          const tileUrl = `${tileApiEndpointToUse}/cog/WebMercatorQuad/tilejson.json`;
+          // Use titiler's COG tile template directly so Mapbox can fetch
+          // tiles without a tilejson round-trip per item.
+          const tilesTemplate = `${tileApiEndpointToUse}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png`;
 
           return [
             ...acc,
             {
               id: `${id}-item-${i}`,
-              tileUrl,
+              tilesTemplate,
               bbox: item.bbox,
               assetHref
             }
@@ -471,7 +471,7 @@ export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
           <RasterPaintLayer
             key={source.id}
             id={source.id}
-            tileApiEndpoint={source.tileUrl}
+            tilesTemplate={source.tilesTemplate}
             tileParams={{
               url: source.assetHref,
               ...tileParams
@@ -484,11 +484,6 @@ export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
             reScale={reScale}
             generatorPrefix='raster-cog-timeseries'
             onStatusChange={changeStatus}
-            metadataFormatter={(tilejsonData) => {
-              return {
-                xyzTileUrl: tilejsonData?.tiles[0]
-              };
-            }}
           />
         );
       })}

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-cog-timeseries.tsx
@@ -1,58 +1,30 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import startOfDay from 'date-fns/startOfDay';
 import endOfDay from 'date-fns/endOfDay';
 
 import { RasterCogTimeseriesProps, StacItemWithAssets } from '../types';
-import { FIT_BOUNDS_PADDING, getMergedBBox, requestQuickCache } from '../utils';
+import { FIT_BOUNDS_PADDING, getMergedBBox } from '../utils';
 import useFitBbox from '../hooks/use-fit-bbox';
 import useMaps from '../hooks/use-maps';
 import FootprintsLayer from './footprints-layer';
 import { useRequestStatus, STATUS_KEY } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
 import PaginationOverlay from './pagination-overlay';
+import { useStacSearchPagination } from './use-stac-search-pagination';
 import { userTzDate2utcString } from '$utils/date';
 import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 
 // Whether or not to print the request logs.
-const LOG = process.env.NODE_ENV !== 'production' ? true : false;
+const LOG = process.env.NODE_ENV !== 'production';
+
+// Default search limit for STAC search.
+const DEFAULT_SEARCH_LIMIT = 500;
 
 interface TileSource {
   id: string;
   tilesTemplate: string;
   bbox: [number, number, number, number];
   assetHref: string;
-}
-
-interface StacLink {
-  rel: string;
-  href: string;
-  method?: string;
-  body?: Record<string, unknown>;
-}
-
-interface StacSearchResponse {
-  features: StacItemWithAssets[];
-  context?: {
-    matched?: number;
-    returned?: number;
-  };
-  numberMatched?: number;
-  numberReturned?: number;
-  links?: StacLink[];
-}
-
-interface PaginationState {
-  hasMore: boolean;
-  totalMatched: number;
-  loadedCount: number;
-  isLoadingMore: boolean;
-  nextLink: StacLink | null;
 }
 
 /**
@@ -73,221 +45,6 @@ function getAssetHref(
   }
 
   return asset.href;
-}
-
-/**
- * Hook to fetch STAC items from a STAC server with pagination support.
- */
-function useStacItemsSearch({
-  id,
-  changeStatus,
-  stacCol,
-  date,
-  stacApiEndpointToUse,
-  searchLimit
-}: {
-  id: string;
-  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
-  stacCol: string;
-  date: Date;
-  stacApiEndpointToUse: string;
-  searchLimit: number;
-}): {
-  stacItems: StacItemWithAssets[];
-  footprints: Array<{
-    bounds: [[number, number], [number, number]];
-    geometry?: StacItemWithAssets['geometry'];
-  }> | null;
-  pagination: PaginationState;
-  loadMore: () => void;
-} {
-  const [stacItems, setStacItems] = useState<StacItemWithAssets[]>([]);
-  const [pagination, setPagination] = useState<PaginationState>({
-    hasMore: false,
-    totalMatched: 0,
-    loadedCount: 0,
-    isLoadingMore: false,
-    nextLink: null
-  });
-  const loadMoreControllerRef = useRef<AbortController | null>(null);
-
-  // Reset when date or collection changes. Also abort any in-flight loadMore
-  // request so its setState calls don't land after the dataset has changed.
-  useEffect(() => {
-    loadMoreControllerRef.current?.abort();
-    loadMoreControllerRef.current = null;
-    setStacItems([]);
-    setPagination({
-      hasMore: false,
-      totalMatched: 0,
-      loadedCount: 0,
-      isLoadingMore: false,
-      nextLink: null
-    });
-  }, [stacCol, date, stacApiEndpointToUse]);
-
-  useEffect(() => {
-    if (!id || !stacCol) return;
-
-    const controller = new AbortController();
-
-    const load = async () => {
-      try {
-        changeStatus({ status: S_LOADING, context: STATUS_KEY.StacSearch });
-
-        const searchUrl = `${stacApiEndpointToUse}/search`;
-
-        // Build search payload using standard STAC parameters
-        const payload = {
-          collections: [stacCol],
-          datetime: `${userTzDate2utcString(
-            startOfDay(date)
-          )}/${userTzDate2utcString(endOfDay(date))}`,
-          limit: searchLimit
-        };
-
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.groupCollapsed(
-            'RasterCogTimeseries %cLoading STAC items',
-            'color: orange;',
-            id
-          );
-          console.log('Search URL', searchUrl);
-          console.log('Payload', payload);
-          console.groupEnd();
-          /* eslint-enable no-console */
-        }
-
-        const responseData = await requestQuickCache<StacSearchResponse>({
-          url: searchUrl,
-          payload,
-          controller
-        });
-
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.groupCollapsed(
-            'RasterCogTimeseries %cReceived STAC items',
-            'color: green;',
-            id
-          );
-          console.log('STAC response', responseData);
-          console.groupEnd();
-          /* eslint-enable no-console */
-        }
-
-        const features = responseData.features || [];
-        const totalMatched =
-          responseData.context?.matched ||
-          responseData.numberMatched ||
-          features.length;
-        const nextLink = responseData.links?.find((l) => l.rel === 'next');
-
-        setStacItems(features);
-        setPagination({
-          hasMore: !!nextLink,
-          totalMatched,
-          loadedCount: features.length,
-          isLoadingMore: false,
-          nextLink: nextLink || null
-        });
-        changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
-      } catch (error) {
-        if (!controller.signal.aborted) {
-          setStacItems([]);
-          setPagination({
-            hasMore: false,
-            totalMatched: 0,
-            loadedCount: 0,
-            isLoadingMore: false,
-            nextLink: null
-          });
-          changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
-        }
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.log(
-            'RasterCogTimeseries %cAborted STAC search',
-            'color: red;',
-            id
-          );
-          console.log(error);
-          /* eslint-enable no-console */
-        }
-        return;
-      }
-    };
-
-    load();
-
-    return () => {
-      controller.abort();
-      changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, stacCol, date, stacApiEndpointToUse, searchLimit]);
-
-  const loadMore = useCallback(async () => {
-    if (!pagination.nextLink || pagination.isLoadingMore) return;
-
-    const controller = new AbortController();
-    loadMoreControllerRef.current?.abort();
-    loadMoreControllerRef.current = controller;
-
-    setPagination((prev) => ({ ...prev, isLoadingMore: true }));
-
-    try {
-      const isPost =
-        pagination.nextLink.method === 'POST' && !!pagination.nextLink.body;
-      const responseData = await requestQuickCache<StacSearchResponse>({
-        url: pagination.nextLink.href,
-        method: isPost ? 'post' : 'get',
-        payload: isPost ? pagination.nextLink.body : null,
-        controller
-      });
-
-      if (controller.signal.aborted) return;
-
-      const newFeatures = responseData.features || [];
-      const nextLink = responseData.links?.find((l) => l.rel === 'next');
-
-      setStacItems((prev) => [...prev, ...newFeatures]);
-      setPagination((prev) => ({
-        ...prev,
-        hasMore: !!nextLink,
-        loadedCount: prev.loadedCount + newFeatures.length,
-        isLoadingMore: false,
-        nextLink: nextLink || null
-      }));
-    } catch (error) {
-      if (controller.signal.aborted) return;
-      /* eslint-disable-next-line no-console */
-      console.error('Error loading more items:', error);
-      setPagination((prev) => ({ ...prev, isLoadingMore: false }));
-    } finally {
-      if (loadMoreControllerRef.current === controller) {
-        loadMoreControllerRef.current = null;
-      }
-    }
-  }, [pagination.nextLink, pagination.isLoadingMore]);
-
-  // Footprints to show where the data is when zoom is low
-  const footprints = useMemo(() => {
-    if (!stacItems.length) return null;
-    return stacItems.map((f) => {
-      const [w, s, e, n] = f.bbox;
-      return {
-        bounds: [
-          [w, s],
-          [e, n]
-        ] as [[number, number], [number, number]],
-        geometry: f.geometry
-      };
-    });
-  }, [stacItems]);
-
-  return { stacItems, footprints, pagination, loadMore };
 }
 
 /**
@@ -374,9 +131,6 @@ function useCogTileSources({
   return tileSources;
 }
 
-// Default search limit for STAC search
-const DEFAULT_SEARCH_LIMIT = 500;
-
 export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
   const {
     id,
@@ -410,13 +164,33 @@ export function RasterCogTimeseries(props: RasterCogTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const { stacItems, footprints, pagination, loadMore } = useStacItemsSearch({
+  const searchUrl = `${stacApiEndpointToUse}/search`;
+  const dateStart = userTzDate2utcString(startOfDay(date));
+  const dateEnd = userTzDate2utcString(endOfDay(date));
+  const searchPayload = useMemo(
+    () => ({
+      collections: [stacCol],
+      datetime: `${dateStart}/${dateEnd}`,
+      limit: searchLimit
+    }),
+    [stacCol, dateStart, dateEnd, searchLimit]
+  );
+  const searchKey = `${stacCol}|${dateStart}|${dateEnd}|${stacApiEndpointToUse}|${searchLimit}|cog`;
+
+  const {
+    items: stacItems,
+    footprints,
+    pagination,
+    loadMore
+  } = useStacSearchPagination<StacItemWithAssets>({
     id,
+    searchUrl,
+    payload: searchPayload,
+    searchKey,
+    enabled: !!stacCol,
     changeStatus,
-    stacCol,
-    date,
-    stacApiEndpointToUse,
-    searchLimit
+    logPrefix: 'RasterCogTimeseries',
+    log: LOG
   });
 
   // Get asset key from sourceParams for tile params

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-paint-layer.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-paint-layer.tsx
@@ -13,6 +13,14 @@ import { ActionStatus, S_SUCCEEDED } from '$utils/status';
 interface RasterPaintLayerProps extends BaseGeneratorParams {
   id: string;
   tileApiEndpoint?: string | string[];
+  /**
+   * If provided, this XYZ tile URL template (e.g.
+   * `https://.../cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png`) is used directly:
+   * no tilejson fetch, source spec uses `tiles: [...]` instead of `url: ...`.
+   * Use this when the tile template is known up-front (e.g. titiler's
+   * `/cog/tiles/...` for per-item COG layers).
+   */
+  tilesTemplate?: string;
   zoomExtent?: number[];
   colorMap?: string | undefined;
   tileParams: Record<string, any>;
@@ -33,6 +41,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
   const {
     id,
     tileApiEndpoint,
+    tilesTemplate,
     tileParams,
     zoomExtent,
     hidden,
@@ -68,35 +77,49 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
 
   useEffect(
     () => {
-      if (!tileApiEndpoint) return;
+      if (!tileApiEndpoint && !tilesTemplate) return;
       const controller = new AbortController();
       async function run() {
         // Create a modified version of the parameters
         const tileParamsAsString = formatTitilerParameter(updatedTileParams);
-        const tileUrl = `${tileApiEndpoint}?${tileParamsAsString}`;
+        const baseUrl = tilesTemplate ?? tileApiEndpoint;
+        const tileUrl = `${baseUrl}?${tileParamsAsString}`;
 
         try {
           let tileUrlMetadata;
-          if (
-            !generatorPrefix.includes('wms') &&
-            !generatorPrefix.includes('wmts')
-          ) {
-            // wms data doesn't have an endpoint for tilejson
-            const tileJsonData = await requestQuickCache<any>({
-              url: tileUrl,
-              method: 'GET',
-              payload: null,
-              controller
-            });
+          let mapSourceParams: Record<string, any>;
 
-            tileUrlMetadata =
-              metadataFormatter &&
-              metadataFormatter(tileJsonData, tileParamsAsString);
+          if (tilesTemplate) {
+            // Tile template is known up-front; skip the tilejson round trip.
+            // Mapbox uses the `tiles` array directly. tileSize: 256 matches
+            // titiler's default tile size.
+            tileUrlMetadata = metadataFormatter
+              ? metadataFormatter(null, tileParamsAsString)
+              : { xyzTileUrl: tileUrl };
+            mapSourceParams = { tiles: [tileUrl], tileSize: 256 };
           } else {
-            tileUrlMetadata =
-              metadataFormatter && metadataFormatter(null, tileParamsAsString);
+            if (
+              !generatorPrefix.includes('wms') &&
+              !generatorPrefix.includes('wmts')
+            ) {
+              // wms data doesn't have an endpoint for tilejson
+              const tileJsonData = await requestQuickCache<any>({
+                url: tileUrl,
+                method: 'GET',
+                payload: null,
+                controller
+              });
+
+              tileUrlMetadata =
+                metadataFormatter &&
+                metadataFormatter(tileJsonData, tileParamsAsString);
+            } else {
+              tileUrlMetadata =
+                metadataFormatter &&
+                metadataFormatter(null, tileParamsAsString);
+            }
+            mapSourceParams = sourceParamFormatter(tileUrl);
           }
-          const mapSourceParams = sourceParamFormatter(tileUrl);
 
           const rasterSource: RasterSourceSpecification = {
             type: 'raster',
@@ -154,6 +177,7 @@ export function RasterPaintLayer(props: RasterPaintLayerProps) {
       id,
       minZoom,
       tileApiEndpoint,
+      tilesTemplate,
       haveTileParamsChanged,
       generatorParams,
       colorMap,

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { LngLatBoundsLike } from 'mapbox-gl';
 import { RasterTimeseriesProps, StacFeature } from '../types';
 import {
   FIT_BOUNDS_PADDING,
@@ -11,28 +10,88 @@ import {
 import useFitBbox from '../hooks/use-fit-bbox';
 import useMaps from '../hooks/use-maps';
 
-import PointsLayer from './points-layer';
+import FootprintsLayer from './footprints-layer';
 import { useRequestStatus, STATUS_KEY } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
+import PaginationOverlay from './pagination-overlay';
 import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 
 // Whether or not to print the request logs.
 const LOG = process.env.NODE_ENV !== 'production' ? true : false;
+
+// Default search limit for STAC search
+const DEFAULT_SEARCH_LIMIT = 500;
+
+interface StacLink {
+  rel: string;
+  href: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+interface StacSearchResponse {
+  features: StacFeature[];
+  context?: {
+    matched?: number;
+    returned?: number;
+  };
+  numberMatched?: number;
+  numberReturned?: number;
+  links?: StacLink[];
+}
+
+interface PaginationState {
+  hasMore: boolean;
+  totalMatched: number;
+  loadedCount: number;
+  isLoadingMore: boolean;
+  nextLink: StacLink | null;
+}
 
 export function useStacResponse({
   id,
   changeStatus,
   stacCol,
   date,
-  stacApiEndpointToUse
-}): [
-  StacFeature[],
-  Array<{ bounds: LngLatBoundsLike; center: [number, number] }> | null
-] {
+  stacApiEndpointToUse,
+  searchLimit
+}: {
+  id: string;
+  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
+  stacCol: string;
+  date: Date;
+  stacApiEndpointToUse: string;
+  searchLimit: number;
+}): {
+  stacCollection: StacFeature[];
+  footprints: Array<{ bounds: [[number, number], [number, number]] }> | null;
+  pagination: PaginationState;
+  loadMore: () => void;
+} {
   //
   // Load stac collection features
   //
   const [stacCollection, setStacCollection] = useState<StacFeature[]>([]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    hasMore: false,
+    totalMatched: 0,
+    loadedCount: 0,
+    isLoadingMore: false,
+    nextLink: null
+  });
+
+  // Reset when date or collection changes
+  useEffect(() => {
+    setStacCollection([]);
+    setPagination({
+      hasMore: false,
+      totalMatched: 0,
+      loadedCount: 0,
+      isLoadingMore: false,
+      nextLink: null
+    });
+  }, [stacCol, date, stacApiEndpointToUse]);
+
   useEffect(() => {
     if (!id || !stacCol) return;
 
@@ -44,7 +103,7 @@ export function useStacResponse({
         const payload = {
           'filter-lang': 'cql2-json',
           filter: getFilterPayload(date, stacCol),
-          limit: 500,
+          limit: searchLimit,
           fields: {
             include: ['bbox'],
             exclude: ['collection', 'links']
@@ -63,9 +122,7 @@ export function useStacResponse({
           /* eslint-enable no-console */
         }
 
-        const responseData = await requestQuickCache<{
-          features: StacFeature[];
-        }>({
+        const responseData = await requestQuickCache<StacSearchResponse>({
           url: `${stacApiEndpointToUse}/search`,
           payload,
           controller
@@ -83,11 +140,32 @@ export function useStacResponse({
           /* eslint-enable no-console */
         }
 
-        setStacCollection(responseData.features);
+        const features = responseData.features || [];
+        const totalMatched =
+          responseData.context?.matched ||
+          responseData.numberMatched ||
+          features.length;
+        const nextLink = responseData.links?.find((l) => l.rel === 'next');
+
+        setStacCollection(features);
+        setPagination({
+          hasMore: !!nextLink,
+          totalMatched,
+          loadedCount: features.length,
+          isLoadingMore: false,
+          nextLink: nextLink || null
+        });
         changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
       } catch (error) {
         if (!controller.signal.aborted) {
           setStacCollection([]);
+          setPagination({
+            hasMore: false,
+            totalMatched: 0,
+            loadedCount: 0,
+            isLoadingMore: false,
+            nextLink: null
+          });
           changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
         }
         if (LOG)
@@ -108,28 +186,67 @@ export function useStacResponse({
       controller.abort();
       changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
     };
-  }, [id, changeStatus, stacCol, date, stacApiEndpointToUse]);
+  }, [id, changeStatus, stacCol, date, stacApiEndpointToUse, searchLimit]);
+
+  const loadMore = useCallback(async () => {
+    if (!pagination.nextLink || pagination.isLoadingMore) return;
+
+    setPagination((prev) => ({ ...prev, isLoadingMore: true }));
+
+    try {
+      const controller = new AbortController();
+      let responseData: StacSearchResponse;
+
+      // Handle both GET and POST next links
+      if (pagination.nextLink.method === 'POST' && pagination.nextLink.body) {
+        responseData = await requestQuickCache<StacSearchResponse>({
+          url: pagination.nextLink.href,
+          payload: pagination.nextLink.body,
+          controller
+        });
+      } else {
+        responseData = await requestQuickCache<StacSearchResponse>({
+          url: pagination.nextLink.href,
+          payload: null,
+          controller
+        });
+      }
+
+      const newFeatures = responseData.features || [];
+      const nextLink = responseData.links?.find((l) => l.rel === 'next');
+
+      setStacCollection((prev) => [...prev, ...newFeatures]);
+      setPagination((prev) => ({
+        ...prev,
+        hasMore: !!nextLink,
+        loadedCount: prev.loadedCount + newFeatures.length,
+        isLoadingMore: false,
+        nextLink: nextLink || null
+      }));
+    } catch (error) {
+      /* eslint-disable-next-line no-console */
+      console.error('Error loading more items:', error);
+      setPagination((prev) => ({ ...prev, isLoadingMore: false }));
+    }
+  }, [pagination.nextLink, pagination.isLoadingMore]);
 
   //
-  // Markers to show where the data is when zoom is low
+  // Footprints to show where the data is when zoom is low
   //
-  const points = useMemo(() => {
+  const footprints = useMemo(() => {
     if (!stacCollection.length) return null;
-    const points = stacCollection.map((f) => {
+    return stacCollection.map((f) => {
       const [w, s, e, n] = f.bbox;
       return {
         bounds: [
           [w, s],
           [e, n]
-        ] as LngLatBoundsLike,
-        center: [(w + e) / 2, (s + n) / 2] as [number, number]
+        ] as [[number, number], [number, number]]
       };
     });
-
-    return points;
   }, [stacCollection]);
 
-  return [stacCollection, points];
+  return { stacCollection, footprints, pagination, loadMore };
 }
 
 function useMosaicUrl({
@@ -257,7 +374,8 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     colorMap,
     reScale,
     envApiStacEndpoint,
-    envApiRasterEndpoint
+    envApiRasterEndpoint,
+    searchLimit = DEFAULT_SEARCH_LIMIT
   } = props;
 
   const { current: mapInstance } = useMaps();
@@ -271,12 +389,13 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const [stacCollection, points] = useStacResponse({
+  const { stacCollection, footprints, pagination, loadMore } = useStacResponse({
     id,
     changeStatus,
     stacCol,
     date,
-    stacApiEndpointToUse
+    stacApiEndpointToUse,
+    searchLimit
   });
 
   const [mosaicUrl] = useMosaicUrl({
@@ -289,9 +408,9 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
   });
 
   //
-  // Listen to mouse events on the markers layer
+  // Listen to mouse events on the footprints layer
   //
-  const onPointsClick = useCallback(
+  const onFootprintsClick = useCallback(
     (features) => {
       const bounds = JSON.parse(features[0].properties.bounds);
       mapInstance?.fitBounds(bounds, { padding: FIT_BOUNDS_PADDING });
@@ -310,12 +429,15 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
 
   return (
     <>
-      {points && (
-        <PointsLayer
+      {footprints && (
+        <FootprintsLayer
           id={id}
-          points={points}
+          footprints={footprints}
           zoomExtent={zoomExtent}
-          onPointsClick={onPointsClick}
+          hidden={hidden}
+          opacity={opacity}
+          generatorOrder={generatorOrder}
+          onFootprintsClick={onFootprintsClick}
         />
       )}
       {mosaicUrl && (
@@ -341,6 +463,14 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
               wmtsTileUrl: `${wmtsBaseUrl}?${tileParamsAsString}`
             };
           }}
+        />
+      )}
+      {pagination.hasMore && !hidden && (
+        <PaginationOverlay
+          loadedCount={pagination.loadedCount}
+          totalMatched={pagination.totalMatched}
+          isLoadingMore={pagination.isLoadingMore}
+          onLoadMore={loadMore}
         />
       )}
     </>

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { RasterTimeseriesProps, StacFeature } from '../types';
 import {
   FIT_BOUNDS_PADDING,
@@ -19,7 +25,12 @@ import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 // Whether or not to print the request logs.
 const LOG = process.env.NODE_ENV !== 'production' ? true : false;
 
-// Default search limit for STAC search
+// Default search limit for STAC search.
+// Note: in mosaic mode this only bounds the items we *fetch* for footprints
+// and pagination UX. The rendered tiles come from the server-side mosaic
+// register, which uses the same CQL filter and therefore covers all matching
+// items regardless of `searchLimit`. Update the JSDoc on `searchLimit` in the
+// dataset config if this behavior changes.
 const DEFAULT_SEARCH_LIMIT = 500;
 
 interface StacLink {
@@ -79,9 +90,13 @@ export function useStacResponse({
     isLoadingMore: false,
     nextLink: null
   });
+  const loadMoreControllerRef = useRef<AbortController | null>(null);
 
-  // Reset when date or collection changes
+  // Reset when date or collection changes. Also abort any in-flight loadMore
+  // request so its setState calls don't land after the dataset has changed.
   useEffect(() => {
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = null;
     setStacCollection([]);
     setPagination({
       hasMore: false,
@@ -168,16 +183,16 @@ export function useStacResponse({
           });
           changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
         }
-        if (LOG)
-          /* eslint-disable-next-line no-console */
+        if (LOG) {
+          /* eslint-disable no-console */
           console.log(
             'RasterTimeseries %cAborted STAC features',
             'color: red;',
             id
           );
-        // Temporarily turning on log for debugging
-        /* eslint-disable-next-line no-console */
-        console.log(error);
+          console.log(error);
+          /* eslint-enable no-console */
+        }
         return;
       }
     };
@@ -191,26 +206,23 @@ export function useStacResponse({
   const loadMore = useCallback(async () => {
     if (!pagination.nextLink || pagination.isLoadingMore) return;
 
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = controller;
+
     setPagination((prev) => ({ ...prev, isLoadingMore: true }));
 
     try {
-      const controller = new AbortController();
-      let responseData: StacSearchResponse;
+      const isPost =
+        pagination.nextLink.method === 'POST' && !!pagination.nextLink.body;
+      const responseData = await requestQuickCache<StacSearchResponse>({
+        url: pagination.nextLink.href,
+        method: isPost ? 'post' : 'get',
+        payload: isPost ? pagination.nextLink.body : null,
+        controller
+      });
 
-      // Handle both GET and POST next links
-      if (pagination.nextLink.method === 'POST' && pagination.nextLink.body) {
-        responseData = await requestQuickCache<StacSearchResponse>({
-          url: pagination.nextLink.href,
-          payload: pagination.nextLink.body,
-          controller
-        });
-      } else {
-        responseData = await requestQuickCache<StacSearchResponse>({
-          url: pagination.nextLink.href,
-          payload: null,
-          controller
-        });
-      }
+      if (controller.signal.aborted) return;
 
       const newFeatures = responseData.features || [];
       const nextLink = responseData.links?.find((l) => l.rel === 'next');
@@ -224,9 +236,14 @@ export function useStacResponse({
         nextLink: nextLink || null
       }));
     } catch (error) {
+      if (controller.signal.aborted) return;
       /* eslint-disable-next-line no-console */
       console.error('Error loading more items:', error);
       setPagination((prev) => ({ ...prev, isLoadingMore: false }));
+    } finally {
+      if (loadMoreControllerRef.current === controller) {
+        loadMoreControllerRef.current = null;
+      }
     }
   }, [pagination.nextLink, pagination.isLoadingMore]);
 
@@ -261,6 +278,10 @@ function useMosaicUrl({
   // Tiles
   //
   const [mosaicUrl, setMosaicUrl] = useState<string | undefined>(undefined);
+  // Track the count we registered for. Pagination only grows stacCollection;
+  // its filter (date+collection) is unchanged, so a re-register would just
+  // produce a duplicate request and cause the mapbox source to flicker.
+  const registeredForCountRef = useRef<number>(0);
   useEffect(() => {
     if (!id || !stacCol) return;
 
@@ -269,7 +290,16 @@ function useMosaicUrl({
     // though if a search returns no data, that date should not be available for
     // the dataset - may be a case of bad configuration.
     if (!stacCollection.length) {
+      registeredForCountRef.current = 0;
       setMosaicUrl(undefined);
+      return;
+    }
+
+    // Skip re-registration when stacCollection only grew via pagination.
+    if (
+      registeredForCountRef.current > 0 &&
+      stacCollection.length > registeredForCountRef.current
+    ) {
       return;
     }
 
@@ -304,6 +334,7 @@ function useMosaicUrl({
         setMosaicUrl(
           mosaicUrl.replace('/{tileMatrixSetId}', '/WebMercatorQuad')
         );
+        registeredForCountRef.current = stacCollection.length;
 
         /* eslint-disable no-console */
         if (LOG) {
@@ -352,6 +383,9 @@ function useMosaicUrl({
     // fires and `stacCollection` changes, causing this hook to run again. This
     // resulted in a race condition when adding the source to the map leading to
     // an error.
+    // Note: pagination also mutates `stacCollection` (appending to it) but
+    // does not require re-registration; that case is handled inside the effect
+    // via `registeredForCountRef`.
   ]);
   return [mosaicUrl];
 }

--- a/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
+++ b/packages/veda-ui/src/components/common/map/style-generators/raster-timeseries.tsx
@@ -20,10 +20,11 @@ import FootprintsLayer from './footprints-layer';
 import { useRequestStatus, STATUS_KEY } from './hooks';
 import { RasterPaintLayer } from './raster-paint-layer';
 import PaginationOverlay from './pagination-overlay';
+import { useStacSearchPagination } from './use-stac-search-pagination';
 import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 
 // Whether or not to print the request logs.
-const LOG = process.env.NODE_ENV !== 'production' ? true : false;
+const LOG = process.env.NODE_ENV !== 'production';
 
 // Default search limit for STAC search.
 // Note: in mosaic mode this only bounds the items we *fetch* for footprints
@@ -32,239 +33,6 @@ const LOG = process.env.NODE_ENV !== 'production' ? true : false;
 // items regardless of `searchLimit`. Update the JSDoc on `searchLimit` in the
 // dataset config if this behavior changes.
 const DEFAULT_SEARCH_LIMIT = 500;
-
-interface StacLink {
-  rel: string;
-  href: string;
-  method?: string;
-  body?: Record<string, unknown>;
-}
-
-interface StacSearchResponse {
-  features: StacFeature[];
-  context?: {
-    matched?: number;
-    returned?: number;
-  };
-  numberMatched?: number;
-  numberReturned?: number;
-  links?: StacLink[];
-}
-
-interface PaginationState {
-  hasMore: boolean;
-  totalMatched: number;
-  loadedCount: number;
-  isLoadingMore: boolean;
-  nextLink: StacLink | null;
-}
-
-export function useStacResponse({
-  id,
-  changeStatus,
-  stacCol,
-  date,
-  stacApiEndpointToUse,
-  searchLimit
-}: {
-  id: string;
-  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
-  stacCol: string;
-  date: Date;
-  stacApiEndpointToUse: string;
-  searchLimit: number;
-}): {
-  stacCollection: StacFeature[];
-  footprints: Array<{ bounds: [[number, number], [number, number]] }> | null;
-  pagination: PaginationState;
-  loadMore: () => void;
-} {
-  //
-  // Load stac collection features
-  //
-  const [stacCollection, setStacCollection] = useState<StacFeature[]>([]);
-  const [pagination, setPagination] = useState<PaginationState>({
-    hasMore: false,
-    totalMatched: 0,
-    loadedCount: 0,
-    isLoadingMore: false,
-    nextLink: null
-  });
-  const loadMoreControllerRef = useRef<AbortController | null>(null);
-
-  // Reset when date or collection changes. Also abort any in-flight loadMore
-  // request so its setState calls don't land after the dataset has changed.
-  useEffect(() => {
-    loadMoreControllerRef.current?.abort();
-    loadMoreControllerRef.current = null;
-    setStacCollection([]);
-    setPagination({
-      hasMore: false,
-      totalMatched: 0,
-      loadedCount: 0,
-      isLoadingMore: false,
-      nextLink: null
-    });
-  }, [stacCol, date, stacApiEndpointToUse]);
-
-  useEffect(() => {
-    if (!id || !stacCol) return;
-
-    const controller = new AbortController();
-
-    const load = async () => {
-      try {
-        changeStatus({ status: S_LOADING, context: STATUS_KEY.StacSearch });
-        const payload = {
-          'filter-lang': 'cql2-json',
-          filter: getFilterPayload(date, stacCol),
-          limit: searchLimit,
-          fields: {
-            include: ['bbox'],
-            exclude: ['collection', 'links']
-          }
-        };
-
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.groupCollapsed(
-            'RasterTimeseries %cLoading STAC features',
-            'color: orange;',
-            id
-          );
-          console.log('Payload', payload);
-          console.groupEnd();
-          /* eslint-enable no-console */
-        }
-
-        const responseData = await requestQuickCache<StacSearchResponse>({
-          url: `${stacApiEndpointToUse}/search`,
-          payload,
-          controller
-        });
-
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.groupCollapsed(
-            'RasterTimeseries %cAdding STAC features',
-            'color: green;',
-            id
-          );
-          console.log('STAC response', responseData);
-          console.groupEnd();
-          /* eslint-enable no-console */
-        }
-
-        const features = responseData.features || [];
-        const totalMatched =
-          responseData.context?.matched ||
-          responseData.numberMatched ||
-          features.length;
-        const nextLink = responseData.links?.find((l) => l.rel === 'next');
-
-        setStacCollection(features);
-        setPagination({
-          hasMore: !!nextLink,
-          totalMatched,
-          loadedCount: features.length,
-          isLoadingMore: false,
-          nextLink: nextLink || null
-        });
-        changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
-      } catch (error) {
-        if (!controller.signal.aborted) {
-          setStacCollection([]);
-          setPagination({
-            hasMore: false,
-            totalMatched: 0,
-            loadedCount: 0,
-            isLoadingMore: false,
-            nextLink: null
-          });
-          changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
-        }
-        if (LOG) {
-          /* eslint-disable no-console */
-          console.log(
-            'RasterTimeseries %cAborted STAC features',
-            'color: red;',
-            id
-          );
-          console.log(error);
-          /* eslint-enable no-console */
-        }
-        return;
-      }
-    };
-    load();
-    return () => {
-      controller.abort();
-      changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
-    };
-  }, [id, changeStatus, stacCol, date, stacApiEndpointToUse, searchLimit]);
-
-  const loadMore = useCallback(async () => {
-    if (!pagination.nextLink || pagination.isLoadingMore) return;
-
-    const controller = new AbortController();
-    loadMoreControllerRef.current?.abort();
-    loadMoreControllerRef.current = controller;
-
-    setPagination((prev) => ({ ...prev, isLoadingMore: true }));
-
-    try {
-      const isPost =
-        pagination.nextLink.method === 'POST' && !!pagination.nextLink.body;
-      const responseData = await requestQuickCache<StacSearchResponse>({
-        url: pagination.nextLink.href,
-        method: isPost ? 'post' : 'get',
-        payload: isPost ? pagination.nextLink.body : null,
-        controller
-      });
-
-      if (controller.signal.aborted) return;
-
-      const newFeatures = responseData.features || [];
-      const nextLink = responseData.links?.find((l) => l.rel === 'next');
-
-      setStacCollection((prev) => [...prev, ...newFeatures]);
-      setPagination((prev) => ({
-        ...prev,
-        hasMore: !!nextLink,
-        loadedCount: prev.loadedCount + newFeatures.length,
-        isLoadingMore: false,
-        nextLink: nextLink || null
-      }));
-    } catch (error) {
-      if (controller.signal.aborted) return;
-      /* eslint-disable-next-line no-console */
-      console.error('Error loading more items:', error);
-      setPagination((prev) => ({ ...prev, isLoadingMore: false }));
-    } finally {
-      if (loadMoreControllerRef.current === controller) {
-        loadMoreControllerRef.current = null;
-      }
-    }
-  }, [pagination.nextLink, pagination.isLoadingMore]);
-
-  //
-  // Footprints to show where the data is when zoom is low
-  //
-  const footprints = useMemo(() => {
-    if (!stacCollection.length) return null;
-    return stacCollection.map((f) => {
-      const [w, s, e, n] = f.bbox;
-      return {
-        bounds: [
-          [w, s],
-          [e, n]
-        ] as [[number, number], [number, number]]
-      };
-    });
-  }, [stacCollection]);
-
-  return { stacCollection, footprints, pagination, loadMore };
-}
 
 function useMosaicUrl({
   id,
@@ -423,13 +191,35 @@ export function RasterTimeseries(props: RasterTimeseriesProps) {
     requestsToTrack: [STATUS_KEY.StacSearch, STATUS_KEY.Layer]
   });
 
-  const { stacCollection, footprints, pagination, loadMore } = useStacResponse({
+  const searchUrl = `${stacApiEndpointToUse}/search`;
+  const searchPayload = useMemo(
+    () => ({
+      'filter-lang': 'cql2-json',
+      filter: getFilterPayload(date, stacCol),
+      limit: searchLimit,
+      fields: {
+        include: ['bbox'],
+        exclude: ['collection', 'links']
+      }
+    }),
+    [date, stacCol, searchLimit]
+  );
+  const searchKey = `${stacCol}|${date.toISOString()}|${stacApiEndpointToUse}|${searchLimit}|mosaic`;
+
+  const {
+    items: stacCollection,
+    footprints,
+    pagination,
+    loadMore
+  } = useStacSearchPagination<StacFeature>({
     id,
+    searchUrl,
+    payload: searchPayload,
+    searchKey,
+    enabled: !!stacCol,
     changeStatus,
-    stacCol,
-    date,
-    stacApiEndpointToUse,
-    searchLimit
+    logPrefix: 'RasterTimeseries',
+    log: LOG
   });
 
   const [mosaicUrl] = useMosaicUrl({

--- a/packages/veda-ui/src/components/common/map/style-generators/use-stac-search-pagination.ts
+++ b/packages/veda-ui/src/components/common/map/style-generators/use-stac-search-pagination.ts
@@ -1,0 +1,281 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { Polygon } from '@turf/helpers';
+
+import { requestQuickCache } from '../utils';
+import { STATUS_KEY } from './hooks';
+import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
+
+/**
+ * Link in a STAC FeatureCollection response. Used for pagination via
+ * the `rel: 'next'` link.
+ */
+export interface StacLink {
+  rel: string;
+  href: string;
+  method?: string;
+  body?: Record<string, unknown>;
+}
+
+/**
+ * Minimal STAC FeatureCollection shape for /search responses we consume.
+ */
+export interface StacSearchResponse<T> {
+  features: T[];
+  context?: {
+    matched?: number;
+    returned?: number;
+  };
+  numberMatched?: number;
+  numberReturned?: number;
+  links?: StacLink[];
+}
+
+export interface PaginationState {
+  hasMore: boolean;
+  totalMatched: number;
+  loadedCount: number;
+  isLoadingMore: boolean;
+  nextLink: StacLink | null;
+}
+
+/**
+ * Items returned by the hook must have a bbox; geometry is optional and
+ * (when present) is forwarded to FootprintsLayer for richer footprints.
+ */
+export interface StacFeatureWithBbox {
+  bbox: [number, number, number, number];
+  geometry?: Polygon;
+}
+
+export interface Footprint {
+  bounds: [[number, number], [number, number]];
+  geometry?: Polygon;
+}
+
+const INITIAL_PAGINATION: PaginationState = {
+  hasMore: false,
+  totalMatched: 0,
+  loadedCount: 0,
+  isLoadingMore: false,
+  nextLink: null
+};
+
+interface UseStacSearchPaginationParams {
+  /** Stable id used in log messages. */
+  id: string;
+  /** Full URL of the STAC /search endpoint. */
+  searchUrl: string;
+  /**
+   * Initial search payload. Object identity does not need to be stable;
+   * the hook reads the latest payload via a ref. The effect re-runs only
+   * when `searchKey` changes.
+   */
+  payload: unknown;
+  /**
+   * Stable string capturing all inputs that should trigger a fresh search
+   * (e.g. `${stacCol}|${date}|${endpoint}|${limit}|cog`). When this changes
+   * the hook resets state and re-issues the initial search.
+   */
+  searchKey: string;
+  /** If false, the hook does not fetch. Use to gate on required inputs. */
+  enabled?: boolean;
+  changeStatus: (params: { status: string; context: STATUS_KEY }) => void;
+  /** Prefix for grouped console logs (e.g. 'RasterCogTimeseries'). */
+  logPrefix: string;
+  /** Whether to print request logs. */
+  log?: boolean;
+}
+
+interface UseStacSearchPaginationReturn<T> {
+  items: T[];
+  footprints: Footprint[] | null;
+  pagination: PaginationState;
+  loadMore: () => void;
+}
+
+/**
+ * Hook that performs a STAC `/search` request with paginated "Load More"
+ * support. Shared between `raster-timeseries` (mosaic mode) and
+ * `raster-cog-timeseries` (cog mode) — the two differ only in the payload
+ * format and the feature shape, both supplied by the caller.
+ *
+ * Behaviour:
+ * - Issues the initial search when `searchKey` changes.
+ * - `loadMore()` follows the `rel: 'next'` link, honouring its HTTP method
+ *   (POST with body, otherwise GET).
+ * - On `searchKey` change, aborts any in-flight loadMore and resets state.
+ * - Items are accumulated across pages; `pagination.loadedCount` tracks the
+ *   total fetched so far and `pagination.totalMatched` reflects the server's
+ *   reported match count.
+ * - Produces `Footprint[]` for FootprintsLayer; uses `feature.geometry`
+ *   when present and falls back to bbox otherwise.
+ */
+export function useStacSearchPagination<T extends StacFeatureWithBbox>({
+  id,
+  searchUrl,
+  payload,
+  searchKey,
+  enabled = true,
+  changeStatus,
+  logPrefix,
+  log = false
+}: UseStacSearchPaginationParams): UseStacSearchPaginationReturn<T> {
+  const [items, setItems] = useState<T[]>([]);
+  const [pagination, setPagination] =
+    useState<PaginationState>(INITIAL_PAGINATION);
+  const loadMoreControllerRef = useRef<AbortController | null>(null);
+
+  // Keep the latest payload accessible inside the load effect without making
+  // the effect depend on the object's identity.
+  const payloadRef = useRef(payload);
+  payloadRef.current = payload;
+
+  // Reset when searchKey changes. Also abort any in-flight loadMore so its
+  // setState calls don't land after the dataset has changed.
+  useEffect(() => {
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = null;
+    setItems([]);
+    setPagination(INITIAL_PAGINATION);
+  }, [searchKey]);
+
+  useEffect(() => {
+    if (!enabled || !id || !searchUrl) return;
+
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        changeStatus({ status: S_LOADING, context: STATUS_KEY.StacSearch });
+
+        if (log) {
+          /* eslint-disable no-console */
+          console.groupCollapsed(
+            `${logPrefix} %cLoading STAC items`,
+            'color: orange;',
+            id
+          );
+          console.log('Search URL', searchUrl);
+          console.log('Payload', payloadRef.current);
+          console.groupEnd();
+          /* eslint-enable no-console */
+        }
+
+        const data = await requestQuickCache<StacSearchResponse<T>>({
+          url: searchUrl,
+          payload: payloadRef.current,
+          controller
+        });
+
+        if (log) {
+          /* eslint-disable no-console */
+          console.groupCollapsed(
+            `${logPrefix} %cReceived STAC items`,
+            'color: green;',
+            id
+          );
+          console.log('STAC response', data);
+          console.groupEnd();
+          /* eslint-enable no-console */
+        }
+
+        const features = data.features || [];
+        const totalMatched =
+          data.context?.matched ?? data.numberMatched ?? features.length;
+        const nextLink = data.links?.find((l) => l.rel === 'next');
+
+        setItems(features);
+        setPagination({
+          hasMore: !!nextLink,
+          totalMatched,
+          loadedCount: features.length,
+          isLoadingMore: false,
+          nextLink: nextLink || null
+        });
+        changeStatus({ status: S_SUCCEEDED, context: STATUS_KEY.StacSearch });
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          setItems([]);
+          setPagination(INITIAL_PAGINATION);
+          changeStatus({ status: S_FAILED, context: STATUS_KEY.StacSearch });
+        }
+        if (log) {
+          /* eslint-disable no-console */
+          console.log(`${logPrefix} %cAborted STAC search`, 'color: red;', id);
+          console.log(error);
+          /* eslint-enable no-console */
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      controller.abort();
+      changeStatus({ status: 'idle', context: STATUS_KEY.StacSearch });
+    };
+    // changeStatus/payloadRef intentionally omitted: searchKey covers
+    // re-fetch triggers and the payload is read from a ref.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchKey, id, searchUrl, enabled, logPrefix, log]);
+
+  const loadMore = useCallback(async () => {
+    if (!pagination.nextLink || pagination.isLoadingMore) return;
+
+    const controller = new AbortController();
+    loadMoreControllerRef.current?.abort();
+    loadMoreControllerRef.current = controller;
+
+    setPagination((prev) => ({ ...prev, isLoadingMore: true }));
+
+    try {
+      const isPost =
+        pagination.nextLink.method === 'POST' && !!pagination.nextLink.body;
+      const data = await requestQuickCache<StacSearchResponse<T>>({
+        url: pagination.nextLink.href,
+        method: isPost ? 'post' : 'get',
+        payload: isPost ? pagination.nextLink.body : null,
+        controller
+      });
+
+      if (controller.signal.aborted) return;
+
+      const newFeatures = data.features || [];
+      const nextLink = data.links?.find((l) => l.rel === 'next');
+
+      setItems((prev) => [...prev, ...newFeatures]);
+      setPagination((prev) => ({
+        ...prev,
+        hasMore: !!nextLink,
+        loadedCount: prev.loadedCount + newFeatures.length,
+        isLoadingMore: false,
+        nextLink: nextLink || null
+      }));
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      /* eslint-disable-next-line no-console */
+      console.error('Error loading more STAC items:', error);
+      setPagination((prev) => ({ ...prev, isLoadingMore: false }));
+    } finally {
+      if (loadMoreControllerRef.current === controller) {
+        loadMoreControllerRef.current = null;
+      }
+    }
+  }, [pagination.nextLink, pagination.isLoadingMore]);
+
+  const footprints = useMemo<Footprint[] | null>(() => {
+    if (!items.length) return null;
+    return items.map((f) => {
+      const [w, s, e, n] = f.bbox;
+      return {
+        bounds: [
+          [w, s],
+          [e, n]
+        ],
+        geometry: f.geometry
+      };
+    });
+  }, [items]);
+
+  return { items, footprints, pagination, loadMore };
+}

--- a/packages/veda-ui/src/components/common/map/types.d.ts
+++ b/packages/veda-ui/src/components/common/map/types.d.ts
@@ -82,6 +82,7 @@ export interface CMRTimeseriesProps extends BaseTimeseriesProps {
 export interface ExternalStacTimeseriesProps extends BaseTimeseriesProps {
   bounds?: number[];
   isPositionSet?: boolean;
+  searchLimit?: number;
 }
 
 export interface ExternalStacItem {

--- a/packages/veda-ui/src/components/common/map/types.d.ts
+++ b/packages/veda-ui/src/components/common/map/types.d.ts
@@ -78,3 +78,24 @@ interface AssetUrlReplacement {
 export interface CMRTimeseriesProps extends BaseTimeseriesProps {
   assetUrlReplacements?: AssetUrlReplacement;
 }
+
+export interface ExternalStacTimeseriesProps extends BaseTimeseriesProps {
+  bounds?: number[];
+  isPositionSet?: boolean;
+}
+
+export interface ExternalStacItem {
+  id: string;
+  bbox: [number, number, number, number];
+  assets: Record<
+    string,
+    {
+      href: string;
+      alternate?: {
+        s3?: {
+          href: string;
+        };
+      };
+    }
+  >;
+}

--- a/packages/veda-ui/src/components/common/map/types.d.ts
+++ b/packages/veda-ui/src/components/common/map/types.d.ts
@@ -68,6 +68,7 @@ export interface RasterTimeseriesProps extends BaseTimeseriesProps {
   bounds?: number[];
   isPositionSet?: boolean;
   envApiStacEndpoint: string;
+  searchLimit?: number;
 }
 
 interface AssetUrlReplacement {
@@ -79,13 +80,13 @@ export interface CMRTimeseriesProps extends BaseTimeseriesProps {
   assetUrlReplacements?: AssetUrlReplacement;
 }
 
-export interface ExternalStacTimeseriesProps extends BaseTimeseriesProps {
+export interface RasterCogTimeseriesProps extends BaseTimeseriesProps {
   bounds?: number[];
   isPositionSet?: boolean;
   searchLimit?: number;
 }
 
-export interface ExternalStacItem {
+export interface StacItemWithAssets {
   id: string;
   bbox: [number, number, number, number];
   geometry?: Polygon;

--- a/packages/veda-ui/src/components/common/map/types.d.ts
+++ b/packages/veda-ui/src/components/common/map/types.d.ts
@@ -88,6 +88,7 @@ export interface ExternalStacTimeseriesProps extends BaseTimeseriesProps {
 export interface ExternalStacItem {
   id: string;
   bbox: [number, number, number, number];
+  geometry?: Polygon;
   assets: Record<
     string,
     {

--- a/packages/veda-ui/src/components/exploration/components/map/layer.tsx
+++ b/packages/veda-ui/src/components/exploration/components/map/layer.tsx
@@ -15,7 +15,7 @@ import { ZarrTimeseries } from '$components/common/map/style-generators/zarr-tim
 import { CMRTimeseries } from '$components/common/map/style-generators/cmr-timeseries';
 import { WMSTimeseries } from '$components/common/map/style-generators/wms-timeseries';
 import { WMTSTimeseries } from '$components/common/map/style-generators/wmts-timeseries';
-import { ExternalStacTimeseries } from '$components/common/map/style-generators/external-stac-timeseries';
+import { RasterCogTimeseries } from '$components/common/map/style-generators/raster-cog-timeseries';
 import { ActionStatus } from '$utils/status';
 import { useVedaUI } from '$context/veda-ui-provider';
 
@@ -148,28 +148,30 @@ export function Layer(props: LayerProps) {
         />
       );
     case 'raster':
+      if (dataset.data.tilingMode === 'cog') {
+        return (
+          <RasterCogTimeseries
+            id={layerId}
+            stacCol={dataset.data.stacCol}
+            stacApiEndpoint={dataset.data.stacApiEndpoint}
+            tileApiEndpoint={dataset.data.tileApiEndpoint}
+            date={relevantDate}
+            zoomExtent={params.zoomExtent}
+            sourceParams={params.sourceParams}
+            generatorOrder={order}
+            hidden={!isVisible}
+            opacity={opacity}
+            onStatusChange={onStatusChange}
+            colorMap={colorMap}
+            reScale={scale}
+            envApiStacEndpoint={envApiStacEndpoint}
+            envApiRasterEndpoint={envApiRasterEndpoint}
+            searchLimit={dataset.data.searchLimit}
+          />
+        );
+      }
       return (
         <RasterTimeseries
-          id={layerId}
-          stacCol={dataset.data.stacCol}
-          stacApiEndpoint={dataset.data.stacApiEndpoint}
-          tileApiEndpoint={dataset.data.tileApiEndpoint}
-          date={relevantDate}
-          zoomExtent={params.zoomExtent}
-          sourceParams={params.sourceParams}
-          generatorOrder={order}
-          hidden={!isVisible}
-          opacity={opacity}
-          onStatusChange={onStatusChange}
-          colorMap={colorMap}
-          reScale={scale}
-          envApiStacEndpoint={envApiStacEndpoint}
-          envApiRasterEndpoint={envApiRasterEndpoint}
-        />
-      );
-    case 'external-stac':
-      return (
-        <ExternalStacTimeseries
           id={layerId}
           stacCol={dataset.data.stacCol}
           stacApiEndpoint={dataset.data.stacApiEndpoint}

--- a/packages/veda-ui/src/components/exploration/components/map/layer.tsx
+++ b/packages/veda-ui/src/components/exploration/components/map/layer.tsx
@@ -185,6 +185,7 @@ export function Layer(props: LayerProps) {
           reScale={scale}
           envApiStacEndpoint={envApiStacEndpoint}
           envApiRasterEndpoint={envApiRasterEndpoint}
+          searchLimit={dataset.data.searchLimit}
         />
       );
     default:

--- a/packages/veda-ui/src/components/exploration/components/map/layer.tsx
+++ b/packages/veda-ui/src/components/exploration/components/map/layer.tsx
@@ -15,6 +15,7 @@ import { ZarrTimeseries } from '$components/common/map/style-generators/zarr-tim
 import { CMRTimeseries } from '$components/common/map/style-generators/cmr-timeseries';
 import { WMSTimeseries } from '$components/common/map/style-generators/wms-timeseries';
 import { WMTSTimeseries } from '$components/common/map/style-generators/wmts-timeseries';
+import { ExternalStacTimeseries } from '$components/common/map/style-generators/external-stac-timeseries';
 import { ActionStatus } from '$utils/status';
 import { useVedaUI } from '$context/veda-ui-provider';
 
@@ -149,6 +150,26 @@ export function Layer(props: LayerProps) {
     case 'raster':
       return (
         <RasterTimeseries
+          id={layerId}
+          stacCol={dataset.data.stacCol}
+          stacApiEndpoint={dataset.data.stacApiEndpoint}
+          tileApiEndpoint={dataset.data.tileApiEndpoint}
+          date={relevantDate}
+          zoomExtent={params.zoomExtent}
+          sourceParams={params.sourceParams}
+          generatorOrder={order}
+          hidden={!isVisible}
+          opacity={opacity}
+          onStatusChange={onStatusChange}
+          colorMap={colorMap}
+          reScale={scale}
+          envApiStacEndpoint={envApiStacEndpoint}
+          envApiRasterEndpoint={envApiRasterEndpoint}
+        />
+      );
+    case 'external-stac':
+      return (
+        <ExternalStacTimeseries
           id={layerId}
           stacCol={dataset.data.stacCol}
           stacApiEndpoint={dataset.data.stacApiEndpoint}

--- a/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -96,7 +96,8 @@ export async function fetchStacDatasetById(
   dataset: TimelineDataset | VizDataset,
   envApiStacEndpoint: string
 ): Promise<StacDatasetData> {
-  const { type, stacCol, stacApiEndpoint, time_density } = dataset.data;
+  const { type, stacCol, stacApiEndpoint, time_density, tilingMode } =
+    dataset.data;
 
   const stacApiEndpointToUse = stacApiEndpoint ?? envApiStacEndpoint;
 
@@ -166,9 +167,10 @@ export async function fetchStacDatasetById(
       isPeriodic: true,
       domain: [domainStart, normalized[1]]
     };
-  } else if (type === 'external-stac') {
-    // External STAC servers may have different metadata structures
-    // Use time_density from MDX config, and normalize domain with null handling
+  } else if (type === 'raster' && tilingMode === 'cog') {
+    // External STAC servers used with COG tiling may have different metadata
+    // structures. Use time_density from MDX config, and normalize domain with
+    // null handling.
     const domain = data.summaries?.datetime?.[0]
       ? data.summaries.datetime
       : data.extent?.temporal?.interval?.[0];

--- a/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-datasets.ts
+++ b/packages/veda-ui/src/components/exploration/hooks/use-stac-metadata-datasets.ts
@@ -166,6 +166,20 @@ export async function fetchStacDatasetById(
       isPeriodic: true,
       domain: [domainStart, normalized[1]]
     };
+  } else if (type === 'external-stac') {
+    // External STAC servers may have different metadata structures
+    // Use time_density from MDX config, and normalize domain with null handling
+    const domain = data.summaries?.datetime?.[0]
+      ? data.summaries.datetime
+      : data.extent?.temporal?.interval?.[0];
+
+    const normalized = normalizeDomain(domain);
+
+    return {
+      ...commonTimeseriesParams,
+      isPeriodic: true,
+      domain: normalized
+    };
   } else {
     const fromSummaries = !!data.summaries?.datetime?.[0];
     const domain = fromSummaries

--- a/packages/veda-ui/src/types/veda.ts
+++ b/packages/veda-ui/src/types/veda.ts
@@ -94,7 +94,25 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   };
   time_density?: TimeDensity;
   info?: LayerInfo;
+  /**
+   * Maximum number of STAC items returned per /search request.
+   *
+   * In `tilingMode: 'cog'` this directly caps how many per-item COG layers
+   * render at once. In `tilingMode: 'mosaic'` (default) tile rendering uses
+   * the server-side mosaic register and is NOT capped by this value; it only
+   * bounds the footprints we draw and the pagination overlay UX.
+   *
+   * Defaults to 500. Some STAC servers return errors for very large limits;
+   * Element84 Earth Search, for example, returns 502 above ~100.
+   */
   searchLimit?: number;
+  /**
+   * `mosaic` (default): titiler `/searches/register` produces one tilejson
+   * for the whole filter (used by VEDA's STAC + raster API).
+   * `cog`: titiler `/cog/tiles` is invoked per STAC item, with `url` set to
+   * the asset href selected via `sourceParams.assets`. Use this for external
+   * STAC servers that don't expose VEDA's mosaic register endpoint.
+   */
   tilingMode?: RasterTilingMode;
 }
 // A normalized compare layer is the result after the compare definition is

--- a/packages/veda-ui/src/types/veda.ts
+++ b/packages/veda-ui/src/types/veda.ts
@@ -93,6 +93,7 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   };
   time_density?: TimeDensity;
   info?: LayerInfo;
+  searchLimit?: number;
 }
 // A normalized compare layer is the result after the compare definition is
 // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The

--- a/packages/veda-ui/src/types/veda.ts
+++ b/packages/veda-ui/src/types/veda.ts
@@ -11,7 +11,8 @@ export type DatasetLayerType =
   | 'zarr'
   | 'cmr'
   | 'wms'
-  | 'wmts';
+  | 'wmts'
+  | 'external-stac';
 
 //
 // Dataset Layers

--- a/packages/veda-ui/src/types/veda.ts
+++ b/packages/veda-ui/src/types/veda.ts
@@ -11,8 +11,9 @@ export type DatasetLayerType =
   | 'zarr'
   | 'cmr'
   | 'wms'
-  | 'wmts'
-  | 'external-stac';
+  | 'wmts';
+
+export type RasterTilingMode = 'mosaic' | 'cog';
 
 //
 // Dataset Layers
@@ -94,6 +95,7 @@ export interface DatasetLayer extends DatasetLayerCommonProps {
   time_density?: TimeDensity;
   info?: LayerInfo;
   searchLimit?: number;
+  tilingMode?: RasterTilingMode;
 }
 // A normalized compare layer is the result after the compare definition is
 // resolved from DatasetLayerCompareSTAC or DatasetLayerCompareInternal. The

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -8,7 +8,8 @@ declare module 'veda' {
   // ///////////////////////////////////////////////////////////////////////////
   //  Datasets                                                                //
   // ///////////////////////////////////////////////////////////////////////////
-  type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr' | 'wms' | 'wmts' | 'external-stac';
+  type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr' | 'wms' | 'wmts';
+  type RasterTilingMode = 'mosaic' | 'cog';
 
   //
   // Dataset Layers
@@ -82,6 +83,7 @@ declare module 'veda' {
     time_density?: TimeDensity;
     info?: LayerInfo;
     searchLimit?: number;
+    tilingMode?: RasterTilingMode;
   }
 
   // TODO: Complete once known

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -81,6 +81,7 @@ declare module 'veda' {
     };
     time_density?: TimeDensity;
     info?: LayerInfo;
+    searchLimit?: number;
   }
 
   // TODO: Complete once known

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -8,7 +8,7 @@ declare module 'veda' {
   // ///////////////////////////////////////////////////////////////////////////
   //  Datasets                                                                //
   // ///////////////////////////////////////////////////////////////////////////
-  type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr' | 'wms';
+  type DatasetLayerType = 'raster' | 'vector' | 'zarr' | 'cmr' | 'wms' | 'wmts' | 'external-stac';
 
   //
   // Dataset Layers

--- a/parcel-resolver-veda/index.d.ts
+++ b/parcel-resolver-veda/index.d.ts
@@ -82,7 +82,25 @@ declare module 'veda' {
     };
     time_density?: TimeDensity;
     info?: LayerInfo;
+    /**
+     * Maximum number of STAC items returned per /search request.
+     *
+     * In `tilingMode: 'cog'` this directly caps how many per-item COG layers
+     * render at once. In `tilingMode: 'mosaic'` (default) tile rendering uses
+     * the server-side mosaic register and is NOT capped by this value; it
+     * only bounds the footprints we draw and the pagination overlay UX.
+     *
+     * Defaults to 500. Some STAC servers return errors for very large limits;
+     * Element84 Earth Search, for example, returns 502 above ~100.
+     */
     searchLimit?: number;
+    /**
+     * `mosaic` (default): titiler `/searches/register` produces one tilejson
+     * for the whole filter (used by VEDA's STAC + raster API).
+     * `cog`: titiler `/cog/tiles` is invoked per STAC item, with `url` set to
+     * the asset href selected via `sourceParams.assets`. Use this for external
+     * STAC servers that don't expose VEDA's mosaic register endpoint.
+     */
     tilingMode?: RasterTilingMode;
   }
 


### PR DESCRIPTION
# Support external STAC servers via `tilingMode: cog`

## Summary

Adds a new `tilingMode` option to `raster` datasets so they can be tiled
either via VEDA's mosaic register endpoint (the existing default) or via
titiler's per-item `/cog/tiles` endpoint. The latter unlocks consumption of
external STAC servers (Element84 Earth Search, GHG Center, NASA CMR
CloudSTAC, etc.) that don't expose a mosaic register endpoint.

## Dataset config

```yaml
type: raster
tilingMode: cog              # 'mosaic' (default) | 'cog'
stacApiEndpoint: https://earth-search.aws.element84.com/v1
tileApiEndpoint: https://openveda.cloud/api/raster
stacCol: sentinel-2-l2a
searchLimit: 100             # caps items per /search request
sourceParams:
  assets: red
  colormap_name: viridis
  rescale: [0, 10000]
```

- `tilingMode: 'mosaic'` (default): unchanged behavior.
  `/searches/register` produces one tilejson for the whole CQL filter.
- `tilingMode: 'cog'`: per-item COG tiling. For each STAC item, the
  selected asset's `href` (preferring `alternate.s3.href` when present)
  is passed to `/cog/tiles?url=...`. Multiple items render as separate
  layers stacked on the map.

## What's also new

- **`searchLimit`**: configurable per-dataset cap on items per `/search`.
  Some external servers (e.g. Element84) error out with `limit: 1000`.
  Works in both tiling modes.
- **Pagination**: STAC search responses with a `next` link now power a
  "Showing N of M items — Load More" overlay. Handles both GET and
  POST next-link methods.
- **`FootprintsLayer`**: replaces the marker-based `PointsLayer` for both
  raster modes. Renders STAC item geometry when the response includes it
  (cog mode), bbox polygons otherwise (mosaic mode). Respects parent
  layer's `hidden` / `opacity` / `generatorOrder`.

## File-level changes

| File | Change |
| --- | --- |
| `types/veda.ts`, `parcel-resolver-veda/index.d.ts` | Add `tilingMode`, `searchLimit` to `DatasetLayer`; remove unused `external-stac` from `DatasetLayerType`. |
| `style-generators/raster-cog-timeseries.tsx` *(new)* | Per-item COG tiling component. |
| `style-generators/raster-timeseries.tsx` | Adds `searchLimit` + pagination. Mosaic register guarded against re-registration on pagination. |
| `style-generators/footprints-layer.tsx` *(new)* | Polygon footprints layer used by both raster modes. |
| `style-generators/pagination-overlay.tsx` *(new)* | Shared "Load More" UI. |
| `exploration/components/map/layer.tsx` | `case 'raster'` branches on `tilingMode === 'cog'`. |
| `exploration/hooks/use-stac-metadata-datasets.ts` | New branch for `type === 'raster' && tilingMode === 'cog'` to handle external STAC metadata structures. |
| `mock/datasets/*-external.data.mdx`, `*-element84.data.mdx` | Test datasets exercising the new path against Element84, GHG Center, and CMR CloudSTAC. |

## Backwards compatibility

`tilingMode` defaults to `'mosaic'`. All existing `raster` datasets
continue to work without any config change.

## Test plan

- [ ] Existing internal raster dataset still renders identically (no new
  `searchLimit`/`tilingMode` in MDX).
- [ ] Sentinel-2 / Landsat (Element84) renders cog tiles; "Load More"
  reveals additional footprints without yanking the map.
- [ ] HLS L30 (NASA CMR CloudSTAC) renders cog tiles.
- [ ] Hide / show / change opacity / change order on a cog layer
  toggles its footprints alongside its tiles.
- [ ] Removing a cog dataset from the timeline cleans up its sources
  and layers from the map style.
- [ ] Date change while a `loadMore` is in flight aborts cleanly (no
  console warnings about state-after-unmount).
