### PR TITLE
fix: make `variables` a repeat query params instead of comma separated

### DIFF
--- a/packages/veda-ui/src/components/common/map/style-generators/utils.spec.ts
+++ b/packages/veda-ui/src/components/common/map/style-generators/utils.spec.ts
@@ -18,13 +18,13 @@ describe('formatTitilerParameter', () => {
     const params = {
       assets: ['visual', 'cog'],
       bidx: [1, 2, 3],
-      variable: ['NPP', 'FIRE']
+      variables: ['NPP', 'FIRE']
     };
 
     const result = formatTitilerParameter(params);
 
     expect(result).toBe(
-      'assets=visual&assets=cog&bidx=1&bidx=2&bidx=3&variable=NPP&variable=FIRE'
+      'assets=visual&assets=cog&bidx=1&bidx=2&bidx=3&variables=NPP&variables=FIRE'
     );
   });
 

--- a/packages/veda-ui/src/components/common/map/style-generators/utils.spec.ts
+++ b/packages/veda-ui/src/components/common/map/style-generators/utils.spec.ts
@@ -17,12 +17,15 @@ describe('formatTitilerParameter', () => {
   it('formats array parameters correctly', () => {
     const params = {
       assets: ['visual', 'cog'],
-      bidx: [1, 2, 3]
+      bidx: [1, 2, 3],
+      variable: ['NPP', 'FIRE']
     };
 
     const result = formatTitilerParameter(params);
 
-    expect(result).toBe('assets=visual&assets=cog&bidx=1&bidx=2&bidx=3');
+    expect(result).toBe(
+      'assets=visual&assets=cog&bidx=1&bidx=2&bidx=3&variable=NPP&variable=FIRE'
+    );
   });
 
   it('does not encode bbox parameter', () => {

--- a/packages/veda-ui/src/components/common/map/style-generators/utils.ts
+++ b/packages/veda-ui/src/components/common/map/style-generators/utils.ts
@@ -10,7 +10,7 @@ export function formatTitilerParameter(params): string {
     bbox,
     sel,
     sel_method,
-    variable,
+    variables,
     ...regularParams
   } = params;
 
@@ -21,7 +21,7 @@ export function formatTitilerParameter(params): string {
     asset_bidx,
     sel,
     sel_method,
-    variable
+    variables
   };
 
   const regularParamsString = qs.stringify(regularParams, {

--- a/packages/veda-ui/src/components/common/map/style-generators/utils.ts
+++ b/packages/veda-ui/src/components/common/map/style-generators/utils.ts
@@ -10,6 +10,7 @@ export function formatTitilerParameter(params): string {
     bbox,
     sel,
     sel_method,
+    variable,
     ...regularParams
   } = params;
 
@@ -19,7 +20,8 @@ export function formatTitilerParameter(params): string {
     bidx,
     asset_bidx,
     sel,
-    sel_method
+    sel_method,
+    variable
   };
 
   const regularParamsString = qs.stringify(regularParams, {


### PR DESCRIPTION
# Description

titiler-cmr expects variables to be a repeat param instead of comma separated