### PR TITLE
chore: disable auto-release, add maintenance mode notice

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
-name: Release Every Monday
+name: Release
 on:
   workflow_dispatch:
-  schedule:
-    # At 10AM EST Monday
-    - cron: '0 15 * * 1'
 
 env:
   NODE: 24

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VEDA Dashboard
 
+> **Maintenance Mode:** veda-ui is in maintenance mode. Only bug fixes and blockers are accepted — no new features or large refactors. See [#1912](https://github.com/NASA-IMPACT/veda-ui/issues/1912) for context.
+
 ![VEDA logo](./docs/media/nasa-veda-logo-pos.svg)
 
 VEDA is a dashboard to explore data.

--- a/docs/development/RELEASE.md
+++ b/docs/development/RELEASE.md
@@ -2,19 +2,19 @@
 
 ## Overview
 
-VEDA UI uses Git tags for its releases (as of Jan 2025). While the git tags can be manually created, the VEDA UI team recommends using the automated process facilitated by GitHub Actions. This process includes instance builds triggered by the release workflow and supports targeting specific branches when necessary. By default, the release version number is determined based on the commit message following the Conventional Commit standard.
+VEDA UI uses Git tags for its releases (as of Jan 2025). Releases are triggered manually via GitHub Actions. The release version number is determined based on commit messages following the Conventional Commit standard.
 
 ## Release Workflow
 
-### What is included in the automated release process
+### What is included in the release process
 
-The automated process handles
+The release process handles:
 
 - Deciding the version number based on commit history
 - Creating Git tag using the version number
 - Creating a commit bumping the version number up in `package.json`
 - Creating GitHub Release
-- Creating [Earth Data instance](https://github.com/nasa-impact/veda-config) preview using VEDA UI version (When the release is made from `main` branch)
+- Creating [Earth Data instance](https://github.com/nasa-impact/veda-config) preview using VEDA UI version (when released from `main` branch)
 
 After the last step, we can manually test if the release did not introduce any unexpected regression through the Preview URL.
 
@@ -22,7 +22,7 @@ After the last step, we can manually test if the release did not introduce any u
 
 #### Trigger Through UI
 
-If you are a contributor, you can trigger a release action through the Actions tab. Navigate to Actions, select the release action Release every other Monday (with the default branch set to `main`), and click the Run workflow button to initiate a release. Select a different branch if you need to make a hotfix patch release. Keep in mind that your commit message should follow the Conventional Commit format when releasing a hotfix, as the Conventional Commit action only recognizes Pull Requests made to the production branch (`main`). Be aware that any release made from other branches than `main` won't trigger instance previews.
+If you are a contributor, you can trigger a release through the Actions tab. Navigate to Actions, select the **Release** workflow (default branch set to `main`), and click the Run workflow button. Select a different branch if you need to make a hotfix patch release. Keep in mind that your commit message should follow the Conventional Commit format when releasing a hotfix, as the Conventional Commit action only recognizes Pull Requests made to the production branch (`main`). Be aware that any release made from branches other than `main` won't trigger instance previews.
 
 ![Screenshot of Github Action](../media/workflow-screenshot.png)
 
@@ -31,7 +31,3 @@ If you are a contributor, you can trigger a release action through the Actions t
 Upon triggering, the GitHub Action builds the [Earth Data (veda-config) instance](https://github.com/nasa-impact/veda-config) using the specified release. It will create a Pull Request, as shown below, on veda-config, building a preview using the released UI.
 
 ![Screenshot of generated PR ](../media/preview-pr.png)
-
-### Scheduled Release
-
-Scheduled releases are not implemented yet but are coming soon!

--- a/docs/development/RELEASE.md
+++ b/docs/development/RELEASE.md
@@ -20,7 +20,7 @@ After the last step, we can manually test if the release did not introduce any u
 
 ### GitHub Action Integration
 
-#### Trigger Through UI
+#### Trigger Through GitHub UI
 
 If you are a contributor, you can trigger a release through the Actions tab. Navigate to Actions, select the **Release** workflow (default branch set to `main`), and click the Run workflow button. Select a different branch if you need to make a hotfix patch release. Keep in mind that your commit message should follow the Conventional Commit format when releasing a hotfix, as the Conventional Commit action only recognizes Pull Requests made to the production branch (`main`). Be aware that any release made from branches other than `main` won't trigger instance previews.
 


### PR DESCRIPTION
## Summary

- Disable scheduled weekly auto-release; releases are now manual-only via `workflow_dispatch`
- Rename workflow from "Release Every Monday" to "Release"
- Add maintenance mode banner to README
- Update RELEASE.md to reflect manual release process